### PR TITLE
Fix stop-signal handling during initial delta snapshot

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -185,13 +185,15 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 					}
 				} else {
 					startWithFullSnapshot = true
-					if ssrStopped, err := ssr.CollectEventsSincePrevSnapshot(ssrStopCh); err != nil {
-						if ssrStopped {
-							logger.Infof("Snapshotter stopped.")
-							ackCh <- emptyStruct
-							handler.Status = http.StatusServiceUnavailable
-							return
-						}
+					ssrStopped, err := ssr.CollectEventsSincePrevSnapshot(ssrStopCh)
+					if ssrStopped {
+						logger.Info("Snapshotter stopped.")
+						ackCh <- emptyStruct
+						handler.Status = http.StatusServiceUnavailable
+						logger.Info("Shutting down...")
+						return
+					}
+					if err != nil {
 						if etcdErr, ok := err.(*errors.EtcdError); ok == true {
 							logger.Errorf("Failed to take first delta snapshot: snapshotter failed with etcd error: %v", etcdErr)
 						} else {


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR fixes stop-channel signal handling while taking the first delta snapshot for the `server` subcommand.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
