### PR TITLE
Add snapstore bucket-related metrics

### DIFF
--- a/doc/usage/metrics.md
+++ b/doc/usage/metrics.md
@@ -50,6 +50,17 @@ Two major steps in initialization of etcd data directory are validation and rest
 | etcdbr_validation_duration_seconds | Total latency distribution of validating data directory. | Histogram |
 | etcdbr_restoration_duration_seconds | Total latency distribution of restoring from snapshot. | Histogram |
 
+### Snapstore
+
+These bucket-related metrics provide information about the latest set of delta snapshots stored in the snapstore. They provide a rough estimation of the amount of time required to perform a restoration from the latest set of snapshots.
+
+| Name | Description | Type |
+|------|-------------|------|
+| etcdbr_snapstore_latest_deltas_total | Total number of delta snapshots taken since the latest full snapshot. | Gauge |
+| etcdbr_snapstore_latest_deltas_revisions_total | Total number of revisions stored in delta snapshots taken since the latest full snapshot. | Gauge |
+
+`etcdbr_snapstore_latest_deltas_revisions_total` indicates the total number of etcd revisions (events) stored in the latest set of delta snapshots. The amount of time it would take to perform an etcd data restoration with the latest set of snapshots is directly proportional to this value.
+
 ### Network
 
 These metrics describe the status of the network usage. We use `/proc/<etcdbr-pid>/net/dev` to get network usage details for the etcdbr process. Currently these metrics are only supported on linux-based distributions.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -32,8 +32,9 @@ const (
 	// LabelKind is a metrics label indicates kind of snapshot associated with metric.
 	LabelKind = "kind"
 
-	namespaceEtcdBR   = "etcdbr"
-	subsystemSnapshot = "snapshot"
+	namespaceEtcdBR    = "etcdbr"
+	subsystemSnapshot  = "snapshot"
+	subsystemSnapstore = "snapstore"
 )
 
 var (
@@ -130,6 +131,27 @@ var (
 			Help:      "Total latency distribution of defragmentation of etcd.",
 		},
 		[]string{LabelSucceeded},
+	)
+
+	// SnapstoreLatestDeltasTotal is metric to expose total number of delta snapshots taken since the latest full snapshot.
+	SnapstoreLatestDeltasTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespaceEtcdBR,
+			Subsystem: subsystemSnapstore,
+			Name:      "latest_deltas_total",
+			Help:      "Total number of delta snapshots taken since the latest full snapshot.",
+		},
+		[]string{},
+	)
+	// SnapstoreLatestDeltasRevisionsTotal is metric to expose total number of revisions stored in delta snapshots taken since the latest full snapshot.
+	SnapstoreLatestDeltasRevisionsTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespaceEtcdBR,
+			Subsystem: subsystemSnapstore,
+			Name:      "latest_deltas_revisions_total",
+			Help:      "Total number of revisions stored in delta snapshots taken since the latest full snapshot.",
+		},
+		[]string{},
 	)
 )
 
@@ -291,6 +313,12 @@ func init() {
 		DefragmentationDurationSeconds.With(prometheus.Labels(combination))
 	}
 
+	// SnapstoreLatestDeltasTotal
+	SnapstoreLatestDeltasTotal.With(prometheus.Labels(map[string]string{}))
+
+	// SnapstoreLatestDeltasSize
+	SnapstoreLatestDeltasRevisionsTotal.With(prometheus.Labels(map[string]string{}))
+
 	// Metrics have to be registered to be exposed:
 	prometheus.MustRegister(GCSnapshotCounter)
 
@@ -302,4 +330,7 @@ func init() {
 	prometheus.MustRegister(RestorationDurationSeconds)
 	prometheus.MustRegister(ValidationDurationSeconds)
 	prometheus.MustRegister(DefragmentationDurationSeconds)
+
+	prometheus.MustRegister(SnapstoreLatestDeltasTotal)
+	prometheus.MustRegister(SnapstoreLatestDeltasRevisionsTotal)
 }

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -255,6 +255,8 @@ func (ssr *Snapshotter) takeFullSnapshot() (*snapstore.Snapshot, error) {
 
 		metrics.LatestSnapshotRevision.With(prometheus.Labels{metrics.LabelKind: ssr.prevSnapshot.Kind}).Set(float64(ssr.prevSnapshot.LastRevision))
 		metrics.LatestSnapshotTimestamp.With(prometheus.Labels{metrics.LabelKind: ssr.prevSnapshot.Kind}).Set(float64(ssr.prevSnapshot.CreatedOn.Unix()))
+		metrics.SnapstoreLatestDeltasTotal.With(prometheus.Labels{}).Set(0)
+		metrics.SnapstoreLatestDeltasRevisionsTotal.With(prometheus.Labels{}).Set(0)
 
 		ssr.logger.Infof("Successfully saved full snapshot at: %s", path.Join(s.SnapDir, s.SnapName))
 	}
@@ -340,6 +342,8 @@ func (ssr *Snapshotter) TakeDeltaSnapshot() (*snapstore.Snapshot, error) {
 	metrics.LatestSnapshotRevision.With(prometheus.Labels{metrics.LabelKind: ssr.prevSnapshot.Kind}).Set(float64(ssr.prevSnapshot.LastRevision))
 	metrics.LatestSnapshotTimestamp.With(prometheus.Labels{metrics.LabelKind: ssr.prevSnapshot.Kind}).Set(float64(ssr.prevSnapshot.CreatedOn.Unix()))
 	metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: snapstore.SnapshotKindDelta}).Set(0)
+	metrics.SnapstoreLatestDeltasTotal.With(prometheus.Labels{}).Inc()
+	metrics.SnapstoreLatestDeltasRevisionsTotal.With(prometheus.Labels{}).Add(float64(snap.LastRevision - snap.StartRevision))
 	ssr.logger.Infof("Successfully saved delta snapshot at: %s", path.Join(snap.SnapDir, snap.SnapName))
 	return snap, nil
 }


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR adds two new metrics `etcdbr_snapstore_latest_deltas_total` and `etcdbr_snapstore_latest_deltas_revisions_total`, which provide information about the delta snapshots since the latest full snapshot in the snapstore (object store bucket). We assume that etcd-backup-restore process is the only handler of snapshots in the respective snapstore bucket, in order to maintain integrity of these metrics.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Add metrics `etcdbr_snapstore_latest_deltas_total` and `etcdbr_snapstore_latest_deltas_revisions_total` to provide information about the delta snapshots since the latest full snapshot in the snapstore.
```
