### PR TITLE
Fix the revision consitency check error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ Etcd-backup-restore is collection of components to backup and restore the [etcd]
 
 * [Setting up a local development environment](doc/development/local_setup.md)
 * [Testing and Dependency Management](doc/development/testing_and_dependencies.md)
-* [Adding support for a new cloud provider](doc/development/new_cp_support.md)
+* [Adding support for a new object store provider](doc/development/new_cp_support.md)
 
 [etcd]: https://github.com/coreos/etcd

--- a/doc/development/new_cp_support.md
+++ b/doc/development/new_cp_support.md
@@ -1,19 +1,19 @@
 # Adding support for a new object store provider
 
- Currently the code design allows only in-tree support for different providers. We have it on roadmap to change code design to allow out-of-tree support for different provider. For adding support for a new object store provider, follow the steps described below. Replace provider with your provider-name.
+ Currently the code design only allows in-tree support for different providers. Our roadmap includes the change to code design to allow out-of-tree support for different providers. For adding support for a new object store provider, follow the steps described below. Replace `provider` with your provider-name.
 
-1. Add a the provider identifier constant in `pkg/snapstore/types.go`.
+1. Add the provider identifier constant in `pkg/snapstore/types.go`.
 1. Add implementation for the `SnapStore` from `pkg/snapstore/types.go` interface  to `pkg/snapstore/provider_snapstore.go`.
-    - :warning: Please use environment variable to pass the credentials.
-    - Provider the factory method to create provider implementation object by loading required access credentials from environment variable.
+    - :warning: Please use environment variable(s) to pass the object store credentials.
+    - Provide the factory method to create provider implementation object by loading required access credentials from environment variable(s).
     - Avoid introducing new command line flags for provider.
 1. Import the required SDK and any other libraries for provider using `GO111MODULE=on go get <provider-sdk>`. This will update the dependency in [go.mod](../../go.mod) and [go.sum](../../go.sum).
 1. Run `make revendor` to download the dependency library to [vendor](../../vendor) directory.
 1. Update the [LICENSE.md](../../LICENSE.md) with license details of newly added dependencies.
 1. Update the `GetSnapstore` method in `pkg/snapstore/utils.go` to add a new case in switch block to support creation of the new provider implementation object.
 1. Add the fake implementation of provider SDK calls under `pkg/snapstore/provider_snapstore_test.go` for unit testing the provider implementation.
-1. Register the provider implementation object for testing under at appropriate place under `pkg/snapstore/snapstore_test.go`.This will run generic test against provider implementation.
-1. Update the [documentation](../../doc/usage/getting_started.md#cloud-provider-credentials) to provide info about passing provider credentials.
+1. Register the provider implementation object for testing at the appropriate place under `pkg/snapstore/snapstore_test.go`. This will run generic test against provider implementation.
+1. Update the [documentation](../usage/getting_started.md#cloud-provider-credentials) to provide info about passing provider credentials.
 1. Update the [helm chart](../../chart/etcd-backup-restore) with provider details.
     - Update the [values.yaml](../../chart/etcd-backup-restore/values.yaml) with configuration for provider.
 1. Refer [this commit](https://github.com/gardener/etcd-backup-restore/pull/108/commits/9bcd4e0e96f85ce1f356f08c06a2ced293aaf20b) to for one of the already added provider support.

--- a/doc/development/new_cp_support.md
+++ b/doc/development/new_cp_support.md
@@ -1,0 +1,20 @@
+# Adding support for a new object store provider
+
+ Currently the code design allows only in-tree support for different providers. We have it on roadmap to change code design to allow out-of-tree support for different provider. For adding support for a new object store provider, follow the steps described below. Replace provider with your provider-name.
+
+1. Add a the provider identifier constant in `pkg/snapstore/types.go`.
+1. Add implementation for the `SnapStore` from `pkg/snapstore/types.go` interface  to `pkg/snapstore/provider_snapstore.go`.
+    - :warning: Please use environment variable to pass the credentials.
+    - Provider the factory method to create provider implementation object by loading required access credentials from environment variable.
+    - Avoid introducing new command line flags for provider.
+1. Import the required SDK and any other libraries for provider using `GO111MODULE=on go get <provider-sdk>`. This will update the dependency in [go.mod](../../go.mod) and [go.sum](../../go.sum).
+1. Run `make revendor` to download the dependency library to [vendor](../../vendor) directory.
+1. Update the [LICENSE.md](../../LICENSE.md) with license details of newly added dependencies.
+1. Update the `GetSnapstore` method in `pkg/snapstore/utils.go` to add a new case in switch block to support creation of the new provider implementation object.
+1. Add the fake implementation of provider SDK calls under `pkg/snapstore/provider_snapstore_test.go` for unit testing the provider implementation.
+1. Register the provider implementation object for testing under at appropriate place under `pkg/snapstore/snapstore_test.go`.This will run generic test against provider implementation.
+1. Update the [documentation](../../doc/usage/getting_started.md#cloud-provider-credentials) to provide info about passing provider credentials.
+1. Update the [helm chart](../../chart/etcd-backup-restore) with provider details.
+    - Update the [values.yaml](../../chart/etcd-backup-restore/values.yaml) with configuration for provider.
+1. Refer [this commit](https://github.com/gardener/etcd-backup-restore/pull/108/commits/9bcd4e0e96f85ce1f356f08c06a2ced293aaf20b) to for one of the already added provider support.
+1. Finally test your code using `make verify`. And raise a PR for review. :smile:

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -45,7 +45,7 @@ const (
 func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int64) error {
 	start := time.Now()
 	dataDirStatus, err := e.Validator.Validate(mode, failBelowRevision)
-	if err != nil && dataDirStatus != validator.DataDirectoryNotExist {
+	if dataDirStatus == validator.DataDirectoryStatusUnknown {
 		metrics.ValidationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Now().Sub(start).Seconds())
 		return fmt.Errorf("error while initializing: %v", err)
 	}

--- a/pkg/initializer/validator/datavalidator_test.go
+++ b/pkg/initializer/validator/datavalidator_test.go
@@ -2,15 +2,16 @@ package validator_test
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path"
 
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 
 	. "github.com/gardener/etcd-backup-restore/pkg/initializer/validator"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Running Datavalidator", func() {
@@ -41,170 +42,244 @@ var _ = Describe("Running Datavalidator", func() {
 		}
 	})
 	Context("with missing data directory", func() {
-		It("should return DataDirStatus as DataDirectoryNotExist or DataDirectoryError, and non-nil error", func() {
+		It("should return DataDirStatus as DataDirectoryNotExist, and non-nil error", func() {
 			tempDir := fmt.Sprintf("%s.%s", restoreDataDir, "temp")
 			err = os.Rename(restoreDataDir, tempDir)
 			Expect(err).ShouldNot(HaveOccurred())
 			dataDirStatus, err := validator.Validate(Full, 0)
 			Expect(err).Should(HaveOccurred())
-			Expect(int(dataDirStatus)).Should(SatisfyAny(Equal(DataDirectoryNotExist), Equal(DataDirectoryError)))
+			Expect(int(dataDirStatus)).Should(Equal(DataDirectoryNotExist))
 			err = os.Rename(tempDir, restoreDataDir)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 
-	Context("with data directory present", func() {
-		Context("with incorrect data directory structure", func() {
-			Context("with missing member directory", func() {
-				It("should return DataDirStatus as DataDirectoryInvStruct or DataDirectoryError, and nil error", func() {
-					memberDir := path.Join(restoreDataDir, "member")
-					tempDir := fmt.Sprintf("%s.%s", memberDir, "temp")
-					err = os.Rename(memberDir, tempDir)
-					Expect(err).ShouldNot(HaveOccurred())
-					dataDirStatus, err := validator.Validate(Full, 0)
-					Expect(err).ShouldNot(HaveOccurred())
-					Expect(int(dataDirStatus)).Should(SatisfyAny(Equal(DataDirectoryInvStruct), Equal(DataDirectoryError)))
-					err = os.Rename(tempDir, memberDir)
-					Expect(err).ShouldNot(HaveOccurred())
-				})
-			})
-			Context("with member directory present", func() {
-				Context("with missing snap directory", func() {
-					It("should return DataDirStatus as DataDirectoryInvStruct or DataDirectoryError, and nil error", func() {
-						snapDir := path.Join(restoreDataDir, "member", "snap")
-						tempDir := fmt.Sprintf("%s.%s", snapDir, "temp")
-						err = os.Rename(snapDir, tempDir)
-						Expect(err).ShouldNot(HaveOccurred())
-						dataDirStatus, err := validator.Validate(Full, 0)
-						Expect(err).ShouldNot(HaveOccurred())
-						Expect(int(dataDirStatus)).Should(SatisfyAny(Equal(DataDirectoryInvStruct), Equal(DataDirectoryError)))
-						err = os.Rename(tempDir, snapDir)
-						Expect(err).ShouldNot(HaveOccurred())
-					})
-				})
-				Context("with missing wal directory", func() {
-					It("should return DataDirStatus as DataDirectoryInvStruct or DataDirectoryError, and nil error", func() {
-						walDir := path.Join(restoreDataDir, "member", "wal")
-						tempDir := fmt.Sprintf("%s.%s", walDir, "temp")
-						err = os.Rename(walDir, tempDir)
-						Expect(err).ShouldNot(HaveOccurred())
-						dataDirStatus, err := validator.Validate(Full, 0)
-						Expect(err).ShouldNot(HaveOccurred())
-						Expect(int(dataDirStatus)).Should(SatisfyAny(Equal(DataDirectoryInvStruct), Equal(DataDirectoryError)))
-						err = os.Rename(tempDir, walDir)
-						Expect(err).ShouldNot(HaveOccurred())
-					})
-				})
+	Context("with missing member directory", func() {
+		It("should return DataDirStatus as DataDirectoryInvStruct, and nil error", func() {
+			memberDir := path.Join(restoreDataDir, "member")
+			tempDir := fmt.Sprintf("%s.%s", memberDir, "temp")
+			err = os.Rename(memberDir, tempDir)
+			Expect(err).ShouldNot(HaveOccurred())
+			dataDirStatus, err := validator.Validate(Full, 0)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(int(dataDirStatus)).Should(Equal(DataDirectoryInvStruct))
+			err = os.Rename(tempDir, memberDir)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
 
-				Context("with empty wal directory and data validation in sanity mode", func() {
-					It("should return DataDirStatus as DataDirectoryValid, and nil error", func() {
-						walDir := path.Join(restoreDataDir, "member", "wal")
-						tempWalDir := fmt.Sprintf("%s.%s", walDir, "temp")
-						err = os.Rename(walDir, tempWalDir)
-						Expect(err).ShouldNot(HaveOccurred())
-						err = os.Mkdir(walDir, 0700)
-						Expect(err).ShouldNot(HaveOccurred())
-						dataDirStatus, err := validator.Validate(Sanity, 0)
-						Expect(err).ShouldNot(HaveOccurred())
-						Expect(int(dataDirStatus)).Should(Equal(DataDirectoryValid))
-						err = os.RemoveAll(walDir)
-						Expect(err).ShouldNot(HaveOccurred())
-						err = os.Rename(tempWalDir, walDir)
-						Expect(err).ShouldNot(HaveOccurred())
-					})
-				})
+	Context("with missing snap directory", func() {
+		It("should return DataDirStatus as DataDirectoryInvStruct , and nil error", func() {
+			snapDir := path.Join(restoreDataDir, "member", "snap")
+			tempDir := fmt.Sprintf("%s.%s", snapDir, "temp")
+			err = os.Rename(snapDir, tempDir)
+			Expect(err).ShouldNot(HaveOccurred())
+			dataDirStatus, err := validator.Validate(Full, 0)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(int(dataDirStatus)).Should(Equal(DataDirectoryInvStruct))
+			err = os.Rename(tempDir, snapDir)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("with missing wal directory", func() {
+		It("should return DataDirStatus as DataDirectoryInvStruct or DataDirectoryStatusUnknown, and nil error", func() {
+			walDir := path.Join(restoreDataDir, "member", "wal")
+			tempDir := fmt.Sprintf("%s.%s", walDir, "temp")
+			err = os.Rename(walDir, tempDir)
+			Expect(err).ShouldNot(HaveOccurred())
+			dataDirStatus, err := validator.Validate(Full, 0)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(int(dataDirStatus)).Should(SatisfyAny(Equal(DataDirectoryInvStruct), Equal(DataDirectoryStatusUnknown)))
+			err = os.Rename(tempDir, walDir)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("with empty wal directory and data validation in sanity mode", func() {
+		It("should return DataDirStatus as DataDirectoryValid, and nil error", func() {
+			walDir := path.Join(restoreDataDir, "member", "wal")
+			tempWalDir := fmt.Sprintf("%s.%s", walDir, "temp")
+			err = os.Rename(walDir, tempWalDir)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = os.Mkdir(walDir, 0700)
+			Expect(err).ShouldNot(HaveOccurred())
+			dataDirStatus, err := validator.Validate(Sanity, 0)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(int(dataDirStatus)).Should(Equal(DataDirectoryValid))
+			err = os.RemoveAll(walDir)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = os.Rename(tempWalDir, walDir)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("with corrupt db file", func() {
+		It("should return DataDirStatus as DataDirectoryCorrupt, and nil error", func() {
+			dbFile := path.Join(restoreDataDir, "member", "snap", "db")
+			_, err = os.Stat(dbFile)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			tempFile := path.Join(outputDir, "temp", "db")
+			err = copyFile(dbFile, tempFile)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			file, err := os.OpenFile(
+				dbFile,
+				os.O_WRONLY|os.O_TRUNC|os.O_CREATE,
+				0666,
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer file.Close()
+
+			// corrupt the db file by writing random data to it
+			byteSlice := []byte("Random data!\n")
+			_, err = file.Write(byteSlice)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			dataDirStatus, err := validator.Validate(Full, 0)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(int(dataDirStatus)).Should(Equal(DataDirectoryCorrupt))
+
+			err = os.Remove(dbFile)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			err = os.Rename(tempFile, dbFile)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("with combination of valid,corrupt,invalid name and empty snap file", func() {
+		It("should return DataDirStatus as DataDirectoryValid , and nil error", func() {
+			snapDir := path.Join(restoreDataDir, "member", "snap")
+			emptySnap := path.Join(snapDir, "empty.snap")
+			corruptSnap := path.Join(snapDir, "corrupt.snap")
+			withoutSnapSuffix := path.Join(snapDir, "corrupt")
+			Expect(err).ShouldNot(HaveOccurred())
+			file, err := os.Create(emptySnap)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer file.Close()
+			createCorruptSnap(corruptSnap)
+			createCorruptSnap(withoutSnapSuffix)
+			defer func() {
+				err = os.Remove(emptySnap + ".broken")
+				Expect(err).ShouldNot(HaveOccurred())
+				err = os.Remove(corruptSnap + ".broken")
+				Expect(err).ShouldNot(HaveOccurred())
+				err = os.Remove(withoutSnapSuffix)
+				Expect(err).ShouldNot(HaveOccurred())
+			}()
+
+			dataDirStatus, err := validator.Validate(Full, 0)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(int(dataDirStatus)).Should(Equal(DataDirectoryValid))
+
+		})
+	})
+
+	Context("with inconsistent revision numbers between etcd and latest snapshot", func() {
+		It("should return DataDirStatus as RevisionConsistencyError, and nil error", func() {
+			tempDir := fmt.Sprintf("%s.%s", restoreDataDir, "temp")
+			err = os.Rename(restoreDataDir, tempDir)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// start etcd
+			etcd, err = startEmbeddedEtcd(restoreDataDir, logger)
+			Expect(err).ShouldNot(HaveOccurred())
+			// populate etcd but with lesser data than previous populate call, so that the new db has a lower revision
+			newEtcdRevision, err := populateEtcdFinite(logger, endpoints, keyFrom, int(keyTo/2))
+			Expect(err).ShouldNot(HaveOccurred())
+
+			etcd.Server.Stop()
+			etcd.Close()
+
+			// etcdRevision: latest revision number on the snapstore (etcd backup)
+			// newEtcdRevision: current revision number on etcd db
+			Expect(etcdRevision).To(BeNumerically(">=", newEtcdRevision))
+			defer func() {
+				err = os.RemoveAll(restoreDataDir)
+				Expect(err).ShouldNot(HaveOccurred())
+				err = os.Rename(tempDir, restoreDataDir)
+				Expect(err).ShouldNot(HaveOccurred())
+			}()
+
+			dataDirStatus, err := validator.Validate(Full, 0)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(int(dataDirStatus)).Should(Equal(RevisionConsistencyError))
+		})
+	})
+
+	Context("with fail below revision configured to low value and no snapshots taken", func() {
+		It("should return DataDirStatus as DataDirectoryValid, and nil error", func() {
+			validator.Config.SnapstoreConfig.Container = path.Join(snapstoreBackupDir, "tmp")
+			dataDirStatus, err := validator.Validate(Full, 0)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(int(dataDirStatus)).Should(Equal(DataDirectoryValid))
+		})
+	})
+
+	Context("with fail below revision configured to high value", func() {
+		const failBelowRevision = math.MaxInt64
+		BeforeEach(func() {
+			validator.Config.SnapstoreConfig = snapstoreConfig
+		})
+
+		Context("with snapstore config provided and snapshot present", func() {
+			It("should return DataDirStatus as DataDirectoryValid and nil error", func() {
+				dataDirStatus, err := validator.Validate(Sanity, failBelowRevision)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(int(dataDirStatus)).Should(Equal(DataDirectoryValid))
 			})
 		})
-		Context("with correct data directory structure", func() {
-			Context("with inconsistent revision numbers between etcd and latest snapshot", func() {
-				It("should return DataDirStatus as RevisionConsistencyError or DataDirectoryError, and nil error", func() {
-					tempDir := fmt.Sprintf("%s.%s", restoreDataDir, "temp")
-					err = os.Rename(restoreDataDir, tempDir)
-					Expect(err).ShouldNot(HaveOccurred())
 
-					// start etcd
-					etcd, err = startEmbeddedEtcd(restoreDataDir, logger)
-					Expect(err).ShouldNot(HaveOccurred())
-					// populate etcd but with lesser data than previous populate call, so that the new db has a lower revision
-					newEtcdRevision, err := populateEtcdFinite(logger, endpoints, keyFrom, int(keyTo/2))
-					Expect(err).ShouldNot(HaveOccurred())
-
-					etcd.Server.Stop()
-					etcd.Close()
-
-					fmt.Printf("\nPrev etcd revision: %d\nNew etcd revision:  %d\n", etcdRevision, newEtcdRevision)
-
-					// etcdRevision: latest revision number on the snapstore (etcd backup)
-					// newEtcdRevision: current revision number on etcd db
-					Expect(etcdRevision).To(BeNumerically(">=", newEtcdRevision))
-
-					dataDirStatus, err := validator.Validate(Full, 0)
-					Expect(err).ShouldNot(HaveOccurred())
-					Expect(int(dataDirStatus)).Should(SatisfyAny(Equal(RevisionConsistencyError), Equal(DataDirectoryError)))
-
-					err = os.RemoveAll(restoreDataDir)
-					Expect(err).ShouldNot(HaveOccurred())
-
-					err = os.Rename(tempDir, restoreDataDir)
-					Expect(err).ShouldNot(HaveOccurred())
-				})
+		Context("with snapstore config provided but no snapshots present", func() {
+			It("should return DataDirStatus as FailBelowRevisionConsistencyError and nil error", func() {
+				validator.Config.SnapstoreConfig.Container = path.Join(snapstoreBackupDir, "tmp")
+				dataDirStatus, err := validator.Validate(Sanity, failBelowRevision)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(int(dataDirStatus)).Should(Equal(FailBelowRevisionConsistencyError))
 			})
-			Context("with consistent revision numbers between etcd and latest snapshot", func() {
-				Context("with corrupt data directory", func() {
-					Context("with corrupt db file", func() {
-						It("should return DataDirStatus as DataDirectoryCorrupt or DataDirectoryError or RevisionConsistencyError, and nil error", func() {
-							dbFile := path.Join(restoreDataDir, "member", "snap", "db")
-							_, err = os.Stat(dbFile)
-							Expect(err).ShouldNot(HaveOccurred())
+		})
 
-							tempFile := path.Join(outputDir, "temp", "db")
-							err = copyFile(dbFile, tempFile)
-							Expect(err).ShouldNot(HaveOccurred())
-
-							file, err := os.OpenFile(
-								dbFile,
-								os.O_WRONLY|os.O_TRUNC|os.O_CREATE,
-								0666,
-							)
-							Expect(err).ShouldNot(HaveOccurred())
-							defer file.Close()
-
-							// corrupt the db file by writing random data to it
-							byteSlice := []byte("Random data!\n")
-							_, err = file.Write(byteSlice)
-							Expect(err).ShouldNot(HaveOccurred())
-
-							dataDirStatus, err := validator.Validate(Full, 0)
-							Expect(err).ShouldNot(HaveOccurred())
-							Expect(int(dataDirStatus)).Should(SatisfyAny(Equal(DataDirectoryCorrupt), Equal(DataDirectoryError), Equal(RevisionConsistencyError)))
-
-							err = os.Remove(dbFile)
-							Expect(err).ShouldNot(HaveOccurred())
-
-							err = os.Rename(tempFile, dbFile)
-							Expect(err).ShouldNot(HaveOccurred())
-						})
-					})
-				})
-				Context("with clean data directory", func() {
-					Context("with fail below revision configured to low value", func() {
-						It("should return DataDirStatus as DataDirectoryValid, and nil error", func() {
-							dataDirStatus, err := validator.Validate(Full, 0)
-							Expect(err).ShouldNot(HaveOccurred())
-							Expect(int(dataDirStatus)).Should(Equal(DataDirectoryValid))
-						})
-					})
-
-					Context("with fail below revision configured to high value", func() {
-						It("should return DataDirStatus as FailBelowRevisionConsistencyError and nil error", func() {
-							validator.Config.SnapstoreConfig.Container = path.Join(snapstoreBackupDir, "tmp")
-							dataDirStatus, err := validator.Validate(Full, 1000000)
-							Expect(err).ShouldNot(HaveOccurred())
-							Expect(int(dataDirStatus)).Should(Equal(FailBelowRevisionConsistencyError))
-						})
-					})
-				})
+		Context("without providing snapstore config", func() {
+			It("should return DataDirStatus as DataDirectoryValid and nil error", func() {
+				validator.Config.SnapstoreConfig = nil
+				dataDirStatus, err := validator.Validate(Sanity, failBelowRevision)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(int(dataDirStatus)).Should(Equal(DataDirectoryValid))
 			})
 		})
 	})
+
+	Context("with failure on snapstore call", func() {
+		It("should return DataDirStatus as DataDirectoryStatusUnknown and error", func() {
+			//this is to fake the failure the snapstore call.
+			validator.Config.SnapstoreConfig.Provider = "unknown"
+			dataDirStatus, err := validator.Validate(Full, 0)
+			Expect(err).Should(HaveOccurred())
+			Expect(int(dataDirStatus)).Should(Equal(DataDirectoryStatusUnknown))
+		})
+	})
+
+	Context("with failure on snapstore call", func() {
+		It("should return DataDirStatus as DataDirectoryStatusUnknown and error", func() {
+			//this is to fake the failure the snapstore call.
+			validator.Config.SnapstoreConfig.Provider = snapstore.SnapstoreProviderFakeFailed
+			dataDirStatus, err := validator.Validate(Full, 0)
+			Expect(err).Should(HaveOccurred())
+			Expect(int(dataDirStatus)).Should(Equal(DataDirectoryStatusUnknown))
+		})
+	})
 })
+
+func createCorruptSnap(filePath string) {
+	file, err := os.Create(filePath)
+	Expect(err).ShouldNot(HaveOccurred())
+	defer file.Close()
+
+	// corrupt the snap file by writing random data to it
+	byteSlice := []byte("Random data!\n")
+	_, err = file.Write(byteSlice)
+	Expect(err).ShouldNot(HaveOccurred())
+}

--- a/pkg/initializer/validator/datavalidator_test.go
+++ b/pkg/initializer/validator/datavalidator_test.go
@@ -241,18 +241,25 @@ var _ = Describe("Running Datavalidator", func() {
 				Expect(int(dataDirStatus)).Should(Equal(FailBelowRevisionConsistencyError))
 			})
 		})
+	})
 
-		Context("without providing snapstore config", func() {
-			It("should return DataDirStatus as DataDirectoryValid and nil error", func() {
-				validator.Config.SnapstoreConfig = nil
-				dataDirStatus, err := validator.Validate(Sanity, failBelowRevision)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(int(dataDirStatus)).Should(Equal(DataDirectoryValid))
-			})
+	Context("without providing snapstore config", func() {
+		It("should return DataDirStatus as DataDirectoryValid and nil error for low failBelowRevision", func() {
+			validator.Config.SnapstoreConfig = nil
+			dataDirStatus, err := validator.Validate(Sanity, 0)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(int(dataDirStatus)).Should(Equal(DataDirectoryValid))
+		})
+
+		It("should return DataDirStatus as DataDirectoryValid and nil error for high failBelowRevision", func() {
+			validator.Config.SnapstoreConfig = nil
+			dataDirStatus, err := validator.Validate(Sanity, math.MaxInt64)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(int(dataDirStatus)).Should(Equal(DataDirectoryValid))
 		})
 	})
 
-	Context("with failure on snapstore call", func() {
+	Context("with failure on snapstore call due to unknown snapstore provider", func() {
 		It("should return DataDirStatus as DataDirectoryStatusUnknown and error", func() {
 			//this is to fake the failure the snapstore call.
 			validator.Config.SnapstoreConfig.Provider = "unknown"
@@ -262,7 +269,7 @@ var _ = Describe("Running Datavalidator", func() {
 		})
 	})
 
-	Context("with failure on snapstore call", func() {
+	Context("with failure on snapstore call due to fake failing snapstore provider", func() {
 		It("should return DataDirStatus as DataDirectoryStatusUnknown and error", func() {
 			//this is to fake the failure the snapstore call.
 			validator.Config.SnapstoreConfig.Provider = snapstore.SnapstoreProviderFakeFailed

--- a/pkg/initializer/validator/types.go
+++ b/pkg/initializer/validator/types.go
@@ -31,8 +31,8 @@ const (
 	DataDirectoryInvStruct
 	// DataDirectoryCorrupt indicates data directory is corrupt.
 	DataDirectoryCorrupt
-	// DataDirectoryError indicates unknown error while validation.
-	DataDirectoryError
+	// DataDirectoryStatusUnknown indicates validator failed to check the data directory status.
+	DataDirectoryStatusUnknown
 	// RevisionConsistencyError indicates current etcd revision is inconsistent with latest snapshot revision.
 	RevisionConsistencyError
 	//FailBelowRevisionConsistencyError indicates the current etcd revision is inconsistent with failBelowRevision.
@@ -49,7 +49,7 @@ type Mode string
 const (
 	// Full Mode does complete validation including the data directory contents for corruption.
 	Full Mode = "full"
-	// Sanity Mode validates only the data revision against the revision in the backup store.
+	// Sanity Mode validates data directory against time efficient checks.
 	Sanity Mode = "sanity"
 )
 

--- a/pkg/initializer/validator/types.go
+++ b/pkg/initializer/validator/types.go
@@ -49,7 +49,7 @@ type Mode string
 const (
 	// Full Mode does complete validation including the data directory contents for corruption.
 	Full Mode = "full"
-	// Sanity Mode validates data directory against time efficient checks.
+	// Sanity Mode does a quick, partial validation of data directory using time-efficient checks.
 	Sanity Mode = "sanity"
 )
 

--- a/pkg/snapstore/failed_snapstore.go
+++ b/pkg/snapstore/failed_snapstore.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapstore
+
+import (
+	"fmt"
+	"io"
+)
+
+// FailedSnapStore is snapstore with fake failed object store as backend
+type FailedSnapStore struct {
+	SnapStore
+}
+
+// NewFailedSnapStore create new FailedSnapStore object.
+func NewFailedSnapStore() *FailedSnapStore {
+	return &FailedSnapStore{}
+}
+
+// Fetch should open reader for the snapshot file from store
+func (f *FailedSnapStore) Fetch(snap Snapshot) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("failed to fetch snapshot %s", snap.SnapName)
+}
+
+// Save will write the snapshot to store
+func (f *FailedSnapStore) Save(snap Snapshot, rc io.ReadCloser) error {
+	return fmt.Errorf("failed to save snapshot %s", snap.SnapName)
+}
+
+// List will list the snapshots from store
+func (f *FailedSnapStore) List() (SnapList, error) {
+	var snapList SnapList
+	return snapList, fmt.Errorf("failed to list the snapshots")
+}
+
+// Delete should delete the snapshot file from store
+func (f *FailedSnapStore) Delete(snap Snapshot) error {
+	return fmt.Errorf("failed to delete snapshot %s", snap.SnapName)
+}

--- a/pkg/snapstore/types.go
+++ b/pkg/snapstore/types.go
@@ -49,6 +49,9 @@ const (
 	SnapstoreProviderSwift = "Swift"
 	// SnapstoreProviderOSS is constant for Alicloud OSS storage provider.
 	SnapstoreProviderOSS = "OSS"
+	// SnapstoreProviderFakeFailed is constant for fake failed storage provider.
+	SnapstoreProviderFakeFailed = "FAILED"
+
 	// SnapshotKindFull is constant for full snapshot kind.
 	SnapshotKindFull = "Full"
 	// SnapshotKindDelta is constant for delta snapshot kind.

--- a/pkg/snapstore/utils.go
+++ b/pkg/snapstore/utils.go
@@ -82,6 +82,8 @@ func GetSnapstore(config *Config) (SnapStore, error) {
 			return nil, fmt.Errorf("storage container name not specified")
 		}
 		return NewOSSSnapStore(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads)
+	case SnapstoreProviderFakeFailed:
+		return NewFailedSnapStore(), nil
 	default:
 		return nil, fmt.Errorf("unsupported storage provider : %s", config.Provider)
 


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
- Because of incorrect error handling at revision consistency check, the etcd-backup-restore used to fail the validation and trigger restore for valid data directory. This was noticed when network was down at validation time but available at restore time. This PR fixes the issue.
- Additionally uses etcd API for etcd snap directory validation. We don't have to maintain code here anymore.
- Improves the test coverage for validator package.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
Fix the error handling in revision consistency check leading to restoration on valid etcd data directory.
```
