### PR TITLE
Expose etcdbr_snapshot_required metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Etcd-backup-restore is collection of components to backup and restore the [etcd]
 * [Monitoring](doc/usage/metrics.md)
 
 ### Design and Proposals
+
 * [Core design](doc/proposals/design.md)
-* [Etcd data validation ](doc/proposals/validation.md)
+* [Etcd data validation](doc/proposals/validation.md)
+* [Data restoration](doc/proposals/restoration.md)
 * [High watch events ingress rate issue](doc/proposals/high_watch_event_ingress_rate.md)
 
 ### Development
@@ -23,6 +25,5 @@ Etcd-backup-restore is collection of components to backup and restore the [etcd]
 * [Setting up a local development environment](doc/development/local_setup.md)
 * [Testing and Dependency Management](doc/development/testing_and_dependencies.md)
 * [Adding support for a new cloud provider](doc/development/new_cp_support.md)
-
 
 [etcd]: https://github.com/coreos/etcd

--- a/doc/usage/metrics.md
+++ b/doc/usage/metrics.md
@@ -8,10 +8,9 @@ Follow the [Prometheus getting started doc][prometheus-getting-started] to spin 
 
 The naming of metrics follows the suggested [Prometheus best practices][prometheus-naming]. All etcd-backup-restore related metrics are put under namespace `etcdbr`.
 
-### ETCD metrics
+## ETCD metrics
 
 The metrics under the `etcd` prefix/namespace are carried forward from etcd library that we use. These metrics do not include details of the `etcd` deployment on which `etcd-backup-restore` utility operates. Instead, it helps in monitoring the `embedded etcd` we spawn during restoration process.
-
 
 ### Snapshot
 
@@ -23,12 +22,15 @@ These metrics describe the status of the snapshotter. In order to detect outages
 | etcdbr_snapshot_gc_total | Total number of garbage collected snapshots. | Counter |
 | etcdbr_snapshot_latest_revision | Revision number of latest snapshot taken. | Gauge |
 | etcdbr_snapshot_latest_timestamp | Timestamp of latest snapshot taken. | Gauge |
+| etcdbr_snapshot_required | Indicates whether a new snapshot is required to be taken. | Gauge |
 
 Abnormally high snapshot duration (`etcdbr_snapshot_duration_seconds`) indicates disk issues and low network bandwidth.
 
 `etcdbr_snapshot_latest_timestamp` indicates the time when last snapshot was taken. If it has been a long time since a snapshot has been taken, then it indicates either the snapshots are being skipped because of no updates on etcd or :warning: something fishy is going on and a possible data loss might occur on the next restoration.
 
 `etcdbr_snapshot_gc_total` gives the total number of snapshots garbage collected since bootstrap. You can use this in coordination with `etcdbr_snapshot_duration_seconds_count` to get number of snapshots in object store.
+
+`etcdbr_snapshot_required` indicates whether a new snapshot is required to be taken. Acts as a boolean flag where zero value implies 'false' and non-zero values imply 'true'. :warning: This metric does not work as expected for the case where delta snapshots are disabled (by setting the etcdbrctl flag `delta-snapshot-period-seconds` to 0).
 
 ### Defragmentation
 
@@ -58,7 +60,6 @@ All these metrics are under subsystem `network`.
 |------|-------------|------|
 | etcdbr_network_transmitted_bytes | The total number of bytes received over network. | Counter |
 | etcdbr_network_received_bytes | The total number of bytes received over network. | Counter |
-
 
 `etcdbr_network_transmitted_bytes` counts the total number of bytes transmitted. Usually this reflects the data uploaded to object store as part of snapshot uploads.
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -70,13 +70,25 @@ var (
 		},
 		[]string{LabelKind},
 	)
-	// LatestSnapshotTimestamp is metric expose latest snapshot timestamp.
+
+	// LatestSnapshotTimestamp is metric to expose latest snapshot timestamp.
 	LatestSnapshotTimestamp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespaceEtcdBR,
 			Subsystem: subsystemSnapshot,
 			Name:      "latest_timestamp",
 			Help:      "Timestamp of latest snapshot taken.",
+		},
+		[]string{LabelKind},
+	)
+
+	// SnapshotRequired is metric to expose snapshot required flag.
+	SnapshotRequired = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespaceEtcdBR,
+			Subsystem: subsystemSnapshot,
+			Name:      "required",
+			Help:      "Indicates whether a snapshot is required to be taken.",
 		},
 		[]string{LabelKind},
 	)
@@ -91,6 +103,7 @@ var (
 		},
 		[]string{LabelKind, LabelSucceeded},
 	)
+
 	// ValidationDurationSeconds is metric to expose the duration required to validate the etcd data directory in seconds.
 	ValidationDurationSeconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -232,6 +245,15 @@ func init() {
 		LatestSnapshotTimestamp.With(prometheus.Labels(combination))
 	}
 
+	// SnapshotRequired
+	snapshotRequiredLabelValues := map[string][]string{
+		LabelKind: labels[LabelKind],
+	}
+	snapshotRequiredCombinations := generateLabelCombinations(snapshotRequiredLabelValues)
+	for _, combination := range snapshotRequiredCombinations {
+		SnapshotRequired.With(prometheus.Labels(combination))
+	}
+
 	// SnapshotDurationSeconds
 	snapshotDurationSecondsLabelValues := map[string][]string{
 		LabelKind:      labels[LabelKind],
@@ -274,6 +296,7 @@ func init() {
 
 	prometheus.MustRegister(LatestSnapshotRevision)
 	prometheus.MustRegister(LatestSnapshotTimestamp)
+	prometheus.MustRegister(SnapshotRequired)
 
 	prometheus.MustRegister(SnapshotDurationSeconds)
 	prometheus.MustRegister(RestorationDurationSeconds)

--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -379,7 +379,7 @@ func (r *Restorer) applyDeltaSnapshots(client *clientv3.Client, ro RestoreOption
 	if err == nil {
 		r.logger.Infof("Restoration complete.")
 	} else {
-		r.logger.Warnf("Restoration failed.")
+		r.logger.Errorf("Restoration failed.")
 	}
 
 	return err


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This is a cherry pick of https://github.com/gardener/etcd-backup-restore/pull/193

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement developer
Expose new metric `etcdbr_snapshot_required`.
```
