### PR TITLE
Defer first full snapshot on etcd startup

### DIFF
--- a/pkg/snapshot/snapshotter/types.go
+++ b/pkg/snapshot/snapshotter/types.go
@@ -53,6 +53,7 @@ type State int
 type Snapshotter struct {
 	logger             *logrus.Logger
 	prevSnapshot       *snapstore.Snapshot
+	PrevFullSnapshot   *snapstore.Snapshot
 	config             *Config
 	fullSnapshotCh     chan struct{}
 	fullSnapshotTimer  *time.Timer


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR defers the first full snapshot on etcd startup, by instead taking a delta snapshot initially and then taking a full snapshot. This helps speeding up setting the readiness probe of etcd to active. If no previous full snapshot exists in the backup or it has been more than 24 hours since the last full snapshot, a full snapshot will be taken on startup, followed by delta snapshots, as was the case earlier.

**Which issue(s) this PR fixes**:
Fixes #150 

**Special notes for your reviewer**:
~Snapshotter `Run()` has been modified with new `delaySeconds` parameter to allow setting deferred snapshot timers~. Also, for the moment, I have hard-coded `24 hours` for checking if previous snapshot is too old, because to make it generic it requires larger effort (to convert any given cron schedule into a uniform time interval). Do let me know if there is an easy/quick way to solve it, or else I can work on it in a separate PR later.
I have tested the PR to the best of my ability. I will also run memory profiling. Please run intensive memory and CPU profiling from your side as well. Thanks.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy user
Full snapshot on etcd startup will now be deferred in favour of an initial delta snapshot, followed by a full snapshot and subsequent delta snapshots.
```
