### PR TITLE
Add helm chart

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Helm chart for etcd
+name: etcd
+version: 0.1.0

--- a/chart/templates/etcd-bootstrap-configmap.yaml
+++ b/chart/templates/etcd-bootstrap-configmap.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etcd-bootstrap-{{ .Values.role }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: etcd
+data:
+  bootstrap.sh: |-
+    #!/bin/sh
+    while true;
+    do
+      wget http://localhost:8080/initialization/status -S -O status;
+      STATUS=`cat status`;
+      case $STATUS in
+      "New")
+            wget http://localhost:8080/initialization/start -S -O - ;;
+      "Progress")
+            sleep 1;
+            continue;;
+      "Failed")
+            continue;;
+      "Successful")
+            exec etcd --config-file /var/etcd/config/etcd.conf.yaml
+            ;;
+      esac;
+    done
+  etcd.conf.yaml: |-
+    # Human-readable name for this member.
+    name: etcd-{{.Values.role}}
+
+    # Path to the data directory.
+    data-dir: /var/etcd/data/new.etcd
+
+    # Number of committed transactions to trigger a snapshot to disk.
+    snapshot-count: 75000
+
+    # Raise alarms when backend size exceeds the given quota. 0 means use the
+    # default quota.
+    quota-backend-bytes: 8589934592
+
+    # List of comma separated URLs to listen on for client traffic.
+    listen-client-urls: {{ if .Values.tls }}https{{ else }}http{{ end }}://0.0.0.0:2379
+
+    # List of this member's client URLs to advertise to the public.
+    # The URLs needed to be a comma-separated list.
+    advertise-client-urls: {{ if .Values.tls }}https{{ else }}http{{ end }}://0.0.0.0:2379
+
+    # Initial cluster token for the etcd cluster during bootstrap.
+    initial-cluster-token: 'new'
+
+    # Initial cluster state ('new' or 'existing').
+    initial-cluster-state: 'new'
+
+{{- if .Values.tls }}
+    client-transport-security:
+      # Path to the client server TLS cert file.
+      cert-file: /var/etcd/ssl/server/tls.crt
+
+      # Path to the client server TLS key file.
+      key-file: /var/etcd/ssl/server/tls.key
+
+      # Enable client cert authentication.
+      client-cert-auth: true
+
+      # Path to the client server TLS trusted CA cert file.
+      trusted-ca-file: /var/etcd/ssl/ca/ca.crt
+{{- end }}

--- a/chart/templates/etcd-client-service.yaml
+++ b/chart/templates/etcd-client-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-{{ .Values.role }}-client
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: etcd-statefulset
+    role: {{ .Values.role }}
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  selector:
+    app: etcd-statefulset
+    role: {{ .Values.role }}
+  ports:
+  - name: client
+    protocol: TCP
+    port: 2379
+    targetPort: 2379

--- a/chart/templates/etcd-statefulset.yaml
+++ b/chart/templates/etcd-statefulset.yaml
@@ -1,0 +1,180 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: etcd-{{ .Values.role }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: etcd-statefulset
+    role: {{ .Values.role }}
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: etcd-{{.Values.role}}
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: etcd-statefulset
+      role: {{ .Values.role }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-etcd-bootstrap: {{ include (print $.Template.BasePath "/etcd-bootstrap-configmap.yaml") . | sha256sum }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+      labels:
+        app: etcd-statefulset
+        role: {{ .Values.role }}
+    spec:
+      containers:
+      - name: etcd
+        image: {{ index .Values.images "etcd" }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /var/etcd/bin/bootstrap.sh
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 5
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -ec
+            - ETCDCTL_API=3
+            - etcdctl
+            - --config-file=/var/etcd/config/etcd.conf.yaml
+            - get
+            - foo
+          initialDelaySeconds: 15
+          periodSeconds: 5
+        ports:
+        - containerPort: 2380
+          name: serverport
+          protocol: TCP
+        - containerPort: 2379
+          name: clientport
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 200m
+            memory: 500Mi
+          limits:
+            cpu: 750m
+            memory: 2560Mi
+        volumeMounts:
+        - name: etcd-{{ .Values.role }}
+          mountPath: /var/etcd/data
+        - name: etcd-bootstrap-sh
+          mountPath: /var/etcd/bin/
+        - name: etcd-config-file
+          mountPath: /var/etcd/config/
+{{- if .Values.tls }}
+        - name: ca-etcd
+          mountPath: /var/etcd/ssl/ca
+        - name: etcd-server-tls
+          mountPath: /var/etcd/ssl/server
+        - name: etcd-client-tls
+          mountPath: /var/etcd/ssl/client
+{{- end }}
+      - name: backup-restore
+        command:
+        - etcdbrctl
+        - server
+        - --schedule={{ .Values.backup.schedule }}
+{{- if eq .Values.backup.garbageCollectionPolicy "LimitBased" }}
+        - --max-backups={{ .Values.backup.maxBackups }}
+        - --garbage-collection-policy={{ .Values.gabageCollectionPolicy }}
+{{- end }}
+        - --data-dir=/var/etcd/data/new.etcd
+        - --storage-provider={{ .Values.backup.storageProvider }}
+        - --store-prefix=etcd-{{ .Values.role }}
+{{- if .Values.tls }}
+        - --cert=/var/etcd/ssl/client/tls.crt
+        - --key=/var/etcd/ssl/client/tls.key
+        - --cacert=/var/etcd/ssl/ca/ca.crt
+        - --insecure-transport=false
+        - --insecure-skip-tls-verify=false
+        - --endpoints=https://etcd-{{ .Values.role }}-0:2379
+{{ else }}
+        - --insecure-transport=true
+        - --insecure-skip-tls-verify=true
+        - --endpoints=http://etcd-{{ .Values.role }}-0:2379
+{{- end }}
+        - --etcd-connection-timeout=300
+        - --delta-snapshot-period-seconds=300
+        image: {{ index .Values.images "etcd-backup-restore" }}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: server
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 300m
+            memory: 1Gi
+        env:
+        - name: STORAGE_CONTAINER
+          value: {{ .Values.backup.storageContainer }}
+{{- if .Values.backup.env }}
+{{ toYaml .Values.backup.env | indent 8 }}
+{{- end }}
+        volumeMounts:
+        - name: etcd-{{ .Values.role }}
+          mountPath: /var/etcd/data
+        - name: etcd-config-file
+          mountPath: /var/etcd/config/
+{{- if .Values.tls }}
+        - name: ca-etcd
+          mountPath: /var/etcd/ssl/ca
+        - name: etcd-client-tls
+          mountPath: /var/etcd/ssl/client
+{{- end }}
+{{- if .Values.backup.volumeMounts }}
+{{ toYaml .Values.backup.volumeMounts | indent 8 }}
+{{- end }}
+      volumes:
+      - name: etcd-bootstrap-sh
+        configMap:
+          name: etcd-bootstrap-{{ .Values.role }}
+          defaultMode: 0744
+          items:
+          - key: bootstrap.sh
+            path: bootstrap.sh
+      - name: etcd-config-file
+        configMap:
+          name: etcd-bootstrap-{{ .Values.role }}
+          defaultMode: 0644
+          items:
+          - key: etcd.conf.yaml
+            path: etcd.conf.yaml
+{{- if .Values.tls }}
+      - name: etcd-server-tls
+        secret:
+          secretName: {{ .Values.tls.serverSecret }}
+      - name: etcd-client-tls
+        secret:
+          secretName: {{ .Values.tls.clientSecret }}
+      - name: ca-etcd
+        secret:
+          secretName: {{ .Values.tls.caSecret }}
+{{- end }}
+{{- if not (eq .Values.backup.storageProvider "Local") }}
+      - name: {{ .Values.backup.backupSecret }}
+        secret:
+          secretName: {{ .Values.backup.backupSecret }}
+{{- end }}
+  volumeClaimTemplates:
+  - metadata:
+      name: etcd-{{ .Values.role }}
+    spec:
+      accessModes:
+      - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: 10Gi

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,133 @@
+
+role: for-test
+
+replicas: 1
+
+images:
+
+  # etcd image to use
+  etcd: quay.io/coreos/etcd:v3.3.10
+
+  # etcd-backup-restore image to use
+  etcd-backup-restore: eu.gcr.io/gardener-project/gardener/etcdbrctl:0.4.0
+
+backup:
+
+  # schedule is cron standard schedule to run backups
+  schedule: "0 */24 * * *"
+
+  # maxBackups is the maximum number of backups to keep (may change in
+  # future)
+  maxBackups: 7
+
+  # mentions the policy for garbage collecting old backups. Allowed values are Exponential(default), LimtBased.
+  garbageCollectionPolicy: Exponential
+
+  storageProvider: "Local"  # Abs,Gcs,S3,Swift empty means no backup,
+
+  backupSecret: etcd-backup
+
+  storageContainer: ""
+
+  # env should include the right list of values for the
+  # storageProvider you use, follow the comments below
+  env: []           # Follow comments below
+
+  # volumeMounts should include the right list of values for the
+  # storageProvider you use, follow the comments below
+  volumeMounts: []  # Follow comments below
+
+# tls field contains the pre-created secrets for etcd. Uncomment the
+# whole tls section if you dont want to use tls for the etcd.
+tls:
+
+  # caSecret should point a pre-created Opaque secret that includes a
+  # "ca.crt" field.
+  caSecret: ca-etcd
+
+  # serverSecret should point a pre-created secret that includes a
+  # signed key pair for server. The secret should have "tls.crt" and
+  # "tls.key" data fields. Certificate CN should be "etcd-<role>",
+  # and "etcd-<role>-0" should be included into the hosts.
+  serverSecret: etcd-server-tls
+
+  # clientSecret should point a pre-created secret that includes a
+  # signed key pair for clients.
+  clientSecret: etcd-client-tls
+
+# podAnnotations will be placed to the resulting etcd pod
+podAnnotations: {}
+
+# Aws S3 storage configuration
+# Note: No volumeMounts variable needed
+# storageProvider: "S3"
+# env:
+# - name: "AWS_REGION"
+#   valueFrom:
+#     secretKeyRef:
+#       name: etcd-backup
+#       key: "region"
+# - name: "AWS_SECRET_ACCESS_KEY"
+#   valueFrom:
+#     secretKeyRef:
+#       name: etcd-backup
+#       key: "secretAccessKey"
+# - name: "AWS_ACCESS_KEY_ID"
+#   valueFrom:
+#     secretKeyRef:
+#       name: etcd-backup
+#       key: "accessKeyID"
+
+# Azure ABS storage configuration
+# Note: No volumeMounts needed
+# storageProvider: "ABS"
+# env:
+# - name: "STORAGE_ACCOUNT"
+#   valueFrom:
+#     secretKeyRef:
+#       name: etcd-backup
+#       key: "storage-account"
+# - name: "STORAGE_KEY"
+#   valueFrom:
+#     secretKeyRef:
+#       name: etcd-backup
+#       key: "storage-key"
+
+# Google Cloud storage configuration
+# storageProvider: "GCS"
+# env:
+# - name: "GOOGLE_APPLICATION_CREDENTIALS"
+#   value: "/root/.gcp/serviceaccount.json"
+# volumeMount:
+# - name: etcd-backup
+#   mountPath: "/root/.gcp/"
+
+# Openstack Swift configuration
+# Note: No volumeMounts variable needed
+# storageProvider: "Swift"
+# env:
+# - name: "OS_AUTH_URL"
+#   valueFrom:
+#     secretKeyRef:
+#       name: etcd-backup
+#       key: "authURL"
+# - name: "OS_DOMAIN_NAME"
+#   valueFrom:
+#     secretKeyRef:
+#       name: etcd-backup
+#       key: "domainName"
+# -	name: "OS_USERNAME"
+#   valueFrom:
+#     secretKeyRef:
+#       name: etcd-backup
+#       key: "username"
+# - name: "OS_PASSWORD"
+#   valueFrom:
+#     secretKeyRef:
+#       name: etcd-backup
+#       key: "password"
+# - name: "OS_TENANT_NAME"
+#   valueFrom:
+#     secretKeyRef:
+#       name: etcd-backup
+#       key: "tenantName"


### PR DESCRIPTION
**What this PR does / why we need it**: 
The only helm chart available for etcd-backup-restore was in gardener, this one adds a helm chart to the upstream.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
* I copied the chart from gardener repo as is and only updated the dummy image names to the ones in use in gardener
* I didn't do any further modification on purpose since gardener seems to be main user better to keep this in sync as much as possible. This one is open to discussions.

Historical discussion in the slack channel can be found in: https://kubernetes.slack.com/archives/CB57N0BFG/p1539340130000100

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
There is now a helm chart to deploy etcd-backup-restore.
```
