### PR TITLE
Add dynamic profiling support

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -76,6 +76,7 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 				Logger:          logger,
 				Status:          http.StatusServiceUnavailable,
 				StopCh:          make(chan struct{}),
+				EnableProfiling: enableProfiling,
 			}
 			logger.Info("Regsitering the http request handlers...")
 			handler.RegisterHandler()
@@ -187,6 +188,7 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 // initializeServerFlags adds the flags to <cmd>
 func initializeServerFlags(serverCmd *cobra.Command) {
 	serverCmd.Flags().IntVarP(&port, "server-port", "p", defaultServerPort, "port on which server should listen")
+	serverCmd.Flags().BoolVar(&enableProfiling, "enable-profiling", false, "enable profiling")
 }
 
 // ProbeEtcd will make the snapshotter probe for etcd endpoint to be available

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -43,7 +43,9 @@ var (
 	caFile                         string
 
 	//server flags
-	port int
+	port            int
+	enableProfiling bool
+
 	//restore flags
 	restoreCluster      string
 	restoreClusterToken string


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR add the exposes the `debug/pprof/*` endpoint to dynamically profile cpu, heap consumption. To enable profiling one has to explicitly set `enable-profiling`  on `server` subcommand.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Dynamic profiling support is added. Now we expose the `debug/pprof/*` endpoint to dynamically profile cpu, heap consumption. To enable profiling one has to explicitly set `enable-profiling`  on `server` sub-command.
```
