### PR TITLE
Add periodical defragmentation support for ETCD

### DIFF
--- a/cmd/types.go
+++ b/cmd/types.go
@@ -41,6 +41,7 @@ var (
 	certFile                       string
 	keyFile                        string
 	caFile                         string
+	defragmentationPeriodHours     int
 
 	//server flags
 	port            int

--- a/pkg/etcdutil/defrag.go
+++ b/pkg/etcdutil/defrag.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdutil
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// defragData defragments the data directory of each etcd member.
+func defragData(tlsConfig *TLSConfig, etcdConnectionTimeout time.Duration) {
+	client, err := GetTLSClientForEtcd(tlsConfig)
+	if err != nil {
+		logrus.Warnf("failed to create etcd client for defragmentation: %v", err)
+		return
+	}
+
+	for _, ep := range tlsConfig.endpoints {
+		logrus.Infof("Defragmenting etcd member[%s]", ep)
+		ctx, cancel := context.WithTimeout(context.TODO(), etcdConnectionTimeout)
+		status, err := client.Status(ctx, ep)
+		cancel()
+		if err != nil {
+			logrus.Warnf("Failed to get status of etcd member[%s] with error: %v", ep, err)
+			continue
+		}
+		dbSizeBeforeDefrag := status.DbSize
+		ctx, cancel = context.WithTimeout(context.TODO(), etcdConnectionTimeout)
+		_, err = client.Defragment(ctx, ep)
+		cancel()
+		if err != nil {
+			logrus.Warnf("Failed to defragment etcd member[%s] with error: %v", ep, err)
+		} else {
+			logrus.Infof("Finished defragmenting etcd member[%s]", ep)
+		}
+		ctx, cancel = context.WithTimeout(context.TODO(), etcdConnectionTimeout)
+		status, err = client.Status(ctx, ep)
+		cancel()
+		if err != nil {
+			logrus.Warnf("Failed to get status of etcd member[%s] with error: %v", ep, err)
+			continue
+		}
+		dbSizeAfterDefrag := status.DbSize
+		logrus.Infof("DB size for etcd member [%s] changed from %dB to %dB by defragmentation", ep, dbSizeBeforeDefrag, dbSizeAfterDefrag)
+	}
+}
+
+// DefragDataPeriodically defragments the data directory of each etcd member.
+func DefragDataPeriodically(stopCh <-chan struct{}, tlsConfig *TLSConfig, defragmentationPeriod, etcdConnectionTimeout time.Duration, callback func()) {
+	if defragmentationPeriod <= time.Hour {
+		logrus.Infof("Disabling defragmentation since defragmentation period [%d] is less than 1", defragmentationPeriod)
+		return
+	}
+	logrus.Infof("Defragmentation period :%d hours", defragmentationPeriod/time.Hour)
+	for {
+		select {
+		case <-stopCh:
+			logrus.Infof("Stopping the defragmentation thread.")
+			return
+		case <-time.After(defragmentationPeriod):
+			defragData(tlsConfig, etcdConnectionTimeout)
+			callback()
+		}
+	}
+}

--- a/pkg/etcdutil/defrag_test.go
+++ b/pkg/etcdutil/defrag_test.go
@@ -1,0 +1,78 @@
+package etcdutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Defrag", func() {
+	var (
+		tlsConfig             *TLSConfig
+		endpoints             = []string{"http://localhost:2379"}
+		etcdConnectionTimeout = time.Duration(30 * time.Second)
+		keyPrefix             = "/defrag/key-"
+		valuePrefix           = "val"
+	)
+	tlsConfig = NewTLSConfig("", "", "", true, true, endpoints)
+	Context("Defragmentation", func() {
+		BeforeEach(func() {
+			client, err := GetTLSClientForEtcd(tlsConfig)
+			defer client.Close()
+			Expect(err).ShouldNot(HaveOccurred())
+			for index := 0; index <= 1000; index++ {
+				ctx, cancel := context.WithTimeout(context.TODO(), etcdConnectionTimeout)
+				client.Put(ctx, fmt.Sprintf("%s%d", keyPrefix, index), valuePrefix)
+				cancel()
+			}
+			for index := 0; index <= 500; index++ {
+				ctx, cancel := context.WithTimeout(context.TODO(), etcdConnectionTimeout)
+				client.Delete(ctx, fmt.Sprintf("%s%d", keyPrefix, index))
+				cancel()
+			}
+		})
+
+		It("should defragment and reduce size of DB within time", func() {
+			client, err := GetTLSClientForEtcd(tlsConfig)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer client.Close()
+			ctx, cancel := context.WithTimeout(context.TODO(), etcdDialTimeout)
+			oldStatus, err := client.Status(ctx, endpoints[0])
+			cancel()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			err = defragData(tlsConfig, etcdConnectionTimeout)
+			Expect(err).ShouldNot(HaveOccurred())
+			ctx, cancel = context.WithTimeout(context.TODO(), etcdDialTimeout)
+			newStatus, err := client.Status(ctx, endpoints[0])
+			cancel()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(newStatus.DbSize).Should(BeNumerically("<", oldStatus.DbSize))
+			Expect(newStatus.Header.GetRevision()).Should(BeNumerically("==", oldStatus.Header.GetRevision()))
+		})
+
+		It("should keep size of DB same in case of timeout", func() {
+			etcdConnectionTimeout = time.Duration(time.Second)
+			client, err := GetTLSClientForEtcd(tlsConfig)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer client.Close()
+			ctx, cancel := context.WithTimeout(context.TODO(), etcdDialTimeout)
+			oldStatus, err := client.Status(ctx, endpoints[0])
+			cancel()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			err = defragData(tlsConfig, time.Duration(time.Microsecond))
+			Expect(err).Should(HaveOccurred())
+			ctx, cancel = context.WithTimeout(context.TODO(), etcdDialTimeout)
+			newStatus, err := client.Status(ctx, endpoints[0])
+			cancel()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(newStatus.Header.GetRevision()).Should(BeNumerically("==", oldStatus.Header.GetRevision()))
+		})
+	})
+})

--- a/pkg/etcdutil/etcdutil.go
+++ b/pkg/etcdutil/etcdutil.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdutil
+
+import (
+	"crypto/tls"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/pkg/transport"
+)
+
+// NewTLSConfig returns the TLSConfig object.
+func NewTLSConfig(cert, key, caCert string, insecureTr, skipVerify bool, endpoints []string) *TLSConfig {
+	return &TLSConfig{
+		cert:       cert,
+		key:        key,
+		caCert:     caCert,
+		insecureTr: insecureTr,
+		skipVerify: skipVerify,
+		endpoints:  endpoints,
+	}
+}
+
+// GetTLSClientForEtcd creates an etcd client using the TLS config params.
+func GetTLSClientForEtcd(tlsConfig *TLSConfig) (*clientv3.Client, error) {
+	// set tls if any one tls option set
+	var cfgtls *transport.TLSInfo
+	tlsinfo := transport.TLSInfo{}
+	if tlsConfig.cert != "" {
+		tlsinfo.CertFile = tlsConfig.cert
+		cfgtls = &tlsinfo
+	}
+
+	if tlsConfig.key != "" {
+		tlsinfo.KeyFile = tlsConfig.key
+		cfgtls = &tlsinfo
+	}
+
+	if tlsConfig.caCert != "" {
+		tlsinfo.CAFile = tlsConfig.caCert
+		cfgtls = &tlsinfo
+	}
+
+	cfg := &clientv3.Config{
+		Endpoints: tlsConfig.endpoints,
+	}
+
+	if cfgtls != nil {
+		clientTLS, err := cfgtls.ClientConfig()
+		if err != nil {
+			return nil, err
+		}
+		cfg.TLS = clientTLS
+	}
+
+	// if key/cert is not given but user wants secure connection, we
+	// should still setup an empty tls configuration for gRPC to setup
+	// secure connection.
+	if cfg.TLS == nil && !tlsConfig.insecureTr {
+		cfg.TLS = &tls.Config{}
+	}
+
+	// If the user wants to skip TLS verification then we should set
+	// the InsecureSkipVerify flag in tls configuration.
+	if tlsConfig.skipVerify && cfg.TLS != nil {
+		cfg.TLS.InsecureSkipVerify = true
+	}
+
+	return clientv3.New(*cfg)
+}

--- a/pkg/etcdutil/etcdutil_suite_test.go
+++ b/pkg/etcdutil/etcdutil_suite_test.go
@@ -1,0 +1,68 @@
+package etcdutil
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/embed"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	outputDir    = "../../test/output"
+	etcdDir      = outputDir + "/default.etcd"
+	etcdEndpoint = "http://localhost:2379"
+)
+
+var (
+	etcd *embed.Etcd
+	err  error
+)
+
+func TestEtcdutil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Etcdutil Suite")
+}
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	err = os.RemoveAll(outputDir)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	etcd, err = startEmbeddedEtcd()
+	Expect(err).ShouldNot(HaveOccurred())
+	var data []byte
+	return data
+}, func(data []byte) {})
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	etcd.Server.Stop()
+	etcd.Close()
+})
+
+func startEmbeddedEtcd() (*embed.Etcd, error) {
+	logger := logrus.New()
+	logger.Infof("Starting embedded etcd")
+	cfg := embed.NewConfig()
+	cfg.Dir = etcdDir
+	cfg.EnableV2 = false
+	cfg.Debug = false
+	cfg.GRPCKeepAliveTimeout = 0
+	e, err := embed.StartEtcd(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	select {
+	case <-e.Server.ReadyNotify():
+		fmt.Printf("Embedded server is ready!\n")
+	case <-time.After(60 * time.Second):
+		e.Server.Stop() // trigger a shutdown
+		e.Close()
+		return nil, fmt.Errorf("server took too long to start")
+	}
+	return e, nil
+}

--- a/pkg/etcdutil/types.go
+++ b/pkg/etcdutil/types.go
@@ -14,6 +14,12 @@
 
 package etcdutil
 
+import (
+	"time"
+)
+
+const etcdDialTimeout = time.Second * 30
+
 // TLSConfig holds cert information and settings for TLS.
 type TLSConfig struct {
 	cert       string

--- a/pkg/etcdutil/types.go
+++ b/pkg/etcdutil/types.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdutil
+
+// TLSConfig holds cert information and settings for TLS.
+type TLSConfig struct {
+	cert       string
+	key        string
+	caCert     string
+	insecureTr bool
+	skipVerify bool
+	endpoints  []string
+}

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 	. "github.com/gardener/etcd-backup-restore/pkg/snapshot/snapshotter"
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
 	. "github.com/onsi/ginkgo"
@@ -58,7 +59,7 @@ var _ = Describe("Snapshotter", func() {
 		Context("With invalid schedule", func() {
 			It("should return error", func() {
 				schedule = "65 * * * 5"
-				tlsConfig := NewTLSConfig(
+				tlsConfig := etcdutil.NewTLSConfig(
 					certFile,
 					keyFile,
 					caFile,
@@ -81,7 +82,7 @@ var _ = Describe("Snapshotter", func() {
 		Context("With valid schedule", func() {
 			It("should create snapshotter config", func() {
 				schedule = "*/5 * * * *"
-				tlsConfig := NewTLSConfig(
+				tlsConfig := etcdutil.NewTLSConfig(
 					certFile,
 					keyFile,
 					caFile,
@@ -112,7 +113,7 @@ var _ = Describe("Snapshotter", func() {
 				testTimeout := time.Duration(time.Minute * time.Duration(maxBackups+1))
 				store, err = snapstore.GetSnapstore(&snapstore.Config{Container: path.Join(outputDir, "snapshotter_2.bkp")})
 				Expect(err).ShouldNot(HaveOccurred())
-				tlsConfig := NewTLSConfig(
+				tlsConfig := etcdutil.NewTLSConfig(
 					certFile,
 					keyFile,
 					caFile,
@@ -161,7 +162,7 @@ var _ = Describe("Snapshotter", func() {
 					testTimeout := time.Duration(time.Minute * time.Duration(maxBackups+1))
 					store, err = snapstore.GetSnapstore(&snapstore.Config{Container: path.Join(outputDir, "snapshotter_3.bkp")})
 					Expect(err).ShouldNot(HaveOccurred())
-					tlsConfig := NewTLSConfig(
+					tlsConfig := etcdutil.NewTLSConfig(
 						certFile,
 						keyFile,
 						caFile,
@@ -218,7 +219,7 @@ var _ = Describe("Snapshotter", func() {
 					etcdConnectionTimeout = 5
 					store, err = snapstore.GetSnapstore(&snapstore.Config{Container: path.Join(outputDir, "snapshotter_4.bkp")})
 					Expect(err).ShouldNot(HaveOccurred())
-					tlsConfig := NewTLSConfig(
+					tlsConfig := etcdutil.NewTLSConfig(
 						certFile,
 						keyFile,
 						caFile,
@@ -363,7 +364,7 @@ var _ = Describe("Snapshotter", func() {
 				fmt.Println("Incremental snapshot list prepared")
 
 				//start test
-				tlsConfig := NewTLSConfig(
+				tlsConfig := etcdutil.NewTLSConfig(
 					certFile,
 					keyFile,
 					caFile,
@@ -413,7 +414,7 @@ var _ = Describe("Snapshotter", func() {
 				testTimeout := time.Duration(time.Second * time.Duration(garbageCollectionPeriodSeconds*2))
 				etcdConnectionTimeout = 5
 				store := prepareStoreForGarbageCollection(now, "garbagecollector_limit_based.bkp")
-				tlsConfig := NewTLSConfig(
+				tlsConfig := etcdutil.NewTLSConfig(
 					certFile,
 					keyFile,
 					caFile,

--- a/pkg/snapshot/snapshotter/types.go
+++ b/pkg/snapshot/snapshotter/types.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
 	"github.com/robfig/cron"
 	"github.com/sirupsen/logrus"
@@ -31,6 +32,8 @@ const (
 	// GarbageCollectionPolicyLimitBased defines the limit based policy for garbage collecting old backups
 	GarbageCollectionPolicyLimitBased = "LimitBased"
 )
+
+var emptyStruct struct{}
 
 // State denotes the state the snapshotter would be in.
 type State int
@@ -47,6 +50,7 @@ type Snapshotter struct {
 	logger             *logrus.Logger
 	prevSnapshot       *snapstore.Snapshot
 	config             *Config
+	fullSnapshotCh     chan struct{}
 	fullSnapshotTimer  *time.Timer
 	deltaSnapshotTimer *time.Timer
 	events             []*event
@@ -65,17 +69,7 @@ type Config struct {
 	etcdConnectionTimeout          time.Duration
 	garbageCollectionPeriodSeconds time.Duration
 	garbageCollectionPolicy        string
-	tlsConfig                      *TLSConfig
-}
-
-// TLSConfig holds cert information and settings for TLS.
-type TLSConfig struct {
-	cert       string
-	key        string
-	caCert     string
-	insecureTr bool
-	skipVerify bool
-	endpoints  []string
+	tlsConfig                      *etcdutil.TLSConfig
 }
 
 // event is wrapper over etcd event to keep track of time of event

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -99,7 +99,7 @@ func (s *GCSSnapStore) Save(snap Snapshot, r io.Reader) error {
 
 	snapshotErr := collectChunkUploadError(errCh, noOfChunks)
 	if len(snapshotErr) == 0 {
-		logrus.Info("All chunk uploaded successfully. Uploading composit object.")
+		logrus.Info("All chunk uploaded successfully. Uploading composite object.")
 		bh := s.client.Bucket(s.bucket)
 		var subObjects []*storage.ObjectHandle
 		for partNumber := int64(1); partNumber <= noOfChunks; partNumber++ {


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Etcd-backup-restore utility when started in server mode will start defragmenting etcd member data directory periodically, so that db size will be under control. You can set defragmentation period in number of hours by setting `defragmentation-period-in-hours` flag on `etcdbrctl server` command.
```
