### PR TITLE
Fix error handling for initial delta snapshot

### DIFF
--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -81,7 +81,10 @@ func GetABSSnapstoreFromClient(container, prefix, tempDir string, maxParallelChu
 	_, err := containerURL.GetProperties(ctx, azblob.LeaseAccessConditions{})
 	if err != nil {
 		aer, ok := err.(azblob.StorageError)
-		if !ok || aer.ServiceCode() != azblob.ServiceCodeContainerNotFound {
+		if !ok {
+			return nil, fmt.Errorf("failed to get properties of container %v with err, %v", container, err.Error())
+		}
+		if aer.ServiceCode() != azblob.ServiceCodeContainerNotFound {
 			return nil, fmt.Errorf("failed to get properties of container %v with err, %v", container, aer.Error())
 		}
 		return nil, fmt.Errorf("container %s does not exist", container)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is cherry pick of https://github.com/gardener/etcd-backup-restore/pull/165 and https://github.com/gardener/etcd-backup-restore/pull/164
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement user
In the case that initial delta snapshot fails, a full snapshot is tried instead.
```
