### PR TITLE
Allow disabling delta snapshots

### DIFF
--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -93,7 +93,7 @@ storing snapshots on various cloud storage providers as well as local disk locat
 func initializeSnapshotterFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVarP(&etcdEndpoints, "endpoints", "e", []string{"127.0.0.1:2379"}, "comma separated list of etcd endpoints")
 	cmd.Flags().StringVarP(&schedule, "schedule", "s", "* */1 * * *", "schedule for snapshots")
-	cmd.Flags().IntVarP(&deltaSnapshotIntervalSeconds, "delta-snapshot-period-seconds", "i", snapshotter.DefaultDeltaSnapshotIntervalSeconds, "Period in seconds after which delta snapshot will be persisted")
+	cmd.Flags().IntVarP(&deltaSnapshotIntervalSeconds, "delta-snapshot-period-seconds", "i", snapshotter.DefaultDeltaSnapshotIntervalSeconds, "Period in seconds after which delta snapshot will be persisted. If this value is set to be lesser than 1, delta snapshotting will be disabled.")
 	cmd.Flags().IntVar(&deltaSnapshotMemoryLimit, "delta-snapshot-memory-limit", snapshotter.DefaultDeltaSnapMemoryLimit, "memory limit after which delta snapshots will be taken")
 	cmd.Flags().IntVarP(&maxBackups, "max-backups", "m", snapshotter.DefaultMaxBackups, "maximum number of previous backups to keep")
 	cmd.Flags().IntVar(&etcdConnectionTimeout, "etcd-connection-timeout", 30, "etcd client connection timeout")

--- a/pkg/initializer/validator/datavalidator.go
+++ b/pkg/initializer/validator/datavalidator.go
@@ -350,15 +350,18 @@ func (d *DataValidator) CheckRevisionConsistency() error {
 		return fmt.Errorf("unable to fetch snapstore: %v", err)
 	}
 
+	var latestSnapshotRevision int64
 	fullSnap, deltaSnaps, err := miscellaneous.GetLatestFullSnapshotAndDeltaSnapList(store)
 	if err != nil {
 		return fmt.Errorf("unable to get snapshots from store: %v", err)
 	}
-	var latestSnapshotRevision int64
-	if len(deltaSnaps) != 0 {
-		latestSnapshotRevision = deltaSnaps[len(deltaSnaps)-1].LastRevision
-	} else {
+	if fullSnap == nil {
+		logger.Infof("No snapshot found.")
+		return nil
+	} else if len(deltaSnaps) == 0 {
 		latestSnapshotRevision = fullSnap.LastRevision
+	} else {
+		latestSnapshotRevision = deltaSnaps[len(deltaSnaps)-1].LastRevision
 	}
 
 	if etcdRevision < latestSnapshotRevision {


### PR DESCRIPTION
**What this PR does / why we need it**:
Added the option to disable delta snapshots, by setting the `--delta-snapshot-period-seconds` flag to any value lesser than 1.

**Which issue(s) this PR fixes**:
Fixes #94 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Added the option to disable delta snapshots, by setting the 'delta-snapshot-period-seconds' flag to any value lesser than 1.
```
