### PR TITLE
Fix snapshotter behavior when starting it without full snapshot

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -241,7 +241,7 @@ func runEtcdProbeLoopWithSnapshotter(tlsConfig *etcdutil.TLSConfig, handler *ser
 				}
 				initialDeltaSnapshotTaken = true
 			} else {
-				logger.Warnf("Failed to collect events for first delta snapshot: %v", err)
+				logger.Warnf("Failed to collect events for first delta snapshot(s): %v", err)
 			}
 		}
 		if !initialDeltaSnapshotTaken {

--- a/pkg/snapstore/utils.go
+++ b/pkg/snapstore/utils.go
@@ -39,7 +39,7 @@ func GetSnapstore(config *Config) (SnapStore, error) {
 	}
 	if _, err := os.Stat(config.TempDir); err != nil {
 		if os.IsNotExist(err) {
-			logrus.Infof("Temporary directory %s does not exit. Creating it...", config.TempDir)
+			logrus.Infof("Temporary directory %s does not exist. Creating it...", config.TempDir)
 			if err := os.MkdirAll(config.TempDir, 0700); err != nil {
 				return nil, fmt.Errorf("failed to create temporary directory %s: %v", config.TempDir, err)
 			}


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR fixes snapshotter behavior for the case when starting snapshotter with `startWithFullSnapshot` set to false.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
