### PR TITLE
Enable draft release for head update variant

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -30,7 +30,9 @@ etcd-backup-restore:
         output_dir: 'binary'
 
   variants:
-    head-update: ~
+    head-update:
+      traits:
+        draft_release: ~
     pull-request:
       traits:
         pull-request: ~


### PR DESCRIPTION
**What this PR does / why we need it**:
We want to have draft releases generated on every head update. 

:information_source: Note: Only users with write access to the repository can view drafts of releases

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

