### PR TITLE
Adapt pod requests based on VPA recommendations

### DIFF
--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -23,7 +23,7 @@ resources:
       cpu: 100m
       memory: 1Gi
     requests:
-      cpu: 100m
+      cpu: 23m
       memory: 128Mi
 
 servicePorts:


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to better utilize the Seed nodes, the pods of the Shoot control plane should only request the resources they really need.
Based on the evaluation of the VPA recommendations for all Shoots on our Canary and Live landscape over a few weeks, the new value reflects the maximum recommendation for the ETCD backup-restore container.
This maximum value also ensures that the ETCD pods aren't evicted from a node at normal scenarios because of exhausted node resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```NONE```
