### PR TITLE
Skip snap store specific sanity check when not configured

### DIFF
--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -89,6 +89,10 @@ func (e *EtcdInitializer) restoreCorruptData() error {
 
 	if e.Config.SnapstoreConfig == nil {
 		logger.Warnf("No snapstore storage provider configured.")
+		logger.Infof("Removing data directory(%s) for snapshot restoration.", dataDir)
+		if err := os.RemoveAll(filepath.Join(dataDir)); err != nil {
+			return fmt.Errorf("failed to delete data directory %s with err: %v", dataDir, err)
+		}
 		return nil
 	}
 	store, err := snapstore.GetSnapstore(e.Config.SnapstoreConfig)


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
Currently, for case like etcd-events where we don't configure storage provider to disable backups, the backup dependent sanity checks fails with panic. This PR fixes the issue.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
In case of storage provider is not configured, i.e. backup disabled, we skip the backup dependent sanity checks.
```
