### PR TITLE
Initialize Prometheus metrics before exposing

### DIFF
--- a/pkg/metrics/metrics_suite_test.go
+++ b/pkg/metrics/metrics_suite_test.go
@@ -1,0 +1,13 @@
+package metrics
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics Suite")
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,76 @@
+package metrics
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Metrics", func() {
+	Describe("Testing helper functions for metrics initialization", func() {
+		Context("Testing wrapInSlice with input", func() {
+			It("should return expected output", func() {
+				input := []string{"a", "b", "c"}
+				expectedOutput := [][]string{{"a"}, {"b"}, {"c"}}
+				output := wrapInSlice(input)
+				Expect(output).Should(Equal(expectedOutput))
+			})
+		})
+		Context("Testing cartesianProduct with inputs", func() {
+			It("should return expected output", func() {
+				input1 := [][]string{{"p", "q"}, {"r", "s"}}
+				input2 := [][]string{{"1", "2"}, {"3", "4"}}
+				expectedOutput := [][]string{
+					{"p", "q", "1", "2"},
+					{"p", "q", "3", "4"},
+					{"r", "s", "1", "2"},
+					{"r", "s", "3", "4"},
+				}
+				output := cartesianProduct(input1, input2)
+				Expect(output).Should(Equal(expectedOutput))
+			})
+		})
+		Context("Testing generateLabelCombinations with input of one label", func() {
+			It("should return expected output", func() {
+				input := map[string][]string{
+					"a": {
+						"1",
+						"2",
+						"3",
+					},
+				}
+				expectedOutput := []map[string]string{
+					{"a": "1"},
+					{"a": "2"},
+					{"a": "3"},
+				}
+				output := generateLabelCombinations(input)
+				Expect(output).Should(Equal(expectedOutput))
+			})
+		})
+		Context("Testing generateLabelCombinations with input of two labels", func() {
+			It("should return expected output", func() {
+				input := map[string][]string{
+					"a": {
+						"1",
+						"2",
+						"3",
+					},
+					"b": {
+						"4",
+						"5",
+					},
+				}
+				expectedOutput := []map[string]string{
+					{"a": "1", "b": "4"},
+					{"a": "1", "b": "5"},
+					{"a": "2", "b": "4"},
+					{"a": "2", "b": "5"},
+					{"a": "3", "b": "4"},
+					{"a": "3", "b": "5"},
+				}
+				output := generateLabelCombinations(input)
+				Expect(output).Should(Equal(expectedOutput))
+			})
+		})
+	})
+})

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"path"
 	"sync"
 	"time"
@@ -78,7 +77,6 @@ func NewSnapshotter(logger *logrus.Logger, config *Config) *Snapshotter {
 	fullSnap, deltaSnapList, err := miscellaneous.GetLatestFullSnapshotAndDeltaSnapList(config.store)
 	if err != nil || fullSnap == nil {
 		prevSnapshot = snapstore.NewSnapshot(snapstore.SnapshotKindFull, 0, 0)
-		metrics.LatestSnapshotTimestamp.With(prometheus.Labels{metrics.LabelKind: prevSnapshot.Kind}).Set(math.NaN())
 	} else if len(deltaSnapList) == 0 {
 		prevSnapshot = fullSnap
 		metrics.LatestSnapshotTimestamp.With(prometheus.Labels{metrics.LabelKind: prevSnapshot.Kind}).Set(float64(prevSnapshot.CreatedOn.Unix()))


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR initializes all Prometheus metrics to their respective zero-values before exposing them.

**Which issue(s) this PR fixes**:
Fixes #167 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
