### PR TITLE
Refactor chunk upload and make the parallel uploads configurable

### DIFF
--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -61,9 +61,11 @@ func NewInitializeCommand(stopCh <-chan struct{}) *cobra.Command {
 			var snapstoreConfig *snapstore.Config
 			if storageProvider != "" {
 				snapstoreConfig = &snapstore.Config{
-					Provider:  storageProvider,
-					Container: storageContainer,
-					Prefix:    path.Join(storagePrefix, backupFormatVersion),
+					Provider:                storageProvider,
+					Container:               storageContainer,
+					Prefix:                  path.Join(storagePrefix, backupFormatVersion),
+					MaxParallelChunkUploads: maxParallelChunkUploads,
+					TempDir:                 snapstoreTempDir,
 				}
 			}
 			etcdInitializer := initializer.NewInitializer(options, snapstoreConfig, logger)

--- a/cmd/miscellaneous.go
+++ b/cmd/miscellaneous.go
@@ -23,4 +23,6 @@ func initializeSnapstoreFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&storageProvider, "storage-provider", "", "snapshot storage provider")
 	cmd.Flags().StringVar(&storageContainer, "store-container", "", "container which will be used as snapstore")
 	cmd.Flags().StringVar(&storagePrefix, "store-prefix", "", "prefix or directory inside container under which snapstore is created")
+	cmd.Flags().IntVar(&maxParallelChunkUploads, "max-parallel-chunk-uploads", 5, "maximum number of parallel chunk uploads allowed ")
+	cmd.Flags().StringVar(&snapstoreTempDir, "snapstore-temp-directory", "/tmp", "temporary directory for processing")
 }

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -50,9 +50,11 @@ func NewRestoreCommand(stopCh <-chan struct{}) *cobra.Command {
 				logger.Fatalf("failed parsing peers urls for restore cluster: %v", err)
 			}
 			snapstoreConfig := &snapstore.Config{
-				Provider:  storageProvider,
-				Container: storageContainer,
-				Prefix:    path.Join(storagePrefix, backupFormatVersion),
+				Provider:                storageProvider,
+				Container:               storageContainer,
+				Prefix:                  path.Join(storagePrefix, backupFormatVersion),
+				MaxParallelChunkUploads: maxParallelChunkUploads,
+				TempDir:                 snapstoreTempDir,
 			}
 			store, err := snapstore.GetSnapstore(snapstoreConfig)
 			if err != nil {

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -57,9 +57,11 @@ var (
 	restoreMaxFetchers  int
 
 	//snapstore flags
-	storageProvider  string
-	storageContainer string
-	storagePrefix    string
+	storageProvider         string
+	storageContainer        string
+	storagePrefix           string
+	maxParallelChunkUploads int
+	snapstoreTempDir        string
 )
 
 var emptyStruct struct{}

--- a/pkg/etcdutil/defrag.go
+++ b/pkg/etcdutil/defrag.go
@@ -65,10 +65,6 @@ func defragData(tlsConfig *TLSConfig, etcdConnectionTimeout time.Duration) error
 
 // DefragDataPeriodically defragments the data directory of each etcd member.
 func DefragDataPeriodically(stopCh <-chan struct{}, tlsConfig *TLSConfig, defragmentationPeriod, etcdConnectionTimeout time.Duration, callback func()) {
-	if defragmentationPeriod <= time.Hour {
-		logrus.Infof("Disabling defragmentation since defragmentation period [%d] is less than 1", defragmentationPeriod)
-		return
-	}
 	logrus.Infof("Defragmentation period :%d hours", defragmentationPeriod/time.Hour)
 	for {
 		select {

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -50,7 +50,7 @@ func (e *EtcdInitializer) Initialize() error {
 			return fmt.Errorf("error while restoring corrupt data: %v", err)
 		}
 	}
-	return err
+	return nil
 }
 
 //NewInitializer creates an etcd initializer object.

--- a/pkg/initializer/validator/datavalidator.go
+++ b/pkg/initializer/validator/datavalidator.go
@@ -86,7 +86,7 @@ func (d *DataValidator) snapDir() string { return filepath.Join(d.memberDir(), "
 func (d *DataValidator) backendPath() string { return filepath.Join(d.snapDir(), "db") }
 
 //Validate performs the steps required to validate data for Etcd instance.
-// The steps involed are:
+// The steps involved are:
 //   * Check if data directory exists.
 //     - If data directory exists
 //		 * Check for data directory structure.

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -24,7 +24,7 @@ import (
 	"path"
 	"sort"
 	"strings"
-	"time"
+	"sync"
 
 	"cloud.google.com/go/storage"
 	"github.com/sirupsen/logrus"
@@ -33,11 +33,13 @@ import (
 
 // GCSSnapStore is snapstore with local disk as backend
 type GCSSnapStore struct {
-	SnapStore
 	prefix string
 	client *storage.Client
 	bucket string
 	ctx    context.Context
+	// maxParallelChunkUploads hold the maximum number of parallel chunk uploads allowed.
+	maxParallelChunkUploads int
+	tempDir                 string
 }
 
 const (
@@ -45,7 +47,7 @@ const (
 )
 
 // NewGCSSnapStore create new S3SnapStore from shared configuration with specified bucket
-func NewGCSSnapStore(bucket, prefix string) (*GCSSnapStore, error) {
+func NewGCSSnapStore(bucket, prefix, tempDir string, maxParallelChunkUploads int) (*GCSSnapStore, error) {
 	ctx := context.TODO()
 	gcsClient, err := storage.NewClient(ctx)
 	if err != nil {
@@ -53,10 +55,12 @@ func NewGCSSnapStore(bucket, prefix string) (*GCSSnapStore, error) {
 	}
 
 	return &GCSSnapStore{
-		prefix: prefix,
-		client: gcsClient,
-		bucket: bucket,
-		ctx:    ctx,
+		prefix:                  prefix,
+		client:                  gcsClient,
+		bucket:                  bucket,
+		ctx:                     ctx,
+		maxParallelChunkUploads: maxParallelChunkUploads,
+		tempDir:                 tempDir,
 	}, nil
 
 }
@@ -70,7 +74,7 @@ func (s *GCSSnapStore) Fetch(snap Snapshot) (io.ReadCloser, error) {
 // Save will write the snapshot to store
 func (s *GCSSnapStore) Save(snap Snapshot, r io.Reader) error {
 	// Save it locally
-	tmpfile, err := ioutil.TempFile(tmpDir, tmpBackupFilePrefix)
+	tmpfile, err := ioutil.TempFile(s.tempDir, tmpBackupFilePrefix)
 	if err != nil {
 		return fmt.Errorf("failed to create snapshot tempfile: %v", err)
 	}
@@ -84,7 +88,6 @@ func (s *GCSSnapStore) Save(snap Snapshot, r io.Reader) error {
 	}
 
 	var (
-		errCh      = make(chan chunkUploadError)
 		chunkSize  = int64(math.Max(float64(minChunkSize), float64(size/gcsNoOfChunk)))
 		noOfChunks = size / chunkSize
 	)
@@ -92,13 +95,34 @@ func (s *GCSSnapStore) Save(snap Snapshot, r io.Reader) error {
 		noOfChunks++
 	}
 
-	logrus.Infof("Uploading snapshot of size: %d, chunkSize: %d, noOfChunks: %d", size, chunkSize, noOfChunks)
-	for offset := int64(0); offset <= size; offset += int64(chunkSize) {
-		go retryComponentUpload(s, &snap, tmpfile, offset, chunkSize, errCh)
+	var (
+		chunkUploadCh = make(chan chunk, noOfChunks)
+		resCh         = make(chan chunkUploadResult, noOfChunks)
+		wg            sync.WaitGroup
+		cancelCh      = make(chan struct{})
+	)
+
+	for i := 0; i < s.maxParallelChunkUploads; i++ {
+		wg.Add(1)
+		go s.componentUploader(&wg, cancelCh, &snap, tmpfile, chunkUploadCh, resCh)
 	}
 
-	snapshotErr := collectChunkUploadError(errCh, noOfChunks)
-	if len(snapshotErr) == 0 {
+	logrus.Infof("Uploading snapshot of size: %d, chunkSize: %d, noOfChunks: %d", size, chunkSize, noOfChunks)
+	for offset, index := int64(0), 1; offset <= size; offset += int64(chunkSize) {
+		newChunk := chunk{
+			id:     index,
+			offset: offset,
+			size:   chunkSize,
+		}
+		chunkUploadCh <- newChunk
+		index++
+	}
+	logrus.Infof("Triggered chunk upload for all chunks, total: %d", noOfChunks)
+
+	snapshotErr := collectChunkUploadError(chunkUploadCh, resCh, cancelCh, noOfChunks)
+	wg.Wait()
+
+	if snapshotErr == nil {
 		logrus.Info("All chunk uploaded successfully. Uploading composite object.")
 		bh := s.client.Bucket(s.bucket)
 		var subObjects []*storage.ObjectHandle
@@ -112,17 +136,17 @@ func (s *GCSSnapStore) Save(snap Snapshot, r io.Reader) error {
 		c := obj.ComposerFrom(subObjects...)
 		ctx, cancel := context.WithTimeout(context.TODO(), chunkUploadTimeout)
 		defer cancel()
-		_, err := c.Run(ctx)
-		return err
+		if _, err := c.Run(ctx); err != nil {
+			return fmt.Errorf("failed uploading composite object for snapshot with error: %v", err)
+		}
+		logrus.Info("Composite object uploaded successfully.")
+		return nil
 	}
-	var collectedErr []string
-	for _, chunkErr := range snapshotErr {
-		collectedErr = append(collectedErr, fmt.Sprintf("failed uploading chunk with offset %d with error %v", chunkErr.offset, chunkErr.err))
-	}
-	return fmt.Errorf(strings.Join(collectedErr, "\n"))
+
+	return fmt.Errorf("failed uploading chunk, id: %d, offset: %d, error: %v", snapshotErr.chunk.id, snapshotErr.chunk.offset, snapshotErr.err)
 }
 
-func uploadComponent(s *GCSSnapStore, snap *Snapshot, file *os.File, offset, chunkSize int64) error {
+func (s *GCSSnapStore) uploadComponent(snap *Snapshot, file *os.File, offset, chunkSize int64) error {
 	fileInfo, err := file.Stat()
 	if err != nil {
 		return err
@@ -147,28 +171,24 @@ func uploadComponent(s *GCSSnapStore, snap *Snapshot, file *os.File, offset, chu
 	return w.Close()
 }
 
-func retryComponentUpload(s *GCSSnapStore, snap *Snapshot, file *os.File, offset, chunkSize int64, errCh chan<- chunkUploadError) {
-	var (
-		maxAttempts uint = 5
-		curAttempt  uint = 1
-		err         error
-	)
+func (s *GCSSnapStore) componentUploader(wg *sync.WaitGroup, stopCh <-chan struct{}, snap *Snapshot, file *os.File, chunkUploadCh chan chunk, errCh chan<- chunkUploadResult) {
+	defer wg.Done()
 	for {
-		logrus.Infof("Uploading chunk with offset : %d, attempt: %d", offset, curAttempt)
-		err = uploadComponent(s, snap, file, offset, chunkSize)
-		logrus.Infof("For chunk upload of offset %d, err %v", offset, err)
-		if err == nil || curAttempt == maxAttempts {
-			break
+		select {
+		case <-stopCh:
+			return
+		case chunk, more := <-chunkUploadCh:
+			if !more {
+				return
+			}
+			logrus.Infof("Uploading chunk with offset : %d, attempt: %d", chunk.offset, chunk.attempt)
+			err := s.uploadComponent(snap, file, chunk.offset, chunk.size)
+			logrus.Infof("For chunk upload of offset %d, err %v", chunk.offset, err)
+			errCh <- chunkUploadResult{
+				err:   err,
+				chunk: &chunk,
+			}
 		}
-		delayTime := (1 << curAttempt)
-		curAttempt++
-		logrus.Warnf("Will try to upload chunk with offset: %d at attempt %d  after %d seconds", offset, curAttempt, delayTime)
-		time.Sleep((time.Duration)(delayTime) * time.Second)
-	}
-
-	errCh <- chunkUploadError{
-		err:    err,
-		offset: offset,
 	}
 }
 

--- a/pkg/snapstore/local_snapstore.go
+++ b/pkg/snapstore/local_snapstore.go
@@ -26,7 +26,6 @@ import (
 
 // LocalSnapStore is snapstore with local disk as backend
 type LocalSnapStore struct {
-	SnapStore
 	prefix string
 }
 

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -35,48 +34,47 @@ import (
 )
 
 const (
-	tmpDir              = "/tmp"
-	tmpBackupFilePrefix = "etcd-backup-"
-)
-
-const (
 	s3NoOfChunk int64 = 10000 //Default configuration in swift installation
 )
 
 // S3SnapStore is snapstore with local disk as backend
 type S3SnapStore struct {
-	SnapStore
 	prefix    string
 	client    s3iface.S3API
 	bucket    string
 	multiPart sync.Mutex
+	// maxParallelChunkUploads hold the maximum number of parallel chunk uploads allowed.
+	maxParallelChunkUploads int
+	tempDir                 string
 }
 
 // NewS3SnapStore create new S3SnapStore from shared configuration with specified bucket
-func NewS3SnapStore(bucket, prefix string) (*S3SnapStore, error) {
-	return NewS3FromSessionOpt(bucket, prefix, session.Options{
+func NewS3SnapStore(bucket, prefix, tempDir string, maxParallelChunkUploads int) (*S3SnapStore, error) {
+	return newS3FromSessionOpt(bucket, prefix, tempDir, maxParallelChunkUploads, session.Options{
 		// Setting this is equal to the AWS_SDK_LOAD_CONFIG environment variable was set.
 		// We want to save the work to set AWS_SDK_LOAD_CONFIG=1 outside.
 		SharedConfigState: session.SharedConfigEnable,
 	})
 }
 
-// NewS3FromSessionOpt will create the new S3 snapstore object from S3 session options
-func NewS3FromSessionOpt(bucket, prefix string, so session.Options) (*S3SnapStore, error) {
+// newS3FromSessionOpt will create the new S3 snapstore object from S3 session options
+func newS3FromSessionOpt(bucket, prefix, tempDir string, maxParallelChunkUploads int, so session.Options) (*S3SnapStore, error) {
 	sess, err := session.NewSessionWithOptions(so)
 	if err != nil {
 		return nil, fmt.Errorf("new AWS session failed: %v", err)
 	}
 	cli := s3.New(sess)
-	return NewS3FromClient(bucket, prefix, cli), nil
+	return NewS3FromClient(bucket, prefix, tempDir, maxParallelChunkUploads, cli), nil
 }
 
 // NewS3FromClient will create the new S3 snapstore object from S3 client
-func NewS3FromClient(bucket, prefix string, cli s3iface.S3API) *S3SnapStore {
+func NewS3FromClient(bucket, prefix, tempDir string, maxParallelChunkUploads int, cli s3iface.S3API) *S3SnapStore {
 	return &S3SnapStore{
-		bucket: bucket,
-		prefix: prefix,
-		client: cli,
+		bucket:                  bucket,
+		prefix:                  prefix,
+		client:                  cli,
+		maxParallelChunkUploads: maxParallelChunkUploads,
+		tempDir:                 tempDir,
 	}
 }
 
@@ -89,14 +87,12 @@ func (s *S3SnapStore) Fetch(snap Snapshot) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return resp.Body, nil
 }
 
 // Save will write the snapshot to store
 func (s *S3SnapStore) Save(snap Snapshot, r io.Reader) error {
-	// since s3 requires io.ReadSeeker, this is the required hack.
-	tmpfile, err := ioutil.TempFile(tmpDir, tmpBackupFilePrefix)
+	tmpfile, err := ioutil.TempFile(s.tempDir, tmpBackupFilePrefix)
 	if err != nil {
 		return fmt.Errorf("failed to create snapshot tempfile: %v", err)
 	}
@@ -125,23 +121,43 @@ func (s *S3SnapStore) Save(snap Snapshot, r io.Reader) error {
 		return fmt.Errorf("failed to initiate multipart upload %v", err)
 	}
 	logrus.Infof("Successfully initiated the multipart upload with upload ID : %s", *uploadOutput.UploadId)
+
 	var (
-		errCh      = make(chan chunkUploadError)
 		chunkSize  = int64(math.Max(float64(minChunkSize), float64(size/s3NoOfChunk)))
 		noOfChunks = size / chunkSize
 	)
 	if size%chunkSize != 0 {
 		noOfChunks++
 	}
+	var (
+		completedParts = make([]*s3.CompletedPart, noOfChunks)
+		chunkUploadCh  = make(chan chunk, noOfChunks)
+		resCh          = make(chan chunkUploadResult, noOfChunks)
+		wg             sync.WaitGroup
+		cancelCh       = make(chan struct{})
+	)
 
-	completedParts := make([]*s3.CompletedPart, noOfChunks)
-	logrus.Infof("Uploading snapshot of size: %d, chunkSize: %d, noOfChunks: %d", size, chunkSize, noOfChunks)
-	for offset := int64(0); offset <= size; offset += int64(chunkSize) {
-		go retryPartUpload(s, &snap, tmpfile, uploadOutput.UploadId, completedParts, offset, chunkSize, errCh)
+	for i := 0; i < s.maxParallelChunkUploads; i++ {
+		wg.Add(1)
+		go s.partUploader(&wg, cancelCh, &snap, tmpfile, uploadOutput.UploadId, completedParts, chunkUploadCh, resCh)
 	}
+	logrus.Infof("Uploading snapshot of size: %d, chunkSize: %d, noOfChunks: %d", size, chunkSize, noOfChunks)
 
-	snapshotErr := collectChunkUploadError(errCh, noOfChunks)
-	if len(snapshotErr) != 0 {
+	for offset, index := int64(0), 1; offset <= size; offset += int64(chunkSize) {
+		newChunk := chunk{
+			id:     index,
+			offset: offset,
+			size:   chunkSize,
+		}
+		logrus.Debugf("Triggering chunk upload for offset: %d", offset)
+		chunkUploadCh <- newChunk
+		index++
+	}
+	logrus.Infof("Triggered chunk upload for all chunks, total: %d", noOfChunks)
+	snapshotErr := collectChunkUploadError(chunkUploadCh, resCh, cancelCh, noOfChunks)
+	wg.Wait()
+
+	if snapshotErr != nil {
 		ctx := context.TODO()
 		ctx, cancel := context.WithTimeout(ctx, chunkUploadTimeout)
 		defer cancel()
@@ -167,20 +183,15 @@ func (s *S3SnapStore) Save(snap Snapshot, r io.Reader) error {
 	}
 
 	if err != nil {
-		return err
+		return fmt.Errorf("failed completing snapshot upload with error %v", err)
 	}
-	if len(snapshotErr) == 0 {
-		return nil
+	if snapshotErr != nil {
+		return fmt.Errorf("failed uploading chunk, id: %d, offset: %d, error: %v", snapshotErr.chunk.id, snapshotErr.chunk.offset, snapshotErr.err)
 	}
-
-	var collectedErr []string
-	for _, chunkErr := range snapshotErr {
-		collectedErr = append(collectedErr, fmt.Sprintf("failed uploading chunk with offset %d with error %v", chunkErr.offset, chunkErr.err))
-	}
-	return fmt.Errorf(strings.Join(collectedErr, "\n"))
+	return nil
 }
 
-func uploadPart(s *S3SnapStore, snap *Snapshot, file *os.File, uploadID *string, completedParts []*s3.CompletedPart, offset, chunkSize int64) error {
+func (s *S3SnapStore) uploadPart(snap *Snapshot, file *os.File, uploadID *string, completedParts []*s3.CompletedPart, offset, chunkSize int64) error {
 	fileInfo, err := file.Stat()
 	if err != nil {
 		return err
@@ -213,30 +224,25 @@ func uploadPart(s *S3SnapStore, snap *Snapshot, file *os.File, uploadID *string,
 	return err
 }
 
-func retryPartUpload(s *S3SnapStore, snap *Snapshot, file *os.File, uploadID *string, completedParts []*s3.CompletedPart, offset, chunkSize int64, errCh chan<- chunkUploadError) {
-	var (
-		maxAttempts uint = 5
-		curAttempt  uint = 1
-		err         error
-	)
+func (s *S3SnapStore) partUploader(wg *sync.WaitGroup, stopCh <-chan struct{}, snap *Snapshot, file *os.File, uploadID *string, completedParts []*s3.CompletedPart, chunkUploadCh <-chan chunk, errCh chan<- chunkUploadResult) {
+	defer wg.Done()
 	for {
-		logrus.Infof("Uploading chunk with offset : %d, attempt: %d", offset, curAttempt)
-		err = uploadPart(s, snap, file, uploadID, completedParts, offset, chunkSize)
-		logrus.Infof("For chunk upload of offset %d, err %v", offset, err)
-		if err == nil || curAttempt == maxAttempts {
-			break
+		select {
+		case <-stopCh:
+			return
+		case chunk, more := <-chunkUploadCh:
+			if !more {
+				return
+			}
+			logrus.Infof("Uploading chunk with id: %d, offset: %d, attempt: %d", chunk.id, chunk.offset, chunk.attempt)
+			err := s.uploadPart(snap, file, uploadID, completedParts, chunk.offset, chunk.size)
+			logrus.Infof("For chunk upload of id: %d, offset: %d, error: %v", chunk.id, chunk.offset, err)
+			errCh <- chunkUploadResult{
+				err:   err,
+				chunk: &chunk,
+			}
 		}
-		delayTime := (1 << curAttempt)
-		curAttempt++
-		logrus.Warnf("Will try to upload chunk with offset: %d at attempt %d  after %d seconds", offset, curAttempt, delayTime)
-		time.Sleep((time.Duration)(delayTime) * time.Second)
 	}
-
-	errCh <- chunkUploadError{
-		err:    err,
-		offset: offset,
-	}
-	return
 }
 
 // List will list the snapshots from store

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Snapstore", func() {
 			multiPartUploads: map[string]*[][]byte{},
 		}
 		snapstores = map[string]SnapStore{
-			"s3": NewS3FromClient(bucket, prefix, &m),
+			"s3": NewS3FromClient(bucket, prefix, "/tmp", 5, &m),
 		}
 	})
 

--- a/pkg/snapstore/types.go
+++ b/pkg/snapstore/types.go
@@ -86,7 +86,7 @@ type Config struct {
 	Prefix string
 	// MaxParallelChunkUploads hold the maximum number of parallel chunk uploads allowed.
 	MaxParallelChunkUploads int
-	// Temporay Directory
+	// Temporary Directory
 	TempDir string
 }
 

--- a/pkg/snapstore/types.go
+++ b/pkg/snapstore/types.go
@@ -52,8 +52,14 @@ const (
 	SnapshotKindFull = "Full"
 	// SnapshotKindDelta is constant for delta snapshot kind
 	SnapshotKindDelta = "Incr"
+
 	// ChunkUploadTimeout is timeout for uploading chunk
 	chunkUploadTimeout = 180 * time.Second
+
+	tmpBackupFilePrefix = "etcd-backup-"
+
+	// maxRetryAttempts indicates the number of attempts to be retried in case of failure to upload chunk.
+	maxRetryAttempts = 5
 )
 
 // Snapshot structure represents the metadata of snapshot
@@ -70,17 +76,27 @@ type Snapshot struct {
 // SnapList is list of snapshots
 type SnapList []*Snapshot
 
-// Config defines the configuration to create snapshot store
+// Config defines the configuration to create snapshot store.
 type Config struct {
-	// Provider indicated the cloud provider
+	// Provider indicated the cloud provider.
 	Provider string
-	// Container holds the name of bucket or container to which snapshot will be stored
+	// Container holds the name of bucket or container to which snapshot will be stored.
 	Container string
-	// Prefix holds the prefix or directory under StorageContainer under which snapshot will be stored
+	// Prefix holds the prefix or directory under StorageContainer under which snapshot will be stored.
 	Prefix string
+	// MaxParallelChunkUploads hold the maximum number of parallel chunk uploads allowed.
+	MaxParallelChunkUploads int
+	// Temporay Directory
+	TempDir string
 }
 
-type chunkUploadError struct {
-	err    error
-	offset int64
+type chunk struct {
+	offset  int64
+	size    int64
+	attempt uint
+	id      int
+}
+type chunkUploadResult struct {
+	err   error
+	chunk *chunk
 }

--- a/pkg/snapstore/utils.go
+++ b/pkg/snapstore/utils.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -32,6 +33,9 @@ func GetSnapstore(config *Config) (SnapStore, error) {
 	if config.Container == "" {
 		config.Container = os.Getenv(envStorageContainer)
 	}
+	if config.MaxParallelChunkUploads <= 0 {
+		config.MaxParallelChunkUploads = 5
+	}
 	switch config.Provider {
 	case SnapstoreProviderLocal, "":
 		if config.Container == "" {
@@ -42,22 +46,22 @@ func GetSnapstore(config *Config) (SnapStore, error) {
 		if config.Container == "" {
 			return nil, fmt.Errorf("storage container name not specified")
 		}
-		return NewS3SnapStore(config.Container, config.Prefix)
+		return NewS3SnapStore(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads)
 	case SnapstoreProviderABS:
 		if config.Container == "" {
 			return nil, fmt.Errorf("storage container name not specified")
 		}
-		return NewABSSnapStore(config.Container, config.Prefix)
+		return NewABSSnapStore(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads)
 	case SnapstoreProviderGCS:
 		if config.Container == "" {
 			return nil, fmt.Errorf("storage container name not specified")
 		}
-		return NewGCSSnapStore(config.Container, config.Prefix)
+		return NewGCSSnapStore(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads)
 	case SnapstoreProviderSwift:
 		if config.Container == "" {
 			return nil, fmt.Errorf("storage container name not specified")
 		}
-		return NewSwiftSnapStore(config.Container, config.Prefix)
+		return NewSwiftSnapStore(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads)
 	default:
 		return nil, fmt.Errorf("unsupported storage provider : %s", config.Provider)
 
@@ -76,18 +80,35 @@ func GetEnvVarOrError(varName string) (string, error) {
 }
 
 // collectChunkUploadError collects the error from all go routine to upload individual chunks
-func collectChunkUploadError(errCh chan chunkUploadError, noOfChunks int64) []chunkUploadError {
-	var snapshotErr []chunkUploadError
+func collectChunkUploadError(chunkUploadCh chan<- chunk, resCh <-chan chunkUploadResult, stopCh chan struct{}, noOfChunks int64) *chunkUploadResult {
 	remainingChunks := noOfChunks
 	logrus.Infof("No of Chunks:= %d", noOfChunks)
-	for {
-		chunkErr := <-errCh
-		if chunkErr.err != nil {
-			snapshotErr = append(snapshotErr, chunkErr)
+	for chunkRes := range resCh {
+		logrus.Infof("Received chunk result for id: %d, offset: %d", chunkRes.chunk.id, chunkRes.chunk.offset)
+		if chunkRes.err != nil {
+			if chunkRes.chunk.attempt == maxRetryAttempts {
+				logrus.Errorf("Received the chunk upload error from one of the workers. Sending stop signal to all workers.")
+				close(stopCh)
+				return &chunkRes
+			}
+			chunk := chunkRes.chunk
+			delayTime := (1 << chunk.attempt)
+			chunk.attempt++
+			logrus.Warnf("Will try to upload chunk id:%d, offset: %d at attempt %d  after %d seconds", chunk.id, chunk.offset, chunk.attempt, delayTime)
+			time.AfterFunc(time.Duration(delayTime)*time.Second, func() {
+				select {
+				case <-stopCh:
+					return
+				default:
+					chunkUploadCh <- *chunk
+				}
+			})
 		}
 		remainingChunks--
 		if remainingChunks == 0 {
-			return snapshotErr
+			close(stopCh)
+			break
 		}
 	}
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
Earlier we used to spawn go routine for all chunks simultaneously which was causing network traffic. This PR refactor the multi-part/chunk upload code. Now, we can configure the number of parallel chunk upload upper limit.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Please test both snapshot and server sub-command against all cloud providers.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy user
Now, snapshot upload happens in chunk. One can configure the number of parallel chunk uploads by setting command line argument `max-parallel-chunk-uploads`. Default is set to 5.
```
