### PR TITLE
Fix upload functionality in S3 mock client for unit tests

### DIFF
--- a/pkg/snapstore/s3_snapstore_test.go
+++ b/pkg/snapstore/s3_snapstore_test.go
@@ -132,7 +132,7 @@ func (m *mockS3Client) CompleteMultipartUploadWithContext(ctx aws.Context, in *s
 			return nil, fmt.Errorf("parts should be sorted in ascending orders")
 		}
 		object = append(object, data[*part.PartNumber-1]...)
-
+		prevPartId = *part.PartNumber
 	}
 	m.objects[*in.Key] = &object
 	delete(m.multiPartUploads, *in.UploadId)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix multipart upload functionality for S3 mock client for snapstore unit tests, so that the check for the ordering of the upload parts by `PartNumber` will now work.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
