### PR TITLE
Optimise delta snapshot to use one time json marshalling

### DIFF
--- a/pkg/snapshot/snapshotter/types.go
+++ b/pkg/snapshot/snapshotter/types.go
@@ -57,13 +57,13 @@ type Snapshotter struct {
 	fullSnapshotCh     chan struct{}
 	fullSnapshotTimer  *time.Timer
 	deltaSnapshotTimer *time.Timer
-	events             []*event
+	events             []byte
 	watchCh            clientv3.WatchChan
 	etcdClient         *clientv3.Client
 	cancelWatch        context.CancelFunc
 	SsrStateMutex      *sync.Mutex
 	SsrState           State
-	eventMemory        int
+	lastEventRevision  int64
 }
 
 // Config stores the configuration parameters for the snapshotter.


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
This PR optimises delta snapshots further by avoiding json marshalling multiple times, resulting in memory spike. 
**Which issue(s) this PR fixes**:
Fixes #102 

**Special notes for your reviewer**:
Please cross check the delta snapshot json rendering and restoration.

Here are the graphs I observed:
WIth this PR:
![image](https://user-images.githubusercontent.com/5590545/53221952-ba951100-3691-11e9-9a33-f04a0dd7c57c.png)

With old master:
![image](https://user-images.githubusercontent.com/5590545/53221977-d13b6800-3691-11e9-86de-5a631ac24ba7.png)

Observations:
* Full snapshot spikes are common in both. independent of db size. Second graph the full snapshot time syncs with first 2 benchmarks , so you might miss-out but 3rd  full snapshot spike is clear.
* Memory consumed is reduced significantly.
* delta-snapshot-memory limit is 10 mb 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
