### PR TITLE
Change AllowReauth to be set to true.

### DIFF
--- a/pkg/snapstore/swift_snapstore.go
+++ b/pkg/snapstore/swift_snapstore.go
@@ -54,6 +54,10 @@ func NewSwiftSnapStore(bucket, prefix, tempDir string, maxParallelChunkUploads i
 	if err != nil {
 		return nil, err
 	}
+	// AllowReauth should be set to true if you grant permission for Gophercloud to
+	// cache your credentials in memory, and to allow Gophercloud to attempt to
+	// re-authenticate automatically if/when your token expires.
+	authOpts.AllowReauth = true
 	provider, err := openstack.AuthenticatedClient(authOpts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
The token from the initial authentication expires the sidecar does not acquire a new token leaving the sidecar broken. `AllowReauth` flag in the auth options has to be set to `true` explicitly so that gophercloud can re-authenticate the token.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator

```
