### PR TITLE
Remove the data directory in case of a failed restore.

### DIFF
--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -76,12 +76,7 @@ func NewInitializer(options *restorer.RestoreOptions, snapstoreConfig *snapstore
 func (e *EtcdInitializer) restoreCorruptData() error {
 	logger := e.Logger
 	dataDir := e.Config.RestoreOptions.RestoreDataDir
-	logger.Infof("Removing data directory(%s) for snapshot restoration.", dataDir)
-	err := removeContents(filepath.Join(dataDir))
-	if err != nil {
-		err = fmt.Errorf("failed to delete the Data directory: %v", err)
-		return err
-	}
+
 	if e.Config.SnapstoreConfig == nil {
 		logger.Warnf("No snapstore storage provider configured. Will only clean the directory.")
 		return nil
@@ -111,25 +106,23 @@ func (e *EtcdInitializer) restoreCorruptData() error {
 		err = fmt.Errorf("Failed to restore snapshot: %v", err)
 		return err
 	}
-	logger.Info("Successfully restored the etcd data directory.")
-	return err
+
+	if err := e.removeContents(dataDir); err != nil {
+		return fmt.Errorf("failed to remove corrupt contents with restored snapshot: %v", err)
+	}
+	logger.Infoln("Successfully restored the etcd data directory.")
+	return nil
 }
 
-func removeContents(dir string) error {
-	d, err := os.Open(dir)
-	if err != nil {
-		return err
+func (e *EtcdInitializer) removeContents(dataDir string) error {
+	logger := e.Logger
+	logger.Infof("Removing data directory(%s) for snapshot restoration.", dataDir)
+	if err := os.RemoveAll(filepath.Join(dataDir)); err != nil {
+		return fmt.Errorf("failed to delete member directory: %v", err)
 	}
-	defer d.Close()
-	names, err := d.Readdirnames(-1)
-	if err != nil {
-		return err
-	}
-	for _, name := range names {
-		err = os.RemoveAll(filepath.Join(dir, name))
-		if err != nil {
-			return err
-		}
+
+	if err := os.Rename(filepath.Join(fmt.Sprintf("%s.%s", dataDir, "part")), filepath.Join(dataDir)); err != nil {
+		return fmt.Errorf("Failed to rename temp snap directory to member directory: %v", err)
 	}
 	return nil
 }

--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -113,7 +113,7 @@ func (r *Restorer) restoreFromBaseSnapshot(ro RestoreOptions) error {
 		return err
 	}
 
-	memberDir := filepath.Join(fmt.Sprintf("%s.%s", ro.RestoreDataDir, "part"), "member")
+	memberDir := filepath.Join(ro.RestoreDataDir, "member")
 	if _, err := os.Stat(memberDir); err == nil {
 		return fmt.Errorf("member directory in data directory(%q) exists", memberDir)
 	}
@@ -306,7 +306,7 @@ func makeWALAndSnap(waldir, snapdir string, cl *membership.RaftCluster, restoreN
 // startEmbeddedEtcd starts the embedded etcd server.
 func startEmbeddedEtcd(ro RestoreOptions) (*embed.Etcd, error) {
 	cfg := embed.NewConfig()
-	cfg.Dir = filepath.Join(ro.RestoreDataDir, "data.part")
+	cfg.Dir = filepath.Join(ro.RestoreDataDir)
 	e, err := embed.StartEtcd(cfg)
 	if err != nil {
 		return nil, err

--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -113,13 +113,13 @@ func (r *Restorer) restoreFromBaseSnapshot(ro RestoreOptions) error {
 		return err
 	}
 
-	memberDir := filepath.Join(ro.RestoreDataDir, "member")
+	memberDir := filepath.Join(fmt.Sprintf("%s.%s", ro.RestoreDataDir, "part"), "member")
 	if _, err := os.Stat(memberDir); err == nil {
 		return fmt.Errorf("member directory in data directory(%q) exists", memberDir)
 	}
 
-	walDir := filepath.Join(ro.RestoreDataDir, "member", "wal")
-	snapdir := filepath.Join(ro.RestoreDataDir, "member", "snap")
+	walDir := filepath.Join(memberDir, "wal")
+	snapdir := filepath.Join(memberDir, "snap")
 	if err = makeDB(snapdir, ro.BaseSnapshot, len(cl.Members()), r.store, false); err != nil {
 		return err
 	}
@@ -306,7 +306,7 @@ func makeWALAndSnap(waldir, snapdir string, cl *membership.RaftCluster, restoreN
 // startEmbeddedEtcd starts the embedded etcd server.
 func startEmbeddedEtcd(ro RestoreOptions) (*embed.Etcd, error) {
 	cfg := embed.NewConfig()
-	cfg.Dir = ro.RestoreDataDir
+	cfg.Dir = filepath.Join(ro.RestoreDataDir, "data.part")
 	e, err := embed.StartEtcd(cfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a hotfix that fixes the bug where etcd can start with partially applied snapshot. If the incremental snapshot is partially applied due to failure in between, the etcd data is consistent though not up-to-date. This PR fixes this issue.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
At the time of restoration, the etcd data directory will be restored to temporary directory with suffix `.part` i.e.`<path-to-etcd-data-dir>.part`. On successful restoration we will replace actual etcd data directory with this. This brings standard and more cleaner approach to restoration. 
```
