### PR TITLE
Fix liveness probe command in helm chart

### DIFF
--- a/chart/etcd-backup-restore/templates/backup-client-service.yaml
+++ b/chart/etcd-backup-restore/templates/backup-client-service.yaml
@@ -16,5 +16,5 @@ spec:
   ports:
   - name: client
     protocol: TCP
-    port: 8080
-    targetPort: 8080
+    port: {{ .Values.servicePorts.backupRestore }}
+    targetPort: {{ .Values.servicePorts.backupRestore }}

--- a/chart/etcd-backup-restore/templates/etcd-bootstrap-configmap.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-bootstrap-configmap.yaml
@@ -35,11 +35,11 @@ data:
     check_and_start_etcd(){
           while true;
           do
-            wget http://localhost:8080/initialization/status -S -O status;
+            wget http://localhost:{{ .Values.servicePorts.backupRestore }}/initialization/status -S -O status;
             STATUS=`cat status`;
             case $STATUS in
             "New")
-                  wget http://localhost:8080/initialization/start?mode=$1 -S -O - ;;
+                  wget http://localhost:{{ .Values.servicePorts.backupRestore }}/initialization/start?mode=$1 -S -O - ;;
             "Progress")
                   sleep 1;
                   continue;;
@@ -88,11 +88,11 @@ data:
     {{- end }}
 
     # List of comma separated URLs to listen on for client traffic.
-    listen-client-urls: {{ if .Values.tls }}https{{ else }}http{{ end }}://0.0.0.0:2379
+    listen-client-urls: {{ if .Values.tls }}https{{ else }}http{{ end }}://0.0.0.0:{{ .Values.servicePorts.client }}
 
     # List of this member's client URLs to advertise to the public.
     # The URLs needed to be a comma-separated list.
-    advertise-client-urls: {{ if .Values.tls }}https{{ else }}http{{ end }}://0.0.0.0:2379
+    advertise-client-urls: {{ if .Values.tls }}https{{ else }}http{{ end }}://0.0.0.0:{{ .Values.servicePorts.client }}
 
     # Initial cluster token for the etcd cluster during bootstrap.
     initial-cluster-token: 'new'

--- a/chart/etcd-backup-restore/templates/etcd-client-service.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-client-service.yaml
@@ -16,5 +16,5 @@ spec:
   ports:
   - name: client
     protocol: TCP
-    port: 2379
-    targetPort: 2379
+    port: {{ .Values.servicePorts.client }}
+    targetPort: {{ .Values.servicePorts.client }}

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -46,7 +46,10 @@ spec:
             - -ec
             - ETCDCTL_API=3
             - etcdctl
-            - --config-file=/var/etcd/config/etcd.conf.yaml
+            - --cert=/var/etcd/ssl/tls/tls.crt
+            - --key=/var/etcd/ssl/tls/tls.key
+            - --cacert=/var/etcd/ssl/ca/ca.crt
+            - --endpoints={{ if .Values.tls }}https{{ else }}http{{ end }}://{{ .Release.Name }}-etcd-0:{{ .Values.servicePorts.client }}
             - get
             - foo
           initialDelaySeconds: 15

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -36,7 +36,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /healthz
-            port: 8080
+            port: {{ .Values.servicePorts.backupRestore }}
           initialDelaySeconds: 5
           periodSeconds: 5
         livenessProbe:
@@ -52,10 +52,10 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 5
         ports:
-        - containerPort: 2380
+        - containerPort: {{ .Values.servicePorts.server }}
           name: server
           protocol: TCP
-        - containerPort: 2379
+        - containerPort: {{ .Values.servicePorts.client }}
           name: client
           protocol: TCP
         resources:
@@ -94,11 +94,11 @@ spec:
         - --cacert=/var/etcd/ssl/ca/ca.crt
         - --insecure-transport=false
         - --insecure-skip-tls-verify=false
-        - --endpoints=https://{{ .Release.Name }}-etcd-0:2379
+        - --endpoints=https://{{ .Release.Name }}-etcd-0:{{ .Values.servicePorts.client }}
 {{ else }}
         - --insecure-transport=true
         - --insecure-skip-tls-verify=true
-        - --endpoints=http://{{ .Release.Name }}-etcd-0:2379
+        - --endpoints=http://{{ .Release.Name }}-etcd-0:{{ .Values.servicePorts.client }}
 {{- end }}
         - --etcd-connection-timeout={{ .Values.backup.etcdConnectionTimeout }}
         - --delta-snapshot-period-seconds={{ int $.Values.backup.deltaSnapshotPeriodSeconds }}
@@ -106,7 +106,7 @@ spec:
         image: {{ .Values.images.etcdBackupRestore.repository }}:{{ .Values.images.etcdBackupRestore.tag }}
         imagePullPolicy: {{ .Values.images.etcdBackupRestore.pullPolicy }}
         ports:
-        - containerPort: 8080
+        - containerPort: {{ .Values.servicePorts.backupRestore }}
           name: server
           protocol: TCP
         resources:

--- a/chart/etcd-backup-restore/templates/etcd-tls-secret.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-tls-secret.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ .Values.tls.caBundle | b64enc }}
   tls.crt: {{ .Values.tls.crt | b64enc }}
   tls.key: {{ .Values.tls.key | b64enc }}
 {{- end }}

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -26,6 +26,11 @@ resources:
       cpu: 100m
       memory: 128Mi
 
+servicePorts:
+  client: 2379
+  server: 2380
+  backupRestore: 8080
+
 backup:
 
   # schedule is cron standard schedule to take full snapshots.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the liveness probe command in the helm chart, which previously used to pass an illegal `--config-file` flag to the `etcdctl` command.
The PR also brings all port numbers in the helm chart into the `values.yaml` file.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Fixed liveness probe command in helm chart.
```
