### PR TITLE
[hotfix] Cleanup in-memory events before stopping snapshotter

### DIFF
--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -377,6 +377,7 @@ func (ssr *Snapshotter) CollectEventsSincePrevSnapshot(stopCh <-chan struct{}) (
 				return false, nil
 			}
 		case <-stopCh:
+			ssr.cleanupInMemoryEvents()
 			return true, nil
 		}
 	}
@@ -441,6 +442,7 @@ func (ssr *Snapshotter) snapshotEventHandler(stopCh <-chan struct{}) error {
 				return err
 			}
 		case <-stopCh:
+			ssr.cleanupInMemoryEvents()
 			return nil
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, in case etcd restarts and there are some events collected by backup restore sidecar in memory, on receiving stop signal via initialisation request due restart of etcd, the next delta snapshot taken post initialization will store duplicate entries in last delta snapshot. Which might lead to corrupt last delta snapshot. This PR fixed the issue by removing those duplicate events in memory.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR is cherry-pick of https://github.com/gardener/etcd-backup-restore/pull/190
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
[Fix] Cleanup in-memory events before stopping snapshotter.
```
