### PR TITLE
Fix etcdbr_snapshot_required metric when skipping full snapshot

### DIFF
--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -273,11 +273,15 @@ func (ssr *Snapshotter) takeFullSnapshot() error {
 
 		metrics.LatestSnapshotRevision.With(prometheus.Labels{metrics.LabelKind: ssr.prevSnapshot.Kind}).Set(float64(ssr.prevSnapshot.LastRevision))
 		metrics.LatestSnapshotTimestamp.With(prometheus.Labels{metrics.LabelKind: ssr.prevSnapshot.Kind}).Set(float64(ssr.prevSnapshot.CreatedOn.Unix()))
-		metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: snapstore.SnapshotKindFull}).Set(0)
-		metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: snapstore.SnapshotKindDelta}).Set(0)
 
 		ssr.logger.Infof("Successfully saved full snapshot at: %s", path.Join(s.SnapDir, s.SnapName))
 	}
+	// setting `snapshotRequired` to 0 for both full and delta snapshot
+	// for the following cases:
+	// i.  Skipped full snapshot since no events were collected
+	// ii. Successfully took a full snapshot
+	metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: snapstore.SnapshotKindFull}).Set(0)
+	metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: snapstore.SnapshotKindDelta}).Set(0)
 
 	if ssr.config.deltaSnapshotInterval < time.Second {
 		// return without creating a watch on events


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR fixes an issue where `etcdbr_snapshot_required` metric was not getting reset to 0 for cases where full snapshot was skipped due to no events collected. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Saw this issue with a cluster that was woken up from hibernation and had no etcd events since previous hibernation, so both initial delta snapshot as well as subsequent full snapshot were skipped, but `etcdbr_snapshot_required` for full snapshot was still 1, due to which a false alert for `KubeEtcdFullBackupFailed` was fired.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
