### PR TITLE
Add TLS support for backup-restore server

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Etcd-backup-restore is collection of components to backup and restore the [etcd]
 * [Getting started](doc/usage/getting_started.md)
 * [Manual restoration](doc/usage/manual_restoration.md)
 * [Monitoring](doc/usage/metrics.md)
+* [Generating SSL certificates](doc/usage/generating_ssl_certificates.md)
 
 ### Design and Proposals
 

--- a/chart/etcd-backup-restore/templates/etcd-bootstrap-configmap.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-bootstrap-configmap.yaml
@@ -13,6 +13,13 @@ data:
     #!/bin/sh
     VALIDATION_MARKER=/var/etcd/data/validation_marker
 
+{{- if .Values.backupRestoreTLS }}
+    # install wget from apk in order to pass --ca-certificate flag because
+    # busybox wget only has bare minimum features, without --ca-certificate option
+    apk update
+    apk add wget
+{{- end }}
+
     trap_and_propagate() {
         PID=$1
         shift
@@ -35,11 +42,11 @@ data:
     check_and_start_etcd(){
           while true;
           do
-            wget "http://localhost:{{ .Values.servicePorts.backupRestore }}/initialization/status" -S -O status;
+            wget {{ if .Values.backupRestoreTLS }}--ca-certificate=/var/etcdbr/ssl/ca/ca.crt "https{{ else }}"http{{ end }}://localhost:{{ .Values.servicePorts.backupRestore }}/initialization/status" -S -O status;
             STATUS=`cat status`;
             case $STATUS in
             "New")
-                  wget "http://localhost:{{ .Values.servicePorts.backupRestore }}/initialization/start?mode=$1{{- if .Values.backup.failBelowRevision }}&failbelowrevision={{ int $.Values.backup.failBelowRevision }}{{- end }}" -S -O - ;;
+                  wget {{ if .Values.backupRestoreTLS }}--ca-certificate=/var/etcdbr/ssl/ca/ca.crt "https{{ else }}"http{{ end }}://localhost:{{ .Values.servicePorts.backupRestore }}/initialization/start?mode=$1{{- if .Values.backup.failBelowRevision }}&failbelowrevision={{ int $.Values.backup.failBelowRevision }}{{- end }}" -S -O - ;;
             "Progress")
                   sleep 1;
                   continue;;
@@ -83,7 +90,7 @@ data:
     data-dir: /var/etcd/data/new.etcd
 
     # metrics configuration
-    metrics: {{ .Values.metrics }}
+    metrics: basic
 
     # Number of committed transactions to trigger a snapshot to disk.
     snapshot-count: 75000
@@ -95,11 +102,11 @@ data:
     {{- end }}
 
     # List of comma separated URLs to listen on for client traffic.
-    listen-client-urls: {{ if .Values.tls }}https{{ else }}http{{ end }}://0.0.0.0:{{ .Values.servicePorts.client }}
+    listen-client-urls: {{ if .Values.etcdTLS }}https{{ else }}http{{ end }}://0.0.0.0:{{ .Values.servicePorts.client }}
 
     # List of this member's client URLs to advertise to the public.
     # The URLs needed to be a comma-separated list.
-    advertise-client-urls: {{ if .Values.tls }}https{{ else }}http{{ end }}://0.0.0.0:{{ .Values.servicePorts.client }}
+    advertise-client-urls: {{ if .Values.etcdTLS }}https{{ else }}http{{ end }}://0.0.0.0:{{ .Values.servicePorts.client }}
 
     # Initial cluster token for the etcd cluster during bootstrap.
     initial-cluster-token: 'new'
@@ -107,7 +114,7 @@ data:
     # Initial cluster state ('new' or 'existing').
     initial-cluster-state: 'new'
 
-{{- if .Values.tls }}
+{{- if .Values.etcdTLS }}
     client-transport-security:
       # Path to the client server TLS cert file.
       cert-file: /var/etcd/ssl/tls/tls.crt

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -35,6 +35,9 @@ spec:
         - /var/etcd/bin/bootstrap.sh
         readinessProbe:
           httpGet:
+{{- if .Values.backupRestoreTLS }}
+            scheme: HTTPS
+{{- end }}
             path: /healthz
             port: {{ .Values.servicePorts.backupRestore }}
           initialDelaySeconds: 5
@@ -46,10 +49,12 @@ spec:
             - -ec
             - ETCDCTL_API=3
             - etcdctl
+{{ if .Values.etcdTLS }}
             - --cert=/var/etcd/ssl/tls/tls.crt
             - --key=/var/etcd/ssl/tls/tls.key
             - --cacert=/var/etcd/ssl/ca/ca.crt
-            - --endpoints={{ if .Values.tls }}https{{ else }}http{{ end }}://{{ .Release.Name }}-etcd-0:{{ .Values.servicePorts.client }}
+{{ end }}
+            - --endpoints={{ if .Values.etcdTLS }}https{{ else }}http{{ end }}://{{ .Release.Name }}-etcd-0:{{ .Values.servicePorts.client }}
 {{- if and .Values.etcdAuth.username .Values.etcdAuth.password }}
             - --user={{ .Values.etcdAuth.username }}:{{ .Values.etcdAuth.password }}
 {{- end }}
@@ -73,11 +78,15 @@ spec:
           mountPath: /var/etcd/bin/
         - name: etcd-config-file
           mountPath: /var/etcd/config/
-{{- if .Values.tls }}
+{{- if .Values.etcdTLS }}
         - name: ca-etcd
           mountPath: /var/etcd/ssl/ca
         - name: etcd-tls
           mountPath: /var/etcd/ssl/tls
+{{- end }}
+{{- if .Values.backupRestoreTLS }}
+        - name: ca-etcdbr
+          mountPath: /var/etcdbr/ssl/ca
 {{- end }}
       - name: backup-restore
         command:
@@ -94,7 +103,7 @@ spec:
 {{- if .Values.backup.etcdQuotaBytes }}
         - --embedded-etcd-quota-bytes={{ int $.Values.backup.etcdQuotaBytes }}
 {{- end }}
-{{- if .Values.tls }}
+{{- if .Values.etcdTLS }}
         - --cert=/var/etcd/ssl/tls/tls.crt
         - --key=/var/etcd/ssl/tls/tls.key
         - --cacert=/var/etcd/ssl/ca/ca.crt
@@ -115,6 +124,10 @@ spec:
 {{- if and .Values.etcdAuth.username .Values.etcdAuth.password }}
         - --etcd-username={{ .Values.etcdAuth.username }}
         - --etcd-password={{ .Values.etcdAuth.password }}
+{{- end }}
+{{- if .Values.backupRestoreTLS }}
+        - --server-cert=/var/etcdbr/ssl/tls/tls.crt
+        - --server-key=/var/etcdbr/ssl/tls/tls.key
 {{- end }}
         image: {{ .Values.images.etcdBackupRestore.repository }}:{{ .Values.images.etcdBackupRestore.tag }}
         imagePullPolicy: {{ .Values.images.etcdBackupRestore.pullPolicy }}
@@ -205,11 +218,17 @@ spec:
           mountPath: /var/etcd/data/
         - name: etcd-config-file
           mountPath: /var/etcd/config/
-{{- if .Values.tls }}
+{{- if .Values.etcdTLS }}
         - name: ca-etcd
           mountPath: /var/etcd/ssl/ca
         - name: etcd-tls
           mountPath: /var/etcd/ssl/tls
+{{- end }}
+{{- if .Values.backupRestoreTLS }}
+        - name: ca-etcdbr
+          mountPath: /var/etcdbr/ssl/ca
+        - name: etcdbr-tls
+          mountPath: /var/etcdbr/ssl/tls
 {{- end }}
 {{- if eq .Values.backup.storageProvider "GCS" }}
         - name: etcd-backup
@@ -230,13 +249,21 @@ spec:
           items:
           - key: etcd.conf.yaml
             path: etcd.conf.yaml
-{{- if .Values.tls }}
-      - name: etcd-tls
-        secret:
-          secretName: {{ .Release.Name }}-etcd-tls
+{{- if .Values.etcdTLS }}
       - name: ca-etcd
         secret:
           secretName: {{ .Release.Name }}-etcd-ca
+      - name: etcd-tls
+        secret:
+          secretName: {{ .Release.Name }}-etcd-tls
+{{- end }}
+{{- if .Values.backupRestoreTLS }}
+      - name: ca-etcdbr
+        secret:
+          secretName: {{ .Release.Name }}-etcdbr-ca
+      - name: etcdbr-tls
+        secret:
+          secretName: {{ .Release.Name }}-etcdbr-tls
 {{- end }}
 {{- if and .Values.backup.storageProvider (not (eq .Values.backup.storageProvider "Local")) }}
       - name: etcd-backup

--- a/chart/etcd-backup-restore/templates/etcd-tls-secret.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-tls-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tls }}
+{{- if .Values.etcdTLS }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ .Values.tls.crt | b64enc }}
-  tls.key: {{ .Values.tls.key | b64enc }}
+  tls.crt: {{ .Values.etcdTLS.crt | b64enc }}
+  tls.key: {{ .Values.etcdTLS.key | b64enc }}
 {{- end }}

--- a/chart/etcd-backup-restore/templates/etcdbr-ca-secret.yaml
+++ b/chart/etcd-backup-restore/templates/etcdbr-ca-secret.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.etcdTLS }}
+{{- if .Values.backupRestoreTLS }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-etcd-ca
+  name: {{ .Release.Name }}-etcdbr-ca
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: etcd
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 type: Opaque
 data:
-  ca.crt: {{ .Values.etcdTLS.caBundle | b64enc }}
+  ca.crt: {{ .Values.backupRestoreTLS.caBundle | b64enc }}
 {{- end }}

--- a/chart/etcd-backup-restore/templates/etcdbr-tls-secret.yaml
+++ b/chart/etcd-backup-restore/templates/etcdbr-tls-secret.yaml
@@ -1,14 +1,15 @@
-{{- if .Values.etcdTLS }}
+{{- if .Values.backupRestoreTLS }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-etcd-ca
+  name: {{ .Release.Name }}-etcdbr-tls
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: etcd
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-type: Opaque
+type: kubernetes.io/tls
 data:
-  ca.crt: {{ .Values.etcdTLS.caBundle | b64enc }}
+  tls.crt: {{ .Values.backupRestoreTLS.crt | b64enc }}
+  tls.key: {{ .Values.backupRestoreTLS.key | b64enc }}
 {{- end }}

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -2,12 +2,12 @@ images:
   # etcd image to use
   etcd:
     repository: quay.io/coreos/etcd
-    tag: v3.3.12
+    tag: v3.3.13
     pullPolicy: IfNotPresent
   # etcd-backup-restore image to use
   etcdBackupRestore:
     repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-    tag: 0.7.0
+    tag: 0.8.0
     pullPolicy: IfNotPresent
 
 resources:
@@ -31,12 +31,7 @@ servicePorts:
   server: 2380
   backupRestore: 8080
 
-etcdAuth: {}
-   #username: username
-   #password: password
-
 backup:
-
   # schedule is cron standard schedule to take full snapshots.
   schedule: "0 */1 * * *"
 
@@ -90,23 +85,42 @@ backup:
   #   accessKeySecret: secret-access-key-with-object-storage-privileges
   #   accessKeyID: access-key-id-with-object-storage-privileges
 
-metrics: basic
+# etcdAuth field contains the pre-created username-password pair
+# for etcd. Comment this whole section if you dont want to use
+# password-based authentication for the etcd.
+etcdAuth: {}
+  # username: username
+  # password: password
 
-# tls field contains the pre-created secrets for etcd. Uncomment the
-# whole tls section if you dont want to use tls for the etcd.
-tls: {}
-  # caBundle: |
-      #   -----BEGIN CERTIFICATE-----
-      #   ...
-      #   -----END CERTIFICATE-----
-  # crt: |
-      #     -----BEGIN CERTIFICATE-----
-      #     ...
-      #     -----END CERTIFICATE-----
-  # key: |
-      #     -----BEGIN RSA PRIVATE KEY-----
-      #     ...
-      #     -----END RSA PRIVATE KEY-----
+etcdTLS: {}
+#   caBundle: |
+#         -----BEGIN CERTIFICATE-----
+#         ...
+#         -----END CERTIFICATE-----
+#   crt: |
+#         -----BEGIN CERTIFICATE-----
+#         ...
+#         -----END CERTIFICATE-----
+#   key: |
+#         -----BEGIN RSA PRIVATE KEY-----
+#         ...
+#         -----END RSA PRIVATE KEY-----
 
-# podAnnotations will be placed to the resulting etcd pod
+# backupRestoreTLS field contains the pre-created secrets for backup-restore server.
+# Comment this whole section if you dont want to use tls for the backup-restore server.
+backupRestoreTLS: {}
+#   caBundle: |
+#         -----BEGIN CERTIFICATE-----
+#         ...
+#         -----END CERTIFICATE-----
+#   crt: |
+#         -----BEGIN CERTIFICATE-----
+#         ...
+#         -----END CERTIFICATE-----
+#   key: |
+#         -----BEGIN RSA PRIVATE KEY-----
+#         ...
+#         -----END RSA PRIVATE KEY-----
+
+# podAnnotations that will be passed to the resulting etcd pod
 podAnnotations: {}

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -49,8 +49,10 @@ var (
 	defragmentationSchedule  string
 
 	//server flags
-	port            int
-	enableProfiling bool
+	port              int
+	enableProfiling   bool
+	serverTLSCertFile string
+	serverTLSKeyFile  string
 
 	//restore flags
 	restoreCluster         string

--- a/doc/usage/generating_ssl_certificates.md
+++ b/doc/usage/generating_ssl_certificates.md
@@ -1,0 +1,160 @@
+# Generating certificates
+
+If you wish to enable TLS authentication for either etcd or etcdbr server or both, please follow this guide. The SSL certificate configurations given here are meant to facilitate smooth deployment of the etcd setup via the provided [helm chart](../../chart/etcd-backup-restore).
+
+## Certificates structure
+
+While deploying the etcd setup via the provided helm chart, TLS can be enabled for the etcd server and/or etcd-backup-restore server by adding the certificate data to the `values.yaml` file as necessary. This data is converted into the respective secrets and mounted onto the pod's containers according to the following directory structure:
+
+- `etcd` container
+
+```console
+/
+└── var
+    ├── etcd                      Contains the CA and server TLS certs for etcd server
+    |   └── ssl
+    |       ├── ca
+    |       |   └── ca.crt
+    |       └── tls
+    |           ├── tls.crt
+    |           └── tls.key
+    └── etcdbr                    Contains the CA and server TLS certs for etcd backup-restore server
+        └── ssl
+            ├── ca
+            |   └── ca.crt
+            └── tls
+                ├── tls.crt
+                └── tls.key
+```
+
+<br>
+
+- `backup-restore` container
+
+```console
+/
+└── var
+    ├── etcd                      Contains the CA and server certs for etcd server
+    |   └── ssl
+    |       ├── ca
+    |       |   └── ca.crt
+    |       └── tls
+    |           ├── tls.crt
+    |           └── tls.key
+    └── etcdbr                    Contains the CA cert for etcd backup-restore server
+        └── ssl
+            └── ca
+                └── ca.crt
+```
+
+## Generating the certificates
+
+### Installing openssl
+
+```console
+# For Mac users
+brew install openssl
+
+# For other flavours of Unix
+apk install openssl
+
+mkdir openssl && cd openssl
+```
+
+### Generating certs for etcd server authentication
+
+#### Generating CA cert bundle
+
+```console
+openssl genrsa -out ca.key 2048
+openssl req -new -key ca.key -subj "/CN=etcd" -out ca.csr
+
+cat > ca.csr.conf <<EOF
+[ v3_ext ]
+keyUsage=critical,digitalSignature,keyEncipherment,keyCertSign,cRLSign
+basicConstraints=critical,CA:TRUE
+EOF
+
+openssl x509 -req -in ca.csr -signkey ca.key -out ca.crt -sha256 -days 3653 -extensions v3_ext -extfile ca.csr.conf
+
+# view contents of the generated certificate
+openssl x509 -in ca.crt -noout -text
+```
+
+#### Generating TLS key-pair
+
+```console
+openssl genrsa -out server.key 2048
+
+# In the `alt_names` section of server.csr.conf, replace all occurrences of `mynamespace` with the namespace into which you'll deploy the helm chart
+cat > server.csr.conf <<EOF
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+
+[ dn ]
+CN = etcd-server
+
+[ req_ext ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = main-etcd-0
+DNS.2 = main-etcd-client
+DNS.3 = main-etcd-client.mynamespace
+DNS.4 = main-etcd-client.mynamespace.svc
+DNS.5 = main-etcd-client.mynamespace.svc.cluster.local
+
+[ v3_ext ]
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth,clientAuth
+basicConstraints=critical,CA:FALSE
+subjectAltName=@alt_names
+EOF
+
+openssl req -new -key server.key -out server.csr -config server.csr.conf
+
+openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -sha256 -days 3653 -extensions v3_ext -extfile server.csr.conf
+
+# view contents of the generated certificate
+openssl x509 -in server.crt -noout -text
+```
+
+### Generating certs for etcdbr server authentication
+
+Follow the same steps as [generating certs for etcd](#generating-certs-for-etcd-server-authentication), but replace all occurrences of `etcd` with `etcdbr` for the `CN` fields and replace `main-etcd-client` with `main-backup-client` in the DNS names if you want to access the TLS-enabled backup-restore server via service. You will also need to add `localhost` to the SAN DNS list if you're deploying the etcd setup via the provided helm chart. If deploying by any other means, or if testing locally, please tweak the config accordingly.
+
+#### Generating CA cert bundle
+
+Follow the same steps as [generating CA cert for etcd](#generating-CA-cert-bundle), but replace`CN=etcd` by `CN=etcdbr` while creating the `ca.csr`.
+
+#### Generating TLS key-pair
+
+Follow the same steps as [generating TLS key-pair for etcd](#generating-tls-key-pair), but modify the `[ dn ]` section in `server.csr.conf` from `CN = etcd` by `CN = etcdbr`. Also change the `[ alt_names ]` section to the following:
+
+```console
+[ alt_names ]
+DNS.1 = localhost
+DNS.2 = main-backup-0
+DNS.3 = main-backup-client
+DNS.4 = main-backup-client.mynamespace
+DNS.5 = main-backup-client.mynamespace.svc
+DNS.6 = main-backup-client.mynamespace.svc.cluster.local
+```
+
+Here, we add `localhost` to the DNS entries so that the etcd bootstrap script may be allowed to trigger data initialization on the backup sidecar via HTTPS.
+
+## Running `etcdbrctl server` with TLS enabled
+
+If you wish to develop/test `etcdbrctl` locally with TLS enabled, you can follow the steps to create the certs and pass them to the `etcdbrctl server` via the following flags.
+
+### For etcd TLS
+
+Pass the CA certificate file via `--cacert` flag, and etcd server TLS certificate and key via `--cert` and `--key` flags respectively.
+
+### For etcdbr TLS
+
+Pass the etcd backup-restore server TLS certificate and key via `--server-cert` and `--server-key` respectively.


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR introduces TLS support for the etcd-backup-restore server. TLS can be enabled via the new `--enable-tls` flag, which also requires the TLS cert and key files in PEM format to be passed via `--server-tls-cert` and `--server-tls-key` flags. This PR also introduces security headers `HTTP-Strict-Transport-Security` and `Content-Security-Policy` for the HTTP responses when TLS is enabled.

**Which issue(s) this PR fixes**:
Fixes #189 #187 

**Special notes for your reviewer**:
Renamed `tls` to `etcdTls` in helm values file, to differentiate between etcd tls config and etcdbr server tls config. Bootstrap script updated to use apk's wget instead of busybox wget in the case where backup-restore TLS is enabled.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```noteworthy developer
Added TLS support for backup-restore server. TLS can be enabled via `--enable-tls` flag, which also requires the TLS cert and key files in PEM format to be passed via `--server-tls-cert` and `--server-tls-key` flags.
```
