### PR TITLE
Cherry pick etcd readiness probe optimization and alpine version update

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.7
+FROM alpine:3.9.3
 
 RUN apk add --update bash curl
 

--- a/chart/templates/etcd-statefulset.yaml
+++ b/chart/templates/etcd-statefulset.yaml
@@ -36,7 +36,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 15
+          initialDelaySeconds: 5
           periodSeconds: 5
         livenessProbe:
           exec:

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -160,11 +160,15 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 					continue
 				}
 
+				// set server's healthz endpoint status to OK so that
+				// etcd is marked as ready to serve traffic
+				handler.Status = http.StatusOK
+
 				if err = ssr.TakeFullSnapshotAndResetTimer(); err != nil {
 					logger.Errorf("Failed to take first snapshot: %v", err)
 					continue
 				}
-				handler.Status = http.StatusOK
+
 				ssr.SsrStateMutex.Lock()
 				ssr.SsrState = snapshotter.SnapshotterActive
 				ssr.SsrStateMutex.Unlock()


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This is a cherry-pick of https://github.com/gardener/etcd-backup-restore/pull/146 and https://github.com/gardener/etcd-backup-restore/pull/151

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Reduced etcd downtime by optimizing readiness probe.
```
```improvement operator
Updated the base image of alpine in docker container to 3.9.3.
```
