### PR TITLE
Pass db quota size config to embedded etcd used by restorer

### DIFF
--- a/chart/templates/etcd-statefulset.yaml
+++ b/chart/templates/etcd-statefulset.yaml
@@ -91,6 +91,9 @@ spec:
         - --data-dir=/var/etcd/data/new.etcd
         - --storage-provider={{ .Values.backup.storageProvider }}
         - --store-prefix=etcd-{{ .Values.role }}
+{{- if .Values.backup.embeddedEtcdQuotaBytes }}
+        - --embeddedEtcdQuotaBytes={{ .Values.backup.embeddedEtcdQuotaBytes }}
+{{- end }}
 {{- if .Values.tls }}
         - --cert=/var/etcd/ssl/client/tls.crt
         - --key=/var/etcd/ssl/client/tls.key

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -29,6 +29,8 @@ backup:
 
   storageContainer: ""
 
+  embeddedEtcdQuotaBytes: 8589934592
+
   # env should include the right list of values for the
   # storageProvider you use, follow the comments below
   env: []           # Follow comments below

--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -49,13 +49,14 @@ func NewInitializeCommand(stopCh <-chan struct{}) *cobra.Command {
 			}
 
 			options := &restorer.RestoreOptions{
-				RestoreDataDir: path.Clean(restoreDataDir),
-				Name:           restoreName,
-				ClusterURLs:    clusterUrlsMap,
-				PeerURLs:       peerUrls,
-				ClusterToken:   restoreClusterToken,
-				SkipHashCheck:  skipHashCheck,
-				MaxFetchers:    restoreMaxFetchers,
+				RestoreDataDir:         path.Clean(restoreDataDir),
+				Name:                   restoreName,
+				ClusterURLs:            clusterUrlsMap,
+				PeerURLs:               peerUrls,
+				ClusterToken:           restoreClusterToken,
+				SkipHashCheck:          skipHashCheck,
+				MaxFetchers:            restoreMaxFetchers,
+				EmbeddedEtcdQuotaBytes: embeddedEtcdQuotaBytes,
 			}
 
 			var snapstoreConfig *snapstore.Config

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -73,15 +73,16 @@ func NewRestoreCommand(stopCh <-chan struct{}) *cobra.Command {
 			rs := restorer.NewRestorer(store, logger)
 
 			options := &restorer.RestoreOptions{
-				RestoreDataDir: path.Clean(restoreDataDir),
-				Name:           restoreName,
-				BaseSnapshot:   *baseSnap,
-				DeltaSnapList:  deltaSnapList,
-				ClusterURLs:    clusterUrlsMap,
-				PeerURLs:       peerUrls,
-				ClusterToken:   restoreClusterToken,
-				SkipHashCheck:  skipHashCheck,
-				MaxFetchers:    restoreMaxFetchers,
+				RestoreDataDir:         path.Clean(restoreDataDir),
+				Name:                   restoreName,
+				BaseSnapshot:           *baseSnap,
+				DeltaSnapList:          deltaSnapList,
+				ClusterURLs:            clusterUrlsMap,
+				PeerURLs:               peerUrls,
+				ClusterToken:           restoreClusterToken,
+				SkipHashCheck:          skipHashCheck,
+				MaxFetchers:            restoreMaxFetchers,
+				EmbeddedEtcdQuotaBytes: embeddedEtcdQuotaBytes,
 			}
 
 			err = rs.Restore(*options)
@@ -107,6 +108,7 @@ func initializeEtcdFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&restoreName, "name", defaultName, "human-readable name for this member")
 	cmd.Flags().BoolVar(&skipHashCheck, "skip-hash-check", false, "ignore snapshot integrity hash value (required if copied from data directory)")
 	cmd.Flags().IntVar(&restoreMaxFetchers, "max-fetchers", 6, "maximum number of threads that will fetch delta snapshots in parallel")
+	cmd.Flags().Int64Var(&embeddedEtcdQuotaBytes, "embedded-etcd-quota-bytes", int64(8*1024*1024*1024), "maximum backend quota for the embedded etcd used for applying delta snapshots")
 }
 
 func initialClusterFromName(name string) string {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -57,13 +57,14 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 			}
 
 			options := &restorer.RestoreOptions{
-				RestoreDataDir: path.Clean(restoreDataDir),
-				Name:           restoreName,
-				ClusterURLs:    clusterUrlsMap,
-				PeerURLs:       peerUrls,
-				ClusterToken:   restoreClusterToken,
-				SkipHashCheck:  skipHashCheck,
-				MaxFetchers:    restoreMaxFetchers,
+				RestoreDataDir:         path.Clean(restoreDataDir),
+				Name:                   restoreName,
+				ClusterURLs:            clusterUrlsMap,
+				PeerURLs:               peerUrls,
+				ClusterToken:           restoreClusterToken,
+				SkipHashCheck:          skipHashCheck,
+				MaxFetchers:            restoreMaxFetchers,
+				EmbeddedEtcdQuotaBytes: embeddedEtcdQuotaBytes,
 			}
 
 			if storageProvider != "" {

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -49,13 +49,14 @@ var (
 	enableProfiling bool
 
 	//restore flags
-	restoreCluster      string
-	restoreClusterToken string
-	restoreDataDir      string
-	restorePeerURLs     []string
-	restoreName         string
-	skipHashCheck       bool
-	restoreMaxFetchers  int
+	restoreCluster         string
+	restoreClusterToken    string
+	restoreDataDir         string
+	restorePeerURLs        []string
+	restoreName            string
+	skipHashCheck          bool
+	restoreMaxFetchers     int
+	embeddedEtcdQuotaBytes int64
 
 	//snapstore flags
 	storageProvider         string

--- a/pkg/snapshot/restorer/restorer_test.go
+++ b/pkg/snapshot/restorer/restorer_test.go
@@ -39,13 +39,14 @@ var _ = Describe("Running Restorer", func() {
 		store snapstore.SnapStore
 		rstr  *Restorer
 
-		restoreCluster      string
-		restoreClusterToken string
-		restoreDataDir      string
-		restorePeerURLs     []string
-		restoreName         string
-		skipHashCheck       bool
-		maxFetchers         int
+		restoreCluster         string
+		restoreClusterToken    string
+		restoreDataDir         string
+		restorePeerURLs        []string
+		restoreName            string
+		skipHashCheck          bool
+		maxFetchers            int
+		embeddedEtcdQuotaBytes int64
 
 		clusterUrlsMap types.URLsMap
 		peerUrls       types.URLs
@@ -68,6 +69,7 @@ var _ = Describe("Running Restorer", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		skipHashCheck = false
 		maxFetchers = 6
+		embeddedEtcdQuotaBytes = 8 * 1024 * 1024 * 1024
 
 		err = corruptEtcdDir()
 		Expect(err).ShouldNot(HaveOccurred())
@@ -87,15 +89,16 @@ var _ = Describe("Running Restorer", func() {
 			maxFetchers = 0
 
 			restoreOptions := RestoreOptions{
-				ClusterURLs:    clusterUrlsMap,
-				ClusterToken:   restoreClusterToken,
-				RestoreDataDir: restoreDataDir,
-				PeerURLs:       peerUrls,
-				SkipHashCheck:  skipHashCheck,
-				Name:           restoreName,
-				MaxFetchers:    maxFetchers,
-				BaseSnapshot:   *baseSnapshot,
-				DeltaSnapList:  deltaSnapList,
+				ClusterURLs:            clusterUrlsMap,
+				ClusterToken:           restoreClusterToken,
+				RestoreDataDir:         restoreDataDir,
+				PeerURLs:               peerUrls,
+				SkipHashCheck:          skipHashCheck,
+				Name:                   restoreName,
+				MaxFetchers:            maxFetchers,
+				EmbeddedEtcdQuotaBytes: embeddedEtcdQuotaBytes,
+				BaseSnapshot:           *baseSnapshot,
+				DeltaSnapList:          deltaSnapList,
 			}
 			err = rstr.Restore(restoreOptions)
 			Expect(err).Should(HaveOccurred())
@@ -108,15 +111,16 @@ var _ = Describe("Running Restorer", func() {
 			maxFetchers = 1
 
 			restoreOptions := RestoreOptions{
-				ClusterURLs:    clusterUrlsMap,
-				ClusterToken:   restoreClusterToken,
-				RestoreDataDir: restoreDataDir,
-				PeerURLs:       peerUrls,
-				SkipHashCheck:  skipHashCheck,
-				Name:           restoreName,
-				MaxFetchers:    maxFetchers,
-				BaseSnapshot:   *baseSnapshot,
-				DeltaSnapList:  deltaSnapList,
+				ClusterURLs:            clusterUrlsMap,
+				ClusterToken:           restoreClusterToken,
+				RestoreDataDir:         restoreDataDir,
+				PeerURLs:               peerUrls,
+				SkipHashCheck:          skipHashCheck,
+				Name:                   restoreName,
+				MaxFetchers:            maxFetchers,
+				EmbeddedEtcdQuotaBytes: embeddedEtcdQuotaBytes,
+				BaseSnapshot:           *baseSnapshot,
+				DeltaSnapList:          deltaSnapList,
 			}
 			err = rstr.Restore(restoreOptions)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -132,15 +136,16 @@ var _ = Describe("Running Restorer", func() {
 			maxFetchers = 4
 
 			restoreOptions := RestoreOptions{
-				ClusterURLs:    clusterUrlsMap,
-				ClusterToken:   restoreClusterToken,
-				RestoreDataDir: restoreDataDir,
-				PeerURLs:       peerUrls,
-				SkipHashCheck:  skipHashCheck,
-				Name:           restoreName,
-				MaxFetchers:    maxFetchers,
-				BaseSnapshot:   *baseSnapshot,
-				DeltaSnapList:  deltaSnapList,
+				ClusterURLs:            clusterUrlsMap,
+				ClusterToken:           restoreClusterToken,
+				RestoreDataDir:         restoreDataDir,
+				PeerURLs:               peerUrls,
+				SkipHashCheck:          skipHashCheck,
+				Name:                   restoreName,
+				MaxFetchers:            maxFetchers,
+				EmbeddedEtcdQuotaBytes: embeddedEtcdQuotaBytes,
+				BaseSnapshot:           *baseSnapshot,
+				DeltaSnapList:          deltaSnapList,
 			}
 			err = rstr.Restore(restoreOptions)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -156,15 +161,16 @@ var _ = Describe("Running Restorer", func() {
 			maxFetchers = 100
 
 			restoreOptions := RestoreOptions{
-				ClusterURLs:    clusterUrlsMap,
-				ClusterToken:   restoreClusterToken,
-				RestoreDataDir: restoreDataDir,
-				PeerURLs:       peerUrls,
-				SkipHashCheck:  skipHashCheck,
-				Name:           restoreName,
-				MaxFetchers:    maxFetchers,
-				BaseSnapshot:   *baseSnapshot,
-				DeltaSnapList:  deltaSnapList,
+				ClusterURLs:            clusterUrlsMap,
+				ClusterToken:           restoreClusterToken,
+				RestoreDataDir:         restoreDataDir,
+				PeerURLs:               peerUrls,
+				SkipHashCheck:          skipHashCheck,
+				Name:                   restoreName,
+				MaxFetchers:            maxFetchers,
+				EmbeddedEtcdQuotaBytes: embeddedEtcdQuotaBytes,
+				BaseSnapshot:           *baseSnapshot,
+				DeltaSnapList:          deltaSnapList,
 			}
 			err = rstr.Restore(restoreOptions)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/snapshot/restorer/types.go
+++ b/pkg/snapshot/restorer/types.go
@@ -36,13 +36,14 @@ type Restorer struct {
 
 // RestoreOptions hold all snapshot restore related fields
 type RestoreOptions struct {
-	ClusterURLs    types.URLsMap
-	ClusterToken   string
-	RestoreDataDir string
-	PeerURLs       types.URLs
-	SkipHashCheck  bool
-	Name           string
-	MaxFetchers    int
+	ClusterURLs            types.URLsMap
+	ClusterToken           string
+	RestoreDataDir         string
+	PeerURLs               types.URLs
+	SkipHashCheck          bool
+	Name                   string
+	MaxFetchers            int
+	EmbeddedEtcdQuotaBytes int64
 	// Base full snapshot + delta snapshots to restore from
 	BaseSnapshot  snapstore.Snapshot
 	DeltaSnapList snapstore.SnapList


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the bug where large size etcd data (greater than 2GB) could not be restored due to the backend quota size not being configured on the embedded etcd instance that is started on the backup sidecar to apply delta snapshots during restoration.

**Which issue(s) this PR fixes**:
Fixes #133 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy user
Added the `embedded-etcd-quota-bytes` flag to allow configuring the backend quota size of the embedded etcd instance used during restoration of data.
```
