### PR TITLE
Add exponential garbage collection policy 

### DIFF
--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -56,6 +56,7 @@ storing snapshots on various cloud storage providers as well as local disk locat
 				deltaSnapshotIntervalSeconds,
 				time.Duration(etcdConnectionTimeout),
 				time.Duration(garbageCollectionPeriodSeconds),
+				garbageCollectionPolicy,
 				tlsConfig)
 			if err != nil {
 				logger.Fatalf("Failed to create snapshotter: %v", err)

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -83,6 +83,7 @@ func initializeSnapshotterFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVarP(&maxBackups, "max-backups", "m", 7, "maximum number of previous backups to keep")
 	cmd.Flags().IntVar(&etcdConnectionTimeout, "etcd-connection-timeout", 30, "etcd client connection timeout")
 	cmd.Flags().IntVar(&garbageCollectionPeriodSeconds, "garbage-collection-period-seconds", 60, "Period in seconds for garbage collecting old backups")
+	cmd.Flags().StringVar(&garbageCollectionPolicy, "garbage-collection-policy", snapshotter.GarbageCollectionPolicyExponential, "Policy for garbage collecting old backups")
 	cmd.Flags().BoolVar(&insecureTransport, "insecure-transport", true, "disable transport security for client connections")
 	cmd.Flags().BoolVar(&insecureSkipVerify, "insecure-skip-tls-verify", false, "skip server certificate verification")
 	cmd.Flags().StringVar(&certFile, "cert", "", "identify secure client using this TLS certificate file")

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -35,6 +35,7 @@ var (
 	maxBackups                     int
 	etcdConnectionTimeout          int
 	garbageCollectionPeriodSeconds int
+	garbageCollectionPolicy        string
 	insecureTransport              bool
 	insecureSkipVerify             bool
 	certFile                       string

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -46,7 +46,7 @@ func (e *EtcdInitializer) Initialize() error {
 		return err
 	}
 	if dataDirStatus != validator.DataDirectoryValid {
-		if err = e.restoreCorruptData(); err != nil {
+		if err := e.restoreCorruptData(); err != nil {
 			err = fmt.Errorf("error while restoring corrupt data: %v", err)
 		}
 	}

--- a/pkg/server/httpAPI.go
+++ b/pkg/server/httpAPI.go
@@ -39,6 +39,7 @@ type HTTPHandler struct {
 	initializationStatusMutex sync.Mutex
 	initializationStatus      string
 	Status                    int
+	StopCh                    chan struct{}
 }
 
 // RegisterHandler registers the handler for different requests
@@ -82,6 +83,9 @@ func (h *HTTPHandler) serveInitialize(rw http.ResponseWriter, req *http.Request)
 		h.Logger.Infof("Updating status from %s to %s", h.initializationStatus, initializationStatusProgress)
 		h.initializationStatus = initializationStatusProgress
 		go func() {
+			// This is needed to stop snapshotter.
+			var s struct{}
+			h.StopCh <- s
 			err := h.EtcdInitializer.Initialize()
 			h.initializationStatusMutex.Lock()
 			defer h.initializationStatusMutex.Unlock()

--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -317,7 +317,7 @@ func startEmbeddedEtcd(ro RestoreOptions) (*embed.Etcd, error) {
 	return e, nil
 }
 
-// applyDeltaSnapshot applies thw events from time sorted list of delta snapshot to etcd sequentially
+// applyDeltaSnapshot applies the events from time sorted list of delta snapshot to etcd sequentially
 func (r *Restorer) applyDeltaSnapshots(client *clientv3.Client, snapList snapstore.SnapList) error {
 	firstDeltaSnap := snapList[0]
 	if err := r.applyFirstDeltaSnapshot(client, *firstDeltaSnap); err != nil {
@@ -338,7 +338,7 @@ func (r *Restorer) applyDeltaSnapshots(client *clientv3.Client, snapList snapsto
 	return nil
 }
 
-// applyFirstDeltaSnapshot applies thw events from first delta snapshot to etcd
+// applyFirstDeltaSnapshot applies the events from first delta snapshot to etcd
 func (r *Restorer) applyFirstDeltaSnapshot(client *clientv3.Client, snap snapstore.Snapshot) error {
 	r.logger.Infof("Applying first delta snapshot %s", path.Join(snap.SnapDir, snap.SnapName))
 	events, err := getEventsFromDeltaSnapshot(r.store, snap)
@@ -369,7 +369,7 @@ func (r *Restorer) applyFirstDeltaSnapshot(client *clientv3.Client, snap snapsto
 	return applyEventsToEtcd(client, events[newRevisionIndex:])
 }
 
-// applyDeltaSnapshot applies thw events from delta snapshot to etcd
+// applyDeltaSnapshot applies the events from delta snapshot to etcd
 func (r *Restorer) applyDeltaSnapshot(client *clientv3.Client, snap snapstore.Snapshot) error {
 	r.logger.Infof("Applying delta snapshot %s", path.Join(snap.SnapDir, snap.SnapName))
 	events, err := getEventsFromDeltaSnapshot(r.store, snap)

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -294,7 +294,7 @@ var _ = Describe("Snapshotter", func() {
 
 				// hourly snapshot
 				snapTime = snapTime.Add(time.Duration(time.Hour))
-				for now.Truncate(time.Hour).Sub(snapTime) >= 0 {
+				for now.Truncate(time.Hour).Sub(snapTime) > 0 {
 					snap := &snapstore.Snapshot{
 						Kind:          snapstore.SnapshotKindFull,
 						CreatedOn:     snapTime,

--- a/pkg/snapshot/snapshotter/types.go
+++ b/pkg/snapshot/snapshotter/types.go
@@ -24,6 +24,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	// GarbageCollectionPolicyExponential defines the exponential policy for garbage collecting old backups
+	GarbageCollectionPolicyExponential = "Exponential"
+	// GarbageCollectionPolicyLimitBased defines the limit based policy for garbage collecting old backups
+	GarbageCollectionPolicyLimitBased = "LimitBased"
+)
+
 // Snapshotter is a struct for etcd snapshot taker
 type Snapshotter struct {
 	logger                         *logrus.Logger
@@ -32,6 +39,7 @@ type Snapshotter struct {
 	maxBackups                     int
 	etcdConnectionTimeout          time.Duration
 	garbageCollectionPeriodSeconds time.Duration
+	garbageCollectionPolicy        string
 	tlsConfig                      *TLSConfig
 	deltaSnapshotIntervalSeconds   int
 	deltaEventCount                int

--- a/pkg/snapstore/snapshot.go
+++ b/pkg/snapstore/snapshot.go
@@ -73,7 +73,7 @@ func ParseSnapshot(snapPath string) (*Snapshot, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid creation time: %s", tokens[3])
 	}
-	s.CreatedOn = time.Unix(unixTime, 0)
+	s.CreatedOn = time.Unix(unixTime, 0).UTC()
 	s.SnapName = snapName
 	s.SnapDir = snapDir
 	return s, nil

--- a/pkg/snapstore/snapshot_test.go
+++ b/pkg/snapstore/snapshot_test.go
@@ -33,37 +33,37 @@ var _ = Describe("Snapshot", func() {
 				interval := int64(5)
 				now := time.Now().Unix()
 				snap1 := Snapshot{
-					CreatedOn:     time.Unix(now, 0),
+					CreatedOn:     time.Unix(now, 0).UTC(),
 					StartRevision: 0,
 					LastRevision:  2088,
 					Kind:          SnapshotKindFull,
 				}
 				snap2 := Snapshot{
-					CreatedOn:     time.Unix(now+1*interval, 0),
+					CreatedOn:     time.Unix(now+1*interval, 0).UTC(),
 					StartRevision: 0,
 					LastRevision:  1988,
 					Kind:          SnapshotKindFull,
 				}
 				snap3 := Snapshot{
-					CreatedOn:     time.Unix(now+2*interval, 0),
+					CreatedOn:     time.Unix(now+2*interval, 0).UTC(),
 					StartRevision: 0,
 					LastRevision:  1888,
 					Kind:          SnapshotKindFull,
 				}
 				snap4 := Snapshot{
-					CreatedOn:     time.Unix(now+3*interval, 0),
+					CreatedOn:     time.Unix(now+3*interval, 0).UTC(),
 					StartRevision: 0,
 					LastRevision:  1788,
 					Kind:          SnapshotKindFull,
 				}
 				snap5 := Snapshot{
-					CreatedOn:     time.Unix(now+4*interval, 0),
+					CreatedOn:     time.Unix(now+4*interval, 0).UTC(),
 					StartRevision: 0,
 					LastRevision:  1688,
 					Kind:          SnapshotKindFull,
 				}
 				snap6 := Snapshot{
-					CreatedOn:     time.Unix(now+5*interval, 0),
+					CreatedOn:     time.Unix(now+5*interval, 0).UTC(),
 					StartRevision: 0,
 					LastRevision:  1588,
 					Kind:          SnapshotKindFull,
@@ -79,7 +79,7 @@ var _ = Describe("Snapshot", func() {
 		Context("given a snapshot", func() {
 			now := time.Now().Unix()
 			snap1 := Snapshot{
-				CreatedOn:     time.Unix(now, 0),
+				CreatedOn:     time.Unix(now, 0).UTC(),
 				StartRevision: 0,
 				LastRevision:  2088,
 				Kind:          SnapshotKindFull,

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -41,19 +41,19 @@ var _ = Describe("Snapstore", func() {
 		prefix := "v1"
 		now := time.Now().Unix()
 		snap1 = Snapshot{
-			CreatedOn:     time.Unix(now, 0),
+			CreatedOn:     time.Unix(now, 0).UTC(),
 			StartRevision: 0,
 			LastRevision:  2088,
 			Kind:          SnapshotKindFull,
 		}
 		snap2 = Snapshot{
-			CreatedOn:     time.Unix(now+100, 0),
+			CreatedOn:     time.Unix(now+100, 0).UTC(),
 			StartRevision: 0,
 			LastRevision:  1988,
 			Kind:          SnapshotKindFull,
 		}
 		snap3 = Snapshot{
-			CreatedOn:     time.Unix(now+200, 0),
+			CreatedOn:     time.Unix(now+200, 0).UTC(),
 			StartRevision: 0,
 			LastRevision:  1958,
 			Kind:          SnapshotKindFull,


### PR DESCRIPTION
Fixes https://github.com/gardener/etcd-backup-restore/issues/3.

Added exponential garbage collection policy
- Keep only the last 24 hourly backups and of all other backups only the last backup in a day
-  Keep only the last 7 daily backups and of all other backups only the last backup in a week
-  Keep only the last 4 weekly backups
Unit tests are added for same