### PR TITLE
Add experimental fail below revision flag

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-bootstrap-configmap.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-bootstrap-configmap.yaml
@@ -35,11 +35,11 @@ data:
     check_and_start_etcd(){
           while true;
           do
-            wget http://localhost:{{ .Values.servicePorts.backupRestore }}/initialization/status -S -O status;
+            wget "http://localhost:{{ .Values.servicePorts.backupRestore }}/initialization/status" -S -O status;
             STATUS=`cat status`;
             case $STATUS in
             "New")
-                  wget http://localhost:{{ .Values.servicePorts.backupRestore }}/initialization/start?mode=$1 -S -O - ;;
+                  wget "http://localhost:{{ .Values.servicePorts.backupRestore }}/initialization/start?mode=$1{{- if .Values.backup.failBelowRevision }}&failbelowrevision={{ int $.Values.backup.failBelowRevision }}{{- end }}" -S -O - ;;
             "Progress")
                   sleep 1;
                   continue;;

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -7,7 +7,7 @@ images:
   # etcd-backup-restore image to use
   etcdBackupRestore:
     repository:  eu.gcr.io/gardener-project/gardener/etcdbrctl
-    tag:  0.6.4
+    tag:  0.7.0
     pullPolicy: IfNotPresent
 
 resources:
@@ -64,6 +64,10 @@ backup:
   # storageProvider indicate the type of backup storage provider.
   # Supported values are ABS,GCS,S3,Swift,OSS,Local, empty means no backup.
   storageProvider: "Local"
+
+  # failBelowRevision indicates the revision below which the validation of etcd will fail and restore will not be triggered in case
+  # there is no snapshot on configured backup bucket.
+  # failBelowRevision: 100000
 
   # Please uncomment the following section based on the storage provider.
   # s3:

--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -81,7 +81,7 @@ func NewInitializeCommand(stopCh <-chan struct{}) *cobra.Command {
 				}
 			}
 			etcdInitializer := initializer.NewInitializer(options, snapstoreConfig, logger)
-			err = etcdInitializer.Initialize(mode)
+			err = etcdInitializer.Initialize(mode, failBelowRevision)
 			if err != nil {
 				logger.Fatalf("initializer failed. %v", err)
 			}
@@ -90,6 +90,7 @@ func NewInitializeCommand(stopCh <-chan struct{}) *cobra.Command {
 	initializeEtcdFlags(initializeCmd)
 	initializeSnapstoreFlags(initializeCmd)
 	initializeValidatorFlags(initializeCmd)
+	initializeCmd.Flags().Int64Var(&failBelowRevision, "experimental-fail-below-revision", 0, "minimum required etcd revision, below which validation fails")
 	return initializeCmd
 }
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -156,12 +156,12 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 
 // startHTTPServer creates and starts the HTTP handler
 // with status 503 (Service Unavailable)
-func startHTTPServer(etcdInitializer *initializer.EtcdInitializer, ssr *snapshotter.Snapshotter) *server.HTTPHandler {
+func startHTTPServer(initializer initializer.Initializer, ssr *snapshotter.Snapshotter) *server.HTTPHandler {
 	// Start http handler with Error state and wait till snapshotter is up
 	// and running before setting the status to OK.
 	handler := &server.HTTPHandler{
 		Port:            port,
-		EtcdInitializer: *etcdInitializer,
+		Initializer:     initializer,
 		Snapshotter:     ssr,
 		Logger:          logger,
 		StopCh:          make(chan struct{}),

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -68,7 +68,8 @@ var (
 	snapstoreTempDir        string
 
 	//initializer flags
-	validationMode string
+	validationMode    string
+	failBelowRevision int64
 )
 
 var emptyStruct struct{}

--- a/pkg/initializer/types.go
+++ b/pkg/initializer/types.go
@@ -38,5 +38,5 @@ type EtcdInitializer struct {
 
 // Initializer is the interface for etcd initialization actions.
 type Initializer interface {
-	Initialize(validator.Mode) error
+	Initialize(validator.Mode, int64) error
 }

--- a/pkg/initializer/validator/types.go
+++ b/pkg/initializer/validator/types.go
@@ -35,6 +35,8 @@ const (
 	DataDirectoryError
 	// RevisionConsistencyError indicates current etcd revision is inconsistent with latest snapshot revision.
 	RevisionConsistencyError
+	//FailBelowRevisionConsistencyError indicates the current etcd revision is inconsistent with failBelowRevision.
+	FailBelowRevisionConsistencyError
 )
 
 const (
@@ -65,5 +67,5 @@ type DataValidator struct {
 
 // Validator is the interface for data validation actions.
 type Validator interface {
-	Validate(Mode) error
+	Validate(Mode, int64) error
 }

--- a/test/e2e/integration/cloud_backup_test.go
+++ b/test/e2e/integration/cloud_backup_test.go
@@ -216,7 +216,7 @@ var _ = Describe("CloudBackup", func() {
 						SnapstoreConfig: snapstoreConfig,
 					},
 				}
-				dataDirStatus, err := dataValidator.Validate(validator.Full)
+				dataDirStatus, err := dataValidator.Validate(validator.Full, 0)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(dataDirStatus).Should(Equal(validator.DataDirStatus(validator.DataDirectoryValid)))
 			})
@@ -248,7 +248,7 @@ var _ = Describe("CloudBackup", func() {
 						SnapstoreConfig: snapstoreConfig,
 					},
 				}
-				dataDirStatus, err := dataValidator.Validate(validator.Full)
+				dataDirStatus, err := dataValidator.Validate(validator.Full, 0)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(dataDirStatus).Should(SatisfyAny(Equal(validator.DataDirStatus(validator.DataDirectoryCorrupt)), Equal(validator.DataDirStatus(validator.RevisionConsistencyError))))
 			})


### PR DESCRIPTION
Main motivation behind this is to help external entity configure revision in case of bucket change or object store prefix change.

Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Added new flag `experimental-fail-below-revision` flag for initializer and `/initialization/start` http call
```
