### PR TITLE
Stop etcd watch client when not in use and streamline the Json encoding for delta snapshot

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -56,6 +56,7 @@ fi
 
 VERSION_FILE="$(readlink  -f "${SOURCE_PATH}/VERSION")"
 VERSION="$(cat "${VERSION_FILE}")"
+GIT_SHA=$(git rev-parse --short HEAD || echo "GitNotFound")
 
 # If no LOCAL_BUILD environment variable is set, we configure the `go build` command
 # to build for linux OS, amd64 architectures and without CGO enablement.
@@ -64,7 +65,7 @@ if [[ -z "$LOCAL_BUILD" ]]; then
     -a \
     -v \
     -o ${BINARY_PATH}/linux-amd64/etcdbrctl \
-    -ldflags "-w -X ${REPOSITORY}/pkg/version.Version=${VERSION}" \
+    -ldflags "-w -X ${REPOSITORY}/pkg/version.Version=${VERSION} -X ${REPOSITORY}/pkg/version.GitSHA=${GIT_SHA}" \
     main.go
 
 # If the LOCAL_BUILD environment variable is set, we simply run `go build`.
@@ -72,6 +73,6 @@ else
   go build \
     -v \
     -o ${BINARY_PATH}/etcdbrctl \
-    -ldflags "-w -X ${REPOSITORY}/pkg/version.Version=${VERSION}" \
+    -ldflags "-w -X ${REPOSITORY}/pkg/version.Version=${VERSION} -X ${REPOSITORY}/pkg/version.GitSHA=${GIT_SHA}" \
     main.go
 fi

--- a/cmd/miscellaneous.go
+++ b/cmd/miscellaneous.go
@@ -15,6 +15,9 @@
 package cmd
 
 import (
+	"runtime"
+
+	ver "github.com/gardener/etcd-backup-restore/pkg/version"
 	"github.com/spf13/cobra"
 )
 
@@ -25,4 +28,11 @@ func initializeSnapstoreFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&storagePrefix, "store-prefix", "", "prefix or directory inside container under which snapstore is created")
 	cmd.Flags().IntVar(&maxParallelChunkUploads, "max-parallel-chunk-uploads", 5, "maximum number of parallel chunk uploads allowed ")
 	cmd.Flags().StringVar(&snapstoreTempDir, "snapstore-temp-directory", "/tmp", "temporary directory for processing")
+}
+
+func printVersionInfo() {
+	logger.Infof("etcd-backup-restore Version: %s", ver.Version)
+	logger.Infof("Git SHA: %s", ver.GitSHA)
+	logger.Infof("Go Version: %s", runtime.Version())
+	logger.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,11 +23,17 @@ func NewBackupRestoreCommand(stopCh <-chan struct{}) *cobra.Command {
 	var RootCmd = &cobra.Command{
 		Use:   "etcdbrctl",
 		Short: "command line utility for etcd backup restore",
-		Long: `The etcdbrctl, command line utility, is built to support etcd's backup and restore 
+		Long: `The etcdbrctl, command line utility, is built to support etcd's backup and restore
 related functionality. Sub-command for this root command will support features
 like scheduled snapshot of etcd, etcd data directory validation and restore etcd
 from previously taken snapshot.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if version {
+				printVersionInfo()
+			}
+		},
 	}
+	RootCmd.Flags().BoolVarP(&version, "version", "v", false, "print version info")
 	RootCmd.AddCommand(NewSnapshotCommand(stopCh),
 		NewRestoreCommand(stopCh),
 		NewInitializeCommand(stopCh),

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -40,6 +40,7 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 		Short: "start the http server with backup scheduler.",
 		Long:  `Server will keep listening for http request to deliver its functionality through http endpoints.`,
 		Run: func(cmd *cobra.Command, args []string) {
+			printVersionInfo()
 			var (
 				snapstoreConfig *snapstore.Config
 				ssrStopCh       chan struct{}

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -32,6 +32,7 @@ func NewSnapshotCommand(stopCh <-chan struct{}) *cobra.Command {
 		Long: `Snapshot utility will backup the etcd at regular interval. It supports
 storing snapshots on various cloud storage providers as well as local disk location.`,
 		Run: func(cmd *cobra.Command, args []string) {
+			printVersionInfo()
 			snapstoreConfig := &snapstore.Config{
 				Provider:                storageProvider,
 				Container:               storageContainer,

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -26,8 +26,8 @@ const (
 )
 
 var (
-	logger = logrus.New()
-
+	logger  = logrus.New()
+	version bool
 	//snapshotter flags
 	schedule                       string
 	etcdEndpoints                  []string

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -347,7 +347,7 @@ func jsonEncodeEvents(events []*event, pw *io.PipeWriter) {
 		return
 	}
 	// write the final check sum to pipe
-	if _, err := mw.Write(hash.Sum(nil)); err != nil {
+	if _, err := pw.Write(hash.Sum(nil)); err != nil {
 		pw.CloseWithError(fmt.Errorf("no event found to encode"))
 		return
 	}

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"path"
 	"sync"
@@ -306,9 +307,9 @@ func (ssr *Snapshotter) takeDeltaSnapshot() error {
 	}
 	data = hash.Sum(data)
 
-	dataReader := bytes.NewReader(data)
+	sumReader := bytes.NewReader(data)
 	startTime := time.Now()
-	if err := ssr.config.store.Save(*snap, dataReader); err != nil {
+	if err := ssr.config.store.Save(*snap, ioutil.NopCloser(sumReader)); err != nil {
 		timeTaken := time.Now().Sub(startTime).Seconds()
 		metrics.SnapshotDurationSeconds.With(prometheus.Labels{metrics.LabelKind: snapstore.SnapshotKindDelta, metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(timeTaken)
 		ssr.logger.Errorf("Error saving delta snapshots. %v", err)

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -16,6 +16,7 @@ package snapshotter_test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"path"
 	"strings"
 	"time"
@@ -554,7 +555,7 @@ func prepareStoreForGarbageCollection(forTime time.Time, storeContainer string) 
 		snap.GenerateSnapshotDirectory()
 		snap.GenerateSnapshotName()
 		snapTime = snapTime.Add(time.Duration(time.Minute * 10))
-		store.Save(snap, strings.NewReader(fmt.Sprintf("dummy-snapshot-content for snap created on %s", snap.CreatedOn)))
+		store.Save(snap, ioutil.NopCloser(strings.NewReader(fmt.Sprintf("dummy-snapshot-content for snap created on %s", snap.CreatedOn))))
 	}
 	return store
 }

--- a/pkg/snapshot/snapshotter/types.go
+++ b/pkg/snapshot/snapshotter/types.go
@@ -59,6 +59,7 @@ type Snapshotter struct {
 	deltaSnapshotTimer *time.Timer
 	events             []*event
 	watchCh            clientv3.WatchChan
+	etcdClient         *clientv3.Client
 	cancelWatch        context.CancelFunc
 	SsrStateMutex      *sync.Mutex
 	SsrState           State

--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -133,17 +133,19 @@ func (a *ABSSnapStore) List() (SnapList, error) {
 }
 
 // Save will write the snapshot to store
-func (a *ABSSnapStore) Save(snap Snapshot, r io.Reader) error {
+func (a *ABSSnapStore) Save(snap Snapshot, rc io.ReadCloser) error {
 	// Save it locally
 	tmpfile, err := ioutil.TempFile(a.tempDir, tmpBackupFilePrefix)
 	if err != nil {
+		rc.Close()
 		return fmt.Errorf("failed to create snapshot tempfile: %v", err)
 	}
 	defer func() {
 		tmpfile.Close()
 		os.Remove(tmpfile.Name())
 	}()
-	size, err := io.Copy(tmpfile, r)
+	size, err := io.Copy(tmpfile, rc)
+	rc.Close()
 	if err != nil {
 		return fmt.Errorf("failed to save snapshot to tmpfile: %v", err)
 	}

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -77,16 +77,18 @@ func (s *GCSSnapStore) Fetch(snap Snapshot) (io.ReadCloser, error) {
 }
 
 // Save will write the snapshot to store.
-func (s *GCSSnapStore) Save(snap Snapshot, r io.Reader) error {
+func (s *GCSSnapStore) Save(snap Snapshot, rc io.ReadCloser) error {
 	tmpfile, err := ioutil.TempFile(s.tempDir, tmpBackupFilePrefix)
 	if err != nil {
+		rc.Close()
 		return fmt.Errorf("failed to create snapshot tempfile: %v", err)
 	}
 	defer func() {
 		tmpfile.Close()
 		os.Remove(tmpfile.Name())
 	}()
-	size, err := io.Copy(tmpfile, r)
+	size, err := io.Copy(tmpfile, rc)
+	rc.Close()
 	if err != nil {
 		return fmt.Errorf("failed to save snapshot to tmpfile: %v", err)
 	}

--- a/pkg/snapstore/local_snapstore.go
+++ b/pkg/snapstore/local_snapstore.go
@@ -48,7 +48,8 @@ func (s *LocalSnapStore) Fetch(snap Snapshot) (io.ReadCloser, error) {
 }
 
 // Save will write the snapshot to store
-func (s *LocalSnapStore) Save(snap Snapshot, r io.Reader) error {
+func (s *LocalSnapStore) Save(snap Snapshot, rc io.ReadCloser) error {
+	defer rc.Close()
 	err := os.MkdirAll(path.Join(s.prefix, snap.SnapDir), 0700)
 	if err != nil && !os.IsExist(err) {
 		return err
@@ -58,7 +59,7 @@ func (s *LocalSnapStore) Save(snap Snapshot, r io.Reader) error {
 		return err
 	}
 	defer f.Close()
-	_, err = io.Copy(f, r)
+	_, err = io.Copy(f, rc)
 	if err != nil {
 		return err
 	}

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/url"
 	"path"
 	"strings"
@@ -114,7 +115,7 @@ var _ = Describe("Snapstore", func() {
 				logrus.Infof("Running tests for %s", key)
 				resetObjectMap()
 				dummyData := make([]byte, 6*1024*1024)
-				err := snapStore.Save(snap3, bytes.NewReader(dummyData))
+				err := snapStore.Save(snap3, ioutil.NopCloser(bytes.NewReader(dummyData)))
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(len(objectMap)).Should(BeNumerically(">", 0))
 			}

--- a/pkg/snapstore/swift_snapstore.go
+++ b/pkg/snapstore/swift_snapstore.go
@@ -91,17 +91,19 @@ func (s *SwiftSnapStore) Fetch(snap Snapshot) (io.ReadCloser, error) {
 }
 
 // Save will write the snapshot to store
-func (s *SwiftSnapStore) Save(snap Snapshot, r io.Reader) error {
+func (s *SwiftSnapStore) Save(snap Snapshot, rc io.ReadCloser) error {
 	// Save it locally
 	tmpfile, err := ioutil.TempFile(s.tempDir, tmpBackupFilePrefix)
 	if err != nil {
+		rc.Close()
 		return fmt.Errorf("failed to create snapshot tempfile: %v", err)
 	}
 	defer func() {
 		tmpfile.Close()
 		os.Remove(tmpfile.Name())
 	}()
-	size, err := io.Copy(tmpfile, r)
+	size, err := io.Copy(tmpfile, rc)
+	rc.Close()
 	if err != nil {
 		return fmt.Errorf("failed to save snapshot to tmpfile: %v", err)
 	}

--- a/pkg/snapstore/types.go
+++ b/pkg/snapstore/types.go
@@ -29,7 +29,7 @@ type SnapStore interface {
 	// List will list all snapshot files on store.
 	List() (SnapList, error)
 	// Save will write the snapshot to store.
-	Save(Snapshot, io.Reader) error
+	Save(Snapshot, io.ReadCloser) error
 	// Delete should delete the snapshot file from store.
 	Delete(Snapshot) error
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+var (
+	// These variables typically come from -ldflags settings in build
+
+	// Version shows the etcd-backup-restore binary version.
+	Version string
+	// GitSHA shows the etcd-backup-restore binary code commit SHA on git.
+	GitSHA string
+)


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
Currently we don't close old client at the time full snapshot. Also, for delta snapshot `json.Marshal` doesn't help in streaming the marshalled data. This modifies the logic there. This PR also, adds the version flag to get binary version info, like from which git commit it was built.
 
**Which issue(s) this PR fixes**:
Fixes partially #95 

**Special notes for your reviewer**:
Please verify it thoroughly. Make use of etcd benchmark tool and monitor the performance.
 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
