### PR TITLE
Fix embedded-etcd-quota-bytes flag on helm chart

### DIFF
--- a/chart/templates/etcd-bootstrap-configmap.yaml
+++ b/chart/templates/etcd-bootstrap-configmap.yaml
@@ -21,7 +21,7 @@ data:
     
     start_managed_etcd(){
           rm -rf $VALIDATION_MARKER
-          etcd --config-file /bootstrap/etcd.conf.yml &
+          etcd --config-file /var/etcd/config/etcd.conf.yaml &
           ETCDPID=$!
           trap_and_propagate $ETCDPID INT TERM
           wait $ETCDPID
@@ -79,8 +79,10 @@ data:
 
     # Raise alarms when backend size exceeds the given quota. 0 means use the
     # default quota.
-    quota-backend-bytes: 8589934592
-
+    {{- if .Values.backup.etcdQuotaBytes }}
+    quota-backend-bytes: {{ int $.Values.backup.etcdQuotaBytes }}
+    {{- end }}
+    
     # List of comma separated URLs to listen on for client traffic.
     listen-client-urls: {{ if .Values.tls }}https{{ else }}http{{ end }}://0.0.0.0:2379
 

--- a/chart/templates/etcd-statefulset.yaml
+++ b/chart/templates/etcd-statefulset.yaml
@@ -91,8 +91,8 @@ spec:
         - --data-dir=/var/etcd/data/new.etcd
         - --storage-provider={{ .Values.backup.storageProvider }}
         - --store-prefix=etcd-{{ .Values.role }}
-{{- if .Values.backup.embeddedEtcdQuotaBytes }}
-        - --embeddedEtcdQuotaBytes={{ .Values.backup.embeddedEtcdQuotaBytes }}
+{{- if .Values.backup.etcdQuotaBytes }}
+        - --embedded-etcd-quota-bytes={{ int $.Values.backup.etcdQuotaBytes }}
 {{- end }}
 {{- if .Values.tls }}
         - --cert=/var/etcd/ssl/client/tls.crt

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,10 +6,10 @@ replicas: 1
 images:
 
   # etcd image to use
-  etcd: quay.io/coreos/etcd:v3.3.10
+  etcd: quay.io/coreos/etcd:v3.3.12
 
   # etcd-backup-restore image to use
-  etcd-backup-restore: eu.gcr.io/gardener-project/gardener/etcdbrctl:0.5.0
+  etcd-backup-restore: eu.gcr.io/gardener-project/gardener/etcdbrctl:0.6.0
 
 backup:
 
@@ -29,7 +29,7 @@ backup:
 
   storageContainer: ""
 
-  embeddedEtcdQuotaBytes: 8589934592
+  etcdQuotaBytes: 8589934592  # 8GB
 
   # env should include the right list of values for the
   # storageProvider you use, follow the comments below


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the typo for `embedded-etcd-quota-bytes` in the helm chart.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
