### PR TITLE
Expose triggering on-demand full snapshot via HTTP endpoint

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -42,13 +42,12 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			printVersionInfo()
 			var (
-				snapstoreConfig           *snapstore.Config
-				ssrStopCh                 chan struct{}
-				ackCh                     chan struct{}
-				ssr                       *snapshotter.Snapshotter
-				handler                   *server.HTTPHandler
-				snapshotterEnabled        bool
-				initialDeltaSnapshotTaken bool
+				snapstoreConfig    *snapstore.Config
+				ssrStopCh          chan struct{}
+				ackCh              chan struct{}
+				ssr                *snapshotter.Snapshotter
+				handler            *server.HTTPHandler
+				snapshotterEnabled bool
 			)
 			ackCh = make(chan struct{})
 			clusterUrlsMap, err := types.NewURLsMap(restoreCluster)
@@ -121,128 +120,22 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 					logger,
 					snapshotterConfig,
 				)
-			}
 
-			// Start http handler with Error state and wait till snapshotter is up
-			// and running before setting the status to OK.
-			// If no storage provider is given, snapshotter will be nil, in which
-			// case the status is set to OK as soon as etcd probe is successful
-			handler = &server.HTTPHandler{
-				Port:            port,
-				EtcdInitializer: *etcdInitializer,
-				Snapshotter:     ssr,
-				Logger:          logger,
-				Status:          http.StatusServiceUnavailable,
-				StopCh:          make(chan struct{}),
-				EnableProfiling: enableProfiling,
-				ReqCh:           make(chan struct{}),
-				AckCh:           make(chan struct{}),
-			}
-			logger.Info("Registering the http request handlers...")
-			handler.RegisterHandler()
-			logger.Info("Starting the http server...")
-			go handler.Start()
-			defer handler.Stop()
+				handler = startHTTPServer(etcdInitializer, ssr)
+				defer handler.Stop()
 
-			if snapshotterEnabled {
 				ssrStopCh = make(chan struct{})
 				go handleSsrStopRequest(handler, ssr, ackCh, ssrStopCh, stopCh)
 				go handleAckState(handler, ackCh)
-			}
-
-			if defragmentationPeriodHours < 1 {
-				logger.Infof("Disabling defragmentation since defragmentation period [%d] is less than 1", defragmentationPeriodHours)
+				startDefragmentationThread(defragmentationPeriodHours, stopCh, tlsConfig, ssr.TriggerFullSnapshot)
+				runEtcdProbeLoopWithSnapshotter(tlsConfig, handler, ssr, ssrStopCh, stopCh, ackCh)
 			} else {
-				go etcdutil.DefragDataPeriodically(stopCh, tlsConfig, time.Duration(defragmentationPeriodHours)*time.Hour, time.Duration(etcdConnectionTimeout)*time.Second, ssr.TriggerFullSnapshot)
-			}
+				// If no storage provider is given, snapshotter will be nil, in which
+				// case the status is set to OK as soon as etcd probe is successful
+				handler = startHTTPServer(etcdInitializer, nil)
+				defer handler.Stop()
 
-			for {
-				logger.Infof("Probing etcd...")
-				select {
-				case <-stopCh:
-					logger.Info("Shutting down...")
-					return
-				default:
-					err = ProbeEtcd(tlsConfig)
-				}
-				if err != nil {
-					logger.Errorf("Failed to probe etcd: %v", err)
-					handler.Status = http.StatusServiceUnavailable
-					continue
-				}
-
-				if snapshotterEnabled {
-					// The decision to either take an initial delta snapshot or
-					// or a full snapshot directly is based on whether there has
-					// been a previous full snapshot (if not, we assume the etcd
-					// to be a fresh etcd) or it has been more than 24 hours since
-					// the last full snapshot was taken.
-					// If this is not the case, we take a delta snapshot by first
-					// collecting all the delta events since the previous snapshot
-					// and take a delta snapshot of these (there may be multiple
-					// delta snapshots based on the amount of events collected and
-					// the delta snapshot memory limit), after which a full snapshot
-					// is taken and the regular snapshot schedule comes into effect.
-
-					// TODO: write code to find out if prev full snapshot is older than it is
-					// supposed to be, according to the given cron schedule, instead of the
-					// hard-coded "24 hours" full snapshot interval
-					if ssr.PrevFullSnapshot != nil && time.Since(ssr.PrevFullSnapshot.CreatedOn).Hours() <= 24 {
-						ssrStopped, err := ssr.CollectEventsSincePrevSnapshot(ssrStopCh)
-						if ssrStopped {
-							logger.Info("Snapshotter stopped.")
-							ackCh <- emptyStruct
-							handler.Status = http.StatusServiceUnavailable
-							logger.Info("Shutting down...")
-							return
-						}
-						if err == nil {
-							if err := ssr.TakeDeltaSnapshot(); err != nil {
-								logger.Warnf("Failed to take first delta snapshot: snapshotter failed with error: %v", err)
-								continue
-							}
-							initialDeltaSnapshotTaken = true
-						} else {
-							logger.Warnf("Failed to collect events for first delta snapshot: %v", err)
-						}
-					}
-					if !initialDeltaSnapshotTaken {
-						if err := ssr.TakeFullSnapshotAndResetTimer(); err != nil {
-							logger.Errorf("Failed to take substitute first full snapshot: %v", err)
-							continue
-						}
-					}
-
-				}
-
-				// set server's healthz endpoint status to OK so that
-				// etcd is marked as ready to serve traffic
-				handler.Status = http.StatusOK
-
-				if !snapshotterEnabled {
-					<-stopCh
-					handler.Status = http.StatusServiceUnavailable
-					logger.Infof("Received stop signal. Terminating !!")
-					return
-				}
-
-				ssr.SsrStateMutex.Lock()
-				ssr.SsrState = snapshotter.SnapshotterActive
-				ssr.SsrStateMutex.Unlock()
-				gcStopCh := make(chan struct{})
-				go ssr.RunGarbageCollector(gcStopCh)
-				logger.Infof("Starting snapshotter...")
-				if err := ssr.Run(ssrStopCh, initialDeltaSnapshotTaken); err != nil {
-					if etcdErr, ok := err.(*errors.EtcdError); ok == true {
-						logger.Errorf("Snapshotter failed with etcd error: %v", etcdErr)
-					} else {
-						logger.Fatalf("Snapshotter failed with error: %v", err)
-					}
-				}
-				logger.Infof("Snapshotter stopped.")
-				ackCh <- emptyStruct
-				handler.Status = http.StatusServiceUnavailable
-				close(gcStopCh)
+				runEtcdProbeLoopWithoutSnapshotter(tlsConfig, handler, stopCh, ackCh)
 			}
 		},
 	}
@@ -252,6 +145,154 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 	initializeSnapstoreFlags(serverCmd)
 	initializeEtcdFlags(serverCmd)
 	return serverCmd
+}
+
+// startHTTPServer creates and starts the HTTP handler
+// with status 503 (Service Unavailable)
+func startHTTPServer(etcdInitializer *initializer.EtcdInitializer, ssr *snapshotter.Snapshotter) *server.HTTPHandler {
+	// Start http handler with Error state and wait till snapshotter is up
+	// and running before setting the status to OK.
+	handler := &server.HTTPHandler{
+		Port:            port,
+		EtcdInitializer: *etcdInitializer,
+		Snapshotter:     ssr,
+		Logger:          logger,
+		Status:          http.StatusServiceUnavailable,
+		StopCh:          make(chan struct{}),
+		EnableProfiling: enableProfiling,
+		ReqCh:           make(chan struct{}),
+		AckCh:           make(chan struct{}),
+	}
+	logger.Info("Registering the http request handlers...")
+	handler.RegisterHandler()
+	logger.Info("Starting the http server...")
+	go handler.Start()
+
+	return handler
+}
+
+// startDefragmentationThread starts the etcd data defragmentation thread
+func startDefragmentationThread(defragPeriod int, stopCh <-chan struct{}, tlsConfig *etcdutil.TLSConfig, triggerFullSnapshotCallback func() error) {
+	if defragPeriod < 1 {
+		logger.Infof("Disabling defragmentation since defragmentation period [%d] is less than 1", defragPeriod)
+		return
+	}
+	go etcdutil.DefragDataPeriodically(stopCh, tlsConfig, time.Duration(defragPeriod)*time.Hour, time.Duration(etcdConnectionTimeout)*time.Second, triggerFullSnapshotCallback)
+}
+
+// runEtcdProbeLoopWithoutSnapshotter runs the etcd probe loop
+// for the case where snapshotter is configured correctly
+func runEtcdProbeLoopWithSnapshotter(tlsConfig *etcdutil.TLSConfig, handler *server.HTTPHandler, ssr *snapshotter.Snapshotter, ssrStopCh chan struct{}, stopCh <-chan struct{}, ackCh chan struct{}) {
+	var (
+		err                       error
+		initialDeltaSnapshotTaken bool
+	)
+
+	for {
+		logger.Infof("Probing etcd...")
+		select {
+		case <-stopCh:
+			logger.Info("Shutting down...")
+			return
+		default:
+			err = ProbeEtcd(tlsConfig)
+		}
+		if err != nil {
+			logger.Errorf("Failed to probe etcd: %v", err)
+			handler.Status = http.StatusServiceUnavailable
+			continue
+		}
+
+		// The decision to either take an initial delta snapshot or
+		// or a full snapshot directly is based on whether there has
+		// been a previous full snapshot (if not, we assume the etcd
+		// to be a fresh etcd) or it has been more than 24 hours since
+		// the last full snapshot was taken.
+		// If this is not the case, we take a delta snapshot by first
+		// collecting all the delta events since the previous snapshot
+		// and take a delta snapshot of these (there may be multiple
+		// delta snapshots based on the amount of events collected and
+		// the delta snapshot memory limit), after which a full snapshot
+		// is taken and the regular snapshot schedule comes into effect.
+
+		// TODO: write code to find out if prev full snapshot is older than it is
+		// supposed to be, according to the given cron schedule, instead of the
+		// hard-coded "24 hours" full snapshot interval
+		if ssr.PrevFullSnapshot != nil && time.Since(ssr.PrevFullSnapshot.CreatedOn).Hours() <= 24 {
+			ssrStopped, err := ssr.CollectEventsSincePrevSnapshot(ssrStopCh)
+			if ssrStopped {
+				logger.Info("Snapshotter stopped.")
+				ackCh <- emptyStruct
+				handler.Status = http.StatusServiceUnavailable
+				logger.Info("Shutting down...")
+				return
+			}
+			if err == nil {
+				if err := ssr.TakeDeltaSnapshot(); err != nil {
+					logger.Warnf("Failed to take first delta snapshot: snapshotter failed with error: %v", err)
+					continue
+				}
+				initialDeltaSnapshotTaken = true
+			} else {
+				logger.Warnf("Failed to collect events for first delta snapshot: %v", err)
+			}
+		}
+		if !initialDeltaSnapshotTaken {
+			if err := ssr.TakeFullSnapshotAndResetTimer(); err != nil {
+				logger.Errorf("Failed to take substitute first full snapshot: %v", err)
+				continue
+			}
+		}
+
+		// set server's healthz endpoint status to OK so that
+		// etcd is marked as ready to serve traffic
+		handler.Status = http.StatusOK
+
+		ssr.SsrStateMutex.Lock()
+		ssr.SsrState = snapshotter.SnapshotterActive
+		ssr.SsrStateMutex.Unlock()
+		gcStopCh := make(chan struct{})
+		go ssr.RunGarbageCollector(gcStopCh)
+		logger.Infof("Starting snapshotter...")
+		if err := ssr.Run(ssrStopCh, initialDeltaSnapshotTaken); err != nil {
+			if etcdErr, ok := err.(*errors.EtcdError); ok == true {
+				logger.Errorf("Snapshotter failed with etcd error: %v", etcdErr)
+			} else {
+				logger.Fatalf("Snapshotter failed with error: %v", err)
+			}
+		}
+		logger.Infof("Snapshotter stopped.")
+		ackCh <- emptyStruct
+		handler.Status = http.StatusServiceUnavailable
+		close(gcStopCh)
+	}
+}
+
+// runEtcdProbeLoopWithoutSnapshotter runs the etcd probe loop
+// for the case where snapshotter is not configured
+func runEtcdProbeLoopWithoutSnapshotter(tlsConfig *etcdutil.TLSConfig, handler *server.HTTPHandler, stopCh <-chan struct{}, ackCh chan struct{}) {
+	var err error
+	for {
+		logger.Infof("Probing etcd...")
+		select {
+		case <-stopCh:
+			logger.Info("Shutting down...")
+			return
+		default:
+			err = ProbeEtcd(tlsConfig)
+		}
+		if err != nil {
+			logger.Errorf("Failed to probe etcd: %v", err)
+			handler.Status = http.StatusServiceUnavailable
+			continue
+		}
+
+		handler.Status = http.StatusOK
+		<-stopCh
+		handler.Status = http.StatusServiceUnavailable
+		logger.Infof("Received stop signal. Terminating !!")
+		return
+	}
 }
 
 // initializeServerFlags adds the flags to <cmd>

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -135,6 +135,11 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 				handler = startHTTPServer(etcdInitializer, nil)
 				defer handler.Stop()
 
+				// start defragmentation without trigerring full snapshot
+				// after each successful data defragmentation
+				startDefragmentationThread(defragmentationPeriodHours, stopCh, tlsConfig, func() error {
+					return nil
+				})
 				runEtcdProbeLoopWithoutSnapshotter(tlsConfig, handler, stopCh, ackCh)
 			}
 		},

--- a/pkg/etcdutil/defrag_test.go
+++ b/pkg/etcdutil/defrag_test.go
@@ -112,7 +112,10 @@ var _ = Describe("Defrag", func() {
 				close(stopCh)
 			})
 
-			DefragDataPeriodically(stopCh, tlsConfig, defragmentationPeriod, etcdConnectionTimeout, func() { defragCount++ })
+			DefragDataPeriodically(stopCh, tlsConfig, defragmentationPeriod, etcdConnectionTimeout, func() error {
+				defragCount++
+				return nil
+			})
 
 			ctx, cancel = context.WithTimeout(context.TODO(), etcdDialTimeout)
 			newStatus, err := client.Status(ctx, endpoints[0])


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds functionality to trigger on-demand full snapshots via the HTTP endpoint `/snapshot/full`.
This PR also fixes a few unhandled scenarios for the case when snapstore provider is not configured, such as etcd readiness probe handling and defragmentation. It also refactors the server command to make it more modular.

**Which issue(s) this PR fixes**:
Fixes #113 

**Special notes for your reviewer**:
Also refactored the `TriggerFullSnapshot` and `DefragDataPeriodically` methods, as well as the order of object creation in `NewServerCommand` in order to pass the `Snapshotter` to the `HTTPHandler`.
Will add unit tests shortly.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy user
Added functionality to trigger on-demand full snapshots via the HTTP endpoint `/snapshot/full`.
```
