### PR TITLE
update clone address with https url

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ First, you need to create a target folder structure before cloning and building 
 
 mkdir -p ~/go/src/github.com/gardener
 cd ~/go/src/github.com/gardener
-git clone git@github.com:gardener/etcd-backup-restore.git
+git clone https://github.com/gardener/etcd-backup-restore.git
 cd etcd-backup-restore
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update clone address with https url.  
**Which issue(s) this PR fixes**:
Clone action will fail with `permission denied` error using original url(`git@github.com:gardener/etcd-backup-restore.git`).
It is ok to use https url to clone this project, so it would be better to use https one in my opinion.
**Special notes for your reviewer**:
NONE
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.
Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator

```
