### PR TITLE
Race condition fix.

### DIFF
--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -58,7 +58,7 @@ func NewRestoreCommand(stopCh <-chan struct{}) *cobra.Command {
 			if err != nil {
 				logger.Fatalf("failed to create snapstore from configured storage provider: %v", err)
 			}
-			logger.Infoln("Finding latest set of snapshot to recover from...")
+			logger.Info("Finding latest set of snapshot to recover from...")
 			baseSnap, deltaSnapList, err := miscellaneous.GetLatestFullSnapshotAndDeltaSnapList(store)
 			if err != nil {
 				logger.Fatalf("failed to get latest snapshot: %v", err)
@@ -86,7 +86,7 @@ func NewRestoreCommand(stopCh <-chan struct{}) *cobra.Command {
 				logger.Fatalf("Failed to restore snapshot: %v", err)
 				return
 			}
-			logger.Infoln("Successfully restored the etcd data directory.")
+			logger.Info("Successfully restored the etcd data directory.")
 		},
 	}
 

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -59,3 +59,5 @@ var (
 	storageContainer string
 	storagePrefix    string
 )
+
+var emptyStruct struct{}

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -91,7 +91,7 @@ func (e *EtcdInitializer) restoreCorruptData() error {
 		err = fmt.Errorf("failed to create snapstore from configured storage provider: %v", err)
 		return err
 	}
-	logger.Infoln("Finding latest set of snapshot to recover from...")
+	logger.Info("Finding latest set of snapshot to recover from...")
 	baseSnap, deltaSnapList, err := miscellaneous.GetLatestFullSnapshotAndDeltaSnapList(store)
 	if err != nil {
 		logger.Errorf("failed to get latest set of snapshot: %v", err)
@@ -111,7 +111,7 @@ func (e *EtcdInitializer) restoreCorruptData() error {
 		err = fmt.Errorf("Failed to restore snapshot: %v", err)
 		return err
 	}
-	logger.Infoln("Successfully restored the etcd data directory.")
+	logger.Info("Successfully restored the etcd data directory.")
 	return err
 }
 

--- a/pkg/server/httpAPI.go
+++ b/pkg/server/httpAPI.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"sync"
+	"sync/atomic"
 
 	"github.com/gardener/etcd-backup-restore/pkg/initializer"
 	"github.com/sirupsen/logrus"
@@ -31,6 +32,26 @@ const (
 	initializationStatusFailed     = "Failed"
 )
 
+var emptyStruct struct{}
+
+// HandlerAckState denotes the state the handler would be in after sending a stop request to the snapshotter.
+type HandlerAckState int32
+
+const (
+	// HandlerAckDone is set when handler has been acknowledged of snapshotter termination.
+	HandlerAckDone uint32 = 0
+	// HandlerAckWaiting is set when handler starts waiting of snapshotter termination.
+	HandlerAckWaiting uint32 = 1
+)
+
+// HandlerRequest represents the type of request handler makes to the snapshotter.
+type HandlerRequest int
+
+const (
+	// HandlerSsrAbort is the HandlerRequest to the snapshotter to terminate the snapshot process.
+	HandlerSsrAbort HandlerRequest = 0
+)
+
 // HTTPHandler is implementation to handle HTTP API exposed by server
 type HTTPHandler struct {
 	EtcdInitializer           initializer.EtcdInitializer
@@ -38,10 +59,13 @@ type HTTPHandler struct {
 	server                    *http.Server
 	Logger                    *logrus.Logger
 	initializationStatusMutex sync.Mutex
+	AckState                  uint32
 	initializationStatus      string
 	Status                    int
 	StopCh                    chan struct{}
 	EnableProfiling           bool
+	ReqCh                     chan struct{}
+	AckCh                     chan struct{}
 }
 
 // RegisterHandler registers the handler for different requests
@@ -110,8 +134,11 @@ func (h *HTTPHandler) serveInitialize(rw http.ResponseWriter, req *http.Request)
 		h.initializationStatus = initializationStatusProgress
 		go func() {
 			// This is needed to stop snapshotter.
-			var s struct{}
-			h.StopCh <- s
+			atomic.StoreUint32(&h.AckState, HandlerAckWaiting)
+			h.Logger.Info("Changed handler state.")
+			h.ReqCh <- emptyStruct
+			h.Logger.Info("Waiting for acknowledgment...")
+			<-h.AckCh
 			err := h.EtcdInitializer.Initialize()
 			h.initializationStatusMutex.Lock()
 			defer h.initializationStatusMutex.Unlock()
@@ -119,6 +146,8 @@ func (h *HTTPHandler) serveInitialize(rw http.ResponseWriter, req *http.Request)
 				h.Logger.Errorf("Failed initialization: %v", err)
 				rw.WriteHeader(http.StatusInternalServerError)
 				h.initializationStatus = initializationStatusFailed
+				// Optional: Event if we send start signal it wi
+				// h.ReqCh <- HandlerSsrStart
 				return
 			}
 			h.Logger.Infof("Successfully initialized data directory \"%s\" for etcd.", h.EtcdInitializer.Validator.Config.DataDir)

--- a/pkg/snapstore/snapshot.go
+++ b/pkg/snapstore/snapshot.go
@@ -24,6 +24,19 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// NewSnapshot returns the snapshot object.
+func NewSnapshot(kind string, startRevision, lastRevision int64) *Snapshot {
+	snap := &Snapshot{
+		Kind:          kind,
+		StartRevision: startRevision,
+		LastRevision:  lastRevision,
+		CreatedOn:     time.Now().UTC(),
+	}
+	snap.GenerateSnapshotDirectory()
+	snap.GenerateSnapshotName()
+	return snap
+}
+
 // GenerateSnapshotName prepares the snapshot name from metadata
 func (s *Snapshot) GenerateSnapshotName() {
 	s.SnapName = fmt.Sprintf("%s-%08d-%08d-%d", s.Kind, s.StartRevision, s.LastRevision, s.CreatedOn.Unix())

--- a/pkg/snapstore/types.go
+++ b/pkg/snapstore/types.go
@@ -53,7 +53,7 @@ const (
 	// SnapshotKindDelta is constant for delta snapshot kind
 	SnapshotKindDelta = "Incr"
 	// ChunkUploadTimeout is timeout for uploading chunk
-	chunkUploadTimeout = 30 * time.Second
+	chunkUploadTimeout = 180 * time.Second
 )
 
 // Snapshot structure represents the metadata of snapshot


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes race-conditions that arise when etcd backup-restore occurs.
**Which issue(s) this PR fixes**:
Fixes #
This PR fixes race-conditions that arise when etcd backup-restore occurs.
- The http handler in the backup-restore should wait till snapshotter has stopped before starting data directory initialization.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator

```
