### PR TITLE
Optimize etcd readiness probe

### DIFF
--- a/chart/templates/etcd-statefulset.yaml
+++ b/chart/templates/etcd-statefulset.yaml
@@ -36,7 +36,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 15
+          initialDelaySeconds: 5
           periodSeconds: 5
         livenessProbe:
           exec:

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -160,11 +160,15 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 					continue
 				}
 
+				// set server's healthz endpoint status to OK so that
+				// etcd is marked as ready to serve traffic
+				handler.Status = http.StatusOK
+
 				if err = ssr.TakeFullSnapshotAndResetTimer(); err != nil {
 					logger.Errorf("Failed to take first snapshot: %v", err)
 					continue
 				}
-				handler.Status = http.StatusOK
+
 				ssr.SsrStateMutex.Lock()
 				ssr.SsrState = snapshotter.SnapshotterActive
 				ssr.SsrStateMutex.Unlock()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR optimizes readiness probe on etcd by marking the health endpoint as ready before taking the first full snapshot rather than after, as was being done previously. This reduces etcd downtime during cluster updates.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Reduced etcd downtime by optimizing readiness probe.
```
