### PR TITLE
[issue-169] Add etcd username and password command line options for c…

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -51,7 +51,7 @@ spec:
             - --cacert=/var/etcd/ssl/ca/ca.crt
             - --endpoints={{ if .Values.tls }}https{{ else }}http{{ end }}://{{ .Release.Name }}-etcd-0:{{ .Values.servicePorts.client }}
 {{- if and .Values.etcdAuth.username .Values.etcdAuth.password }}
-            - --user=.Values.etcdAuth.username:.Values.etcdAuth.password
+            - --user={{ .Values.etcdAuth.username }}:{{ .Values.etcdAuth.password }}
 {{- end }}            
             - get
             - foo
@@ -110,8 +110,8 @@ spec:
         - --delta-snapshot-period-seconds={{ int $.Values.backup.deltaSnapshotPeriodSeconds }}
         - --delta-snapshot-memory-limit={{ int $.Values.backup.deltaSnapshotMemoryLimit }}
 {{- if and .Values.etcdAuth.username .Values.etcdAuth.password }}
-        - --etcd-username=.Values.etcdAuth.username
-        - --etcd-password=.Values.etcdAuth.password
+        - --etcd-username={{ .Values.etcdAuth.username }}
+        - --etcd-password={{ .Values.etcdAuth.password }}
 {{- end }}           
         image: {{ .Values.images.etcdBackupRestore.repository }}:{{ .Values.images.etcdBackupRestore.tag }}
         imagePullPolicy: {{ .Values.images.etcdBackupRestore.pullPolicy }}

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -50,8 +50,8 @@ spec:
             - --key=/var/etcd/ssl/tls/tls.key
             - --cacert=/var/etcd/ssl/ca/ca.crt
             - --endpoints={{ if .Values.tls }}https{{ else }}http{{ end }}://{{ .Release.Name }}-etcd-0:{{ .Values.servicePorts.client }}
-{{- if .Values.etcdAuth.user }}
-            - --user=.Values.etcdAuth.user
+{{- if and .Values.etcdAuth.username .Values.etcdAuth.password }}
+            - --user=.Values.etcdAuth.username:.Values.etcdAuth.password
 {{- end }}            
             - get
             - foo
@@ -109,6 +109,10 @@ spec:
         - --etcd-connection-timeout={{ .Values.backup.etcdConnectionTimeout }}
         - --delta-snapshot-period-seconds={{ int $.Values.backup.deltaSnapshotPeriodSeconds }}
         - --delta-snapshot-memory-limit={{ int $.Values.backup.deltaSnapshotMemoryLimit }}
+{{- if and .Values.etcdAuth.username .Values.etcdAuth.password }}
+        - --etcd-username=.Values.etcdAuth.username
+        - --etcd-password=.Values.etcdAuth.password
+{{- end }}           
         image: {{ .Values.images.etcdBackupRestore.repository }}:{{ .Values.images.etcdBackupRestore.tag }}
         imagePullPolicy: {{ .Values.images.etcdBackupRestore.pullPolicy }}
         ports:

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -50,6 +50,9 @@ spec:
             - --key=/var/etcd/ssl/tls/tls.key
             - --cacert=/var/etcd/ssl/ca/ca.crt
             - --endpoints={{ if .Values.tls }}https{{ else }}http{{ end }}://{{ .Release.Name }}-etcd-0:{{ .Values.servicePorts.client }}
+{{- if .Values.etcdAuth.user }}
+            - --user=.Values.etcdAuth.user
+{{- end }}            
             - get
             - foo
           initialDelaySeconds: 15

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -31,6 +31,9 @@ servicePorts:
   server: 2380
   backupRestore: 8080
 
+etcdAuth:
+  # user: username:password
+
 backup:
 
   # schedule is cron standard schedule to take full snapshots.

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -31,8 +31,9 @@ servicePorts:
   server: 2380
   backupRestore: 8080
 
-etcdAuth:
-  # user: username:password
+etcdAuth: {}
+   #username: username
+   #password: password
 
 backup:
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -92,7 +92,9 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 				caFile,
 				insecureTransport,
 				insecureSkipVerify,
-				etcdEndpoints)
+				etcdEndpoints,
+				etcdUsername,
+				etcdPassword)
 
 			if snapshotterEnabled {
 				ss, err := snapstore.GetSnapstore(snapstoreConfig)

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -51,7 +51,9 @@ storing snapshots on various cloud storage providers as well as local disk locat
 				caFile,
 				insecureTransport,
 				insecureSkipVerify,
-				etcdEndpoints)
+				etcdEndpoints,
+				etcdUsername,
+				etcdPassword)
 			snapshotterConfig, err := snapshotter.NewSnapshotterConfig(
 				schedule,
 				ss,
@@ -105,5 +107,7 @@ func initializeSnapshotterFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&certFile, "cert", "", "identify secure client using this TLS certificate file")
 	cmd.Flags().StringVar(&keyFile, "key", "", "identify secure client using this TLS key file")
 	cmd.Flags().StringVar(&caFile, "cacert", "", "verify certificates of TLS-enabled secure servers using this CA bundle")
+	cmd.Flags().StringVar(&etcdUsername, "etcd-username", "", "etcd server username, if one is required")
+	cmd.Flags().StringVar(&etcdPassword, "etcd-password", "", "etcd server password, if one is required")
 	cmd.Flags().IntVar(&defragmentationPeriodHours, "defragmentation-period-hours", 72, "period after which we should defragment etcd data directory")
 }

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -31,6 +31,8 @@ var (
 	//snapshotter flags
 	schedule                       string
 	etcdEndpoints                  []string
+	etcdUsername                   string
+	etcdPassword                   string
 	deltaSnapshotIntervalSeconds   int
 	deltaSnapshotMemoryLimit       int
 	maxBackups                     int

--- a/pkg/etcdutil/defrag_test.go
+++ b/pkg/etcdutil/defrag_test.go
@@ -30,8 +30,10 @@ var _ = Describe("Defrag", func() {
 		etcdConnectionTimeout = time.Duration(30 * time.Second)
 		keyPrefix             = "/defrag/key-"
 		valuePrefix           = "val"
+		etcdUsername          string
+		etcdPassword          string
 	)
-	tlsConfig = NewTLSConfig("", "", "", true, true, endpoints)
+	tlsConfig = NewTLSConfig("", "", "", true, true, endpoints, etcdUsername, etcdPassword)
 	Context("Defragmentation", func() {
 		BeforeEach(func() {
 			now := time.Now().Unix()

--- a/pkg/etcdutil/etcdutil.go
+++ b/pkg/etcdutil/etcdutil.go
@@ -22,7 +22,7 @@ import (
 )
 
 // NewTLSConfig returns the TLSConfig object.
-func NewTLSConfig(cert, key, caCert string, insecureTr, skipVerify bool, endpoints []string) *TLSConfig {
+func NewTLSConfig(cert, key, caCert string, insecureTr, skipVerify bool, endpoints []string, username, password string) *TLSConfig {
 	return &TLSConfig{
 		cert:       cert,
 		key:        key,
@@ -30,6 +30,8 @@ func NewTLSConfig(cert, key, caCert string, insecureTr, skipVerify bool, endpoin
 		insecureTr: insecureTr,
 		skipVerify: skipVerify,
 		endpoints:  endpoints,
+		username:   username,
+		password:   password,
 	}
 }
 
@@ -76,6 +78,11 @@ func GetTLSClientForEtcd(tlsConfig *TLSConfig) (*clientv3.Client, error) {
 	// the InsecureSkipVerify flag in tls configuration.
 	if tlsConfig.skipVerify && cfg.TLS != nil {
 		cfg.TLS.InsecureSkipVerify = true
+	}
+
+	if tlsConfig.username != "" && tlsConfig.password != "" {
+		cfg.Username = tlsConfig.username
+		cfg.Password = tlsConfig.password
 	}
 
 	return clientv3.New(*cfg)

--- a/pkg/etcdutil/types.go
+++ b/pkg/etcdutil/types.go
@@ -28,4 +28,6 @@ type TLSConfig struct {
 	insecureTr bool
 	skipVerify bool
 	endpoints  []string
+	username   string
+	password   string
 }

--- a/pkg/initializer/validator/validator_suite_test.go
+++ b/pkg/initializer/validator/validator_suite_test.go
@@ -139,6 +139,8 @@ func runSnapshotter(logger *logrus.Logger, deltaSnapshotPeriod int, endpoints []
 		garbageCollectionPeriodSeconds = time.Duration(60)
 		schedule                       = "0 0 1 1 *"
 		garbageCollectionPolicy        = snapshotter.GarbageCollectionPolicyLimitBased
+		etcdUsername                   string
+		etcdPassword                   string
 	)
 
 	store, err = snapstore.GetSnapstore(&snapstore.Config{Container: snapstoreDir, Provider: "Local"})
@@ -153,6 +155,8 @@ func runSnapshotter(logger *logrus.Logger, deltaSnapshotPeriod int, endpoints []
 		insecureTransport,
 		insecureSkipVerify,
 		endpoints,
+		etcdUsername,
+		etcdPassword,
 	)
 
 	snapshotterConfig, err := snapshotter.NewSnapshotterConfig(

--- a/pkg/snapshot/restorer/restorer_suite_test.go
+++ b/pkg/snapshot/restorer/restorer_suite_test.go
@@ -137,6 +137,8 @@ func runSnapshotter(logger *logrus.Logger, deltaSnapshotPeriod int, endpoints []
 		garbageCollectionPeriodSeconds = time.Duration(60)
 		schedule                       = "0 0 1 1 *"
 		garbageCollectionPolicy        = snapshotter.GarbageCollectionPolicyLimitBased
+		etcdUsername                   string
+		etcdPassword                   string
 	)
 
 	store, err = snapstore.GetSnapstore(&snapstore.Config{Container: snapstoreDir, Provider: "Local"})
@@ -151,6 +153,8 @@ func runSnapshotter(logger *logrus.Logger, deltaSnapshotPeriod int, endpoints []
 		insecureTransport,
 		insecureSkipVerify,
 		endpoints,
+		etcdUsername,
+		etcdPassword,
 	)
 
 	snapshotterConfig, err := snapshotter.NewSnapshotterConfig(

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -43,6 +43,8 @@ var _ = Describe("Snapshotter", func() {
 		caFile                         string
 		insecureTransport              bool
 		insecureSkipVerify             bool
+		etcdUsername                   string
+		etcdPassword                    string
 		err                            error
 	)
 	BeforeEach(func() {
@@ -67,7 +69,9 @@ var _ = Describe("Snapshotter", func() {
 					caFile,
 					insecureTransport,
 					insecureSkipVerify,
-					endpoints)
+					endpoints,
+					etcdUsername,
+					etcdPassword)
 				_, err := NewSnapshotterConfig(
 					schedule,
 					store,
@@ -91,7 +95,9 @@ var _ = Describe("Snapshotter", func() {
 					caFile,
 					insecureTransport,
 					insecureSkipVerify,
-					endpoints)
+					endpoints,
+					etcdUsername,
+					etcdPassword)
 				_, err := NewSnapshotterConfig(
 					schedule,
 					store,
@@ -123,7 +129,9 @@ var _ = Describe("Snapshotter", func() {
 					caFile,
 					insecureTransport,
 					insecureSkipVerify,
-					endpoints)
+					endpoints,
+					etcdUsername,
+					etcdPassword)
 				snapshotterConfig, err := NewSnapshotterConfig(
 					schedule,
 					store,
@@ -173,7 +181,9 @@ var _ = Describe("Snapshotter", func() {
 						caFile,
 						insecureTransport,
 						insecureSkipVerify,
-						endpoints)
+						endpoints,
+						etcdUsername,
+						etcdPassword)
 					snapshotterConfig, err := NewSnapshotterConfig(
 						schedule,
 						store,
@@ -243,7 +253,9 @@ var _ = Describe("Snapshotter", func() {
 							caFile,
 							insecureTransport,
 							insecureSkipVerify,
-							endpoints)
+							endpoints,
+							etcdUsername,
+							etcdPassword)
 						snapshotterConfig, err := NewSnapshotterConfig(
 							schedule,
 							store,
@@ -286,7 +298,9 @@ var _ = Describe("Snapshotter", func() {
 							caFile,
 							insecureTransport,
 							insecureSkipVerify,
-							endpoints)
+							endpoints,
+							etcdUsername,
+							etcdPassword)
 						snapshotterConfig, err := NewSnapshotterConfig(
 							schedule,
 							store,
@@ -439,7 +453,9 @@ var _ = Describe("Snapshotter", func() {
 					caFile,
 					insecureTransport,
 					insecureSkipVerify,
-					endpoints)
+					endpoints,
+					etcdUsername,
+					etcdPassword)
 				snapshotterConfig, err := NewSnapshotterConfig(
 					schedule,
 					store,
@@ -483,7 +499,9 @@ var _ = Describe("Snapshotter", func() {
 					caFile,
 					insecureTransport,
 					insecureSkipVerify,
-					endpoints)
+					endpoints,
+					etcdUsername,
+					etcdPassword)
 				snapshotterConfig, err := NewSnapshotterConfig(
 					schedule,
 					store,


### PR DESCRIPTION
…lusters secured with username/password.

**What this PR does / why we need it**:

Adds username and password command line options to authenticate to the etcd cluster under backup.

**Which issue(s) this PR fixes**:
Fixes #

https://github.com/gardener/etcd-backup-restore/issues/169

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|
- target_group:   user|operator
-->
```noteworthy user
Added command-line options `etcd-username` and `etcd-password` to connect to etcd with username-password if necessary.

```
