### PR TITLE
Fix S3 mock client race condition

### DIFF
--- a/pkg/snapstore/s3_snapstore_test.go
+++ b/pkg/snapstore/s3_snapstore_test.go
@@ -96,6 +96,7 @@ func (m *mockS3Client) UploadPartWithContext(ctx aws.Context, in *s3.UploadPartI
 		m.multiPartUploads[*in.UploadId] = &t
 	}
 	m.multiPartUploadsMutex.Unlock()
+
 	size, err := in.Body.Seek(0, io.SeekEnd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to seek at the end of body %v", err)
@@ -108,7 +109,10 @@ func (m *mockS3Client) UploadPartWithContext(ctx aws.Context, in *s3.UploadPartI
 		return nil, fmt.Errorf("failed to read complete body %v", err)
 	}
 
+	m.multiPartUploadsMutex.Lock()
 	(*m.multiPartUploads[*in.UploadId])[*in.PartNumber-1] = content
+	m.multiPartUploadsMutex.Unlock()
+
 	eTag := string(*in.PartNumber)
 	out := &s3.UploadPartOutput{
 		ETag: &eTag,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a data race condition in the S3 mock client used for the unit tests for the snapstore package.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
