### PR TITLE
Return metadata for latest and triggered snapshots

### DIFF
--- a/pkg/defragmentor/defrag.go
+++ b/pkg/defragmentor/defrag.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 	"github.com/gardener/etcd-backup-restore/pkg/metrics"
+	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
 	"github.com/prometheus/client_golang/prometheus"
 	cron "github.com/robfig/cron/v3"
 	"github.com/sirupsen/logrus"
@@ -30,7 +31,7 @@ const (
 )
 
 // CallbackFunc is type decalration for callback function for defragmentor
-type CallbackFunc func(ctx context.Context) error
+type CallbackFunc func(ctx context.Context) (*snapstore.Snapshot, error)
 
 // defragmentorJob implement the cron.Job for etcd defragmentation.
 type defragmentorJob struct {
@@ -55,7 +56,7 @@ func (d *defragmentorJob) Run() {
 		d.logger.Warnf("Failed to defrag data with error: %v", err)
 	} else {
 		if d.callback != nil {
-			if err = d.callback(d.ctx); err != nil {
+			if _, err = d.callback(d.ctx); err != nil {
 				d.logger.Warnf("defragmentation callback failed with error: %v", err)
 			}
 		}

--- a/pkg/defragmentor/defrag_test.go
+++ b/pkg/defragmentor/defrag_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
+	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
 
 	. "github.com/gardener/etcd-backup-restore/pkg/defragmentor"
 	. "github.com/onsi/ginkgo"
@@ -123,9 +124,9 @@ var _ = Describe("Defrag", func() {
 
 			defragThreadCtx, cancelDefragThread := context.WithTimeout(testCtx, time.Second*time.Duration(135))
 			defer cancelDefragThread()
-			DefragDataPeriodically(defragThreadCtx, etcdConnectionConfig, defragSchedule, func(_ context.Context) error {
+			DefragDataPeriodically(defragThreadCtx, etcdConnectionConfig, defragSchedule, func(_ context.Context) (*snapstore.Snapshot, error) {
 				defragCount++
-				return nil
+				return nil, nil
 			}, logger)
 
 			statusReqCtx, cancelStatusReq = context.WithTimeout(testCtx, etcdDialTimeout)

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -209,7 +209,7 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 				return
 			}
 			if err == nil {
-				if err := ssr.TakeDeltaSnapshot(); err != nil {
+				if _, err := ssr.TakeDeltaSnapshot(); err != nil {
 					b.logger.Warnf("Failed to take first delta snapshot: snapshotter failed with error: %v", err)
 					continue
 				}
@@ -222,7 +222,7 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 			// need to take a full snapshot here
 			metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: snapstore.SnapshotKindDelta}).Set(0)
 			metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: snapstore.SnapshotKindFull}).Set(1)
-			if err := ssr.TakeFullSnapshotAndResetTimer(); err != nil {
+			if _, err := ssr.TakeFullSnapshotAndResetTimer(); err != nil {
 				b.logger.Errorf("Failed to take substitute first full snapshot: %v", err)
 				continue
 			}

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -35,3 +35,9 @@ type BackupRestoreComponentConfig struct {
 	RestorationConfig       *restorer.RestorationConfig    `json:"restorationConfig,omitempty"`
 	DefragmentationSchedule string                         `json:"defragmentationSchedule"`
 }
+
+// latestSnapshotMetadata holds snapshot details of latest full and delta snapshots
+type latestSnapshotMetadataResponse struct {
+	FullSnapshot   *snapstore.Snapshot `json:"fullSnapshot"`
+	DeltaSnapshots snapstore.SnapList  `json:"deltaSnapshots"`
+}

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -72,8 +72,8 @@ func NewSnapshotter(logger *logrus.Entry, config *Config, store snapstore.SnapSt
 		SsrStateMutex:      &sync.Mutex{},
 		fullSnapshotReqCh:  make(chan struct{}),
 		deltaSnapshotReqCh: make(chan struct{}),
-		fullSnapshotAckCh:  make(chan error),
-		deltaSnapshotAckCh: make(chan error),
+		fullSnapshotAckCh:  make(chan result),
+		deltaSnapshotAckCh: make(chan result),
 		cancelWatch:        func() {},
 	}, nil
 }
@@ -115,33 +115,41 @@ func (ssr *Snapshotter) Run(stopCh <-chan struct{}, startWithFullSnapshot bool) 
 
 // TriggerFullSnapshot sends the events to take full snapshot. This is to
 // trigger full snapshot externally out of regular schedule.
-func (ssr *Snapshotter) TriggerFullSnapshot(ctx context.Context) error {
+func (ssr *Snapshotter) TriggerFullSnapshot(ctx context.Context) (*snapstore.Snapshot, error) {
 	ssr.SsrStateMutex.Lock()
 	defer ssr.SsrStateMutex.Unlock()
 
 	if ssr.SsrState != SnapshotterActive {
-		return fmt.Errorf("snapshotter is not active")
+		return nil, fmt.Errorf("snapshotter is not active")
 	}
 	ssr.logger.Info("Triggering out of schedule full snapshot...")
 	ssr.fullSnapshotReqCh <- emptyStruct
-	return <-ssr.fullSnapshotAckCh
+	res := <-ssr.fullSnapshotAckCh
+	if res.Err != nil {
+		return nil, res.Err
+	}
+	return res.Snapshot, nil
 }
 
 // TriggerDeltaSnapshot sends the events to take delta snapshot. This is to
 // trigger delta snapshot externally out of regular schedule.
-func (ssr *Snapshotter) TriggerDeltaSnapshot() error {
+func (ssr *Snapshotter) TriggerDeltaSnapshot() (*snapstore.Snapshot, error) {
 	ssr.SsrStateMutex.Lock()
 	defer ssr.SsrStateMutex.Unlock()
 
 	if ssr.SsrState != SnapshotterActive {
-		return fmt.Errorf("snapshotter is not active")
+		return nil, fmt.Errorf("snapshotter is not active")
 	}
 	if ssr.config.DeltaSnapshotPeriod.Duration < deltaSnapshotIntervalThreshold {
-		return fmt.Errorf("Found delta snapshot interval %s less than %v. Delta snapshotting is disabled. ", ssr.config.DeltaSnapshotPeriod.Duration, time.Duration(deltaSnapshotIntervalThreshold))
+		return nil, fmt.Errorf("Found delta snapshot interval %s less than %v. Delta snapshotting is disabled. ", ssr.config.DeltaSnapshotPeriod.Duration, time.Duration(deltaSnapshotIntervalThreshold))
 	}
 	ssr.logger.Info("Triggering out of schedule delta snapshot...")
 	ssr.deltaSnapshotReqCh <- emptyStruct
-	return <-ssr.deltaSnapshotAckCh
+	res := <-ssr.deltaSnapshotAckCh
+	if res.Err != nil {
+		return nil, res.Err
+	}
+	return res.Snapshot, nil
 }
 
 // stop stops the snapshotter. Once stopped any subsequent calls will
@@ -181,29 +189,30 @@ func (ssr *Snapshotter) closeEtcdClient() {
 
 // TakeFullSnapshotAndResetTimer takes a full snapshot and resets the full snapshot
 // timer as per the schedule.
-func (ssr *Snapshotter) TakeFullSnapshotAndResetTimer() error {
+func (ssr *Snapshotter) TakeFullSnapshotAndResetTimer() (*snapstore.Snapshot, error) {
 	ssr.logger.Infof("Taking scheduled snapshot for time: %s", time.Now().Local())
-	if err := ssr.takeFullSnapshot(); err != nil {
+	s, err := ssr.takeFullSnapshot()
+	if err != nil {
 		// As per design principle, in business critical service if backup is not working,
 		// it's better to fail the process. So, we are quiting here.
 		ssr.logger.Warnf("Taking scheduled snapshot failed: %v", err)
-		return err
+		return nil, err
 	}
 
-	return ssr.resetFullSnapshotTimer()
+	return s, ssr.resetFullSnapshotTimer()
 }
 
 // takeFullSnapshot will store full snapshot of etcd to snapstore.
 // It basically will connect to etcd. Then ask for snapshot. And finally
 // store it to underlying snapstore on the fly.
-func (ssr *Snapshotter) takeFullSnapshot() error {
+func (ssr *Snapshotter) takeFullSnapshot() (*snapstore.Snapshot, error) {
 	defer ssr.cleanupInMemoryEvents()
 	// close previous watch and client.
 	ssr.closeEtcdClient()
 
 	client, err := etcdutil.GetTLSClientForEtcd(ssr.etcdConnectionConfig)
 	if err != nil {
-		return &errors.EtcdError{
+		return nil, &errors.EtcdError{
 			Message: fmt.Sprintf("failed to create etcd client: %v", err),
 		}
 	}
@@ -215,7 +224,7 @@ func (ssr *Snapshotter) takeFullSnapshot() error {
 	resp, err := client.Get(ctx, "", clientv3.WithLastRev()...)
 	cancel()
 	if err != nil {
-		return &errors.EtcdError{
+		return nil, &errors.EtcdError{
 			Message: fmt.Sprintf("failed to get etcd latest revision: %v", err),
 		}
 	}
@@ -228,7 +237,7 @@ func (ssr *Snapshotter) takeFullSnapshot() error {
 		defer cancel()
 		rc, err := client.Snapshot(ctx)
 		if err != nil {
-			return &errors.EtcdError{
+			return nil, &errors.EtcdError{
 				Message: fmt.Sprintf("failed to create etcd snapshot: %v", err),
 			}
 		}
@@ -238,7 +247,7 @@ func (ssr *Snapshotter) takeFullSnapshot() error {
 		if err := ssr.store.Save(*s, rc); err != nil {
 			timeTaken := time.Now().Sub(startTime).Seconds()
 			metrics.SnapshotDurationSeconds.With(prometheus.Labels{metrics.LabelKind: snapstore.SnapshotKindFull, metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(timeTaken)
-			return &errors.SnapstoreError{
+			return nil, &errors.SnapstoreError{
 				Message: fmt.Sprintf("failed to save snapshot: %v", err),
 			}
 		}
@@ -261,7 +270,7 @@ func (ssr *Snapshotter) takeFullSnapshot() error {
 
 	if ssr.config.DeltaSnapshotPeriod.Duration < time.Second {
 		// return without creating a watch on events
-		return nil
+		return ssr.prevSnapshot, nil
 	}
 
 	watchCtx, cancelWatch := context.WithCancel(context.TODO())
@@ -270,7 +279,7 @@ func (ssr *Snapshotter) takeFullSnapshot() error {
 	ssr.watchCh = client.Watch(watchCtx, "", clientv3.WithPrefix(), clientv3.WithRev(ssr.prevSnapshot.LastRevision+1))
 	ssr.logger.Infof("Applied watch on etcd from revision: %d", ssr.prevSnapshot.LastRevision+1)
 
-	return nil
+	return ssr.prevSnapshot, nil
 }
 
 func (ssr *Snapshotter) cleanupInMemoryEvents() {
@@ -278,12 +287,13 @@ func (ssr *Snapshotter) cleanupInMemoryEvents() {
 	ssr.lastEventRevision = -1
 }
 
-func (ssr *Snapshotter) takeDeltaSnapshotAndResetTimer() error {
-	if err := ssr.TakeDeltaSnapshot(); err != nil {
+func (ssr *Snapshotter) takeDeltaSnapshotAndResetTimer() (*snapstore.Snapshot, error) {
+	s, err := ssr.TakeDeltaSnapshot()
+	if err != nil {
 		// As per design principle, in business critical service if backup is not working,
 		// it's better to fail the process. So, we are quiting here.
 		ssr.logger.Warnf("Taking delta snapshot failed: %v", err)
-		return err
+		return nil, err
 	}
 
 	if ssr.deltaSnapshotTimer == nil {
@@ -294,18 +304,18 @@ func (ssr *Snapshotter) takeDeltaSnapshotAndResetTimer() error {
 		ssr.logger.Infof("Resetting delta snapshot to run after %s.", ssr.config.DeltaSnapshotPeriod.Duration.String())
 		ssr.deltaSnapshotTimer.Reset(ssr.config.DeltaSnapshotPeriod.Duration)
 	}
-	return nil
+	return s, nil
 }
 
 // TakeDeltaSnapshot takes a delta snapshot that contains
 // the etcd events collected up till now
-func (ssr *Snapshotter) TakeDeltaSnapshot() error {
+func (ssr *Snapshotter) TakeDeltaSnapshot() (*snapstore.Snapshot, error) {
 	defer ssr.cleanupInMemoryEvents()
 	ssr.logger.Infof("Taking delta snapshot for time: %s", time.Now().Local())
 
 	if len(ssr.events) == 0 {
 		ssr.logger.Infof("No events received to save snapshot. Skipping delta snapshot.")
-		return nil
+		return nil, nil
 	}
 	ssr.events = append(ssr.events, byte(']'))
 
@@ -315,7 +325,7 @@ func (ssr *Snapshotter) TakeDeltaSnapshot() error {
 	// compute hash
 	hash := sha256.New()
 	if _, err := hash.Write(ssr.events); err != nil {
-		return fmt.Errorf("failed to compute hash of events: %v", err)
+		return nil, fmt.Errorf("failed to compute hash of events: %v", err)
 	}
 	ssr.events = hash.Sum(ssr.events)
 	startTime := time.Now()
@@ -323,7 +333,7 @@ func (ssr *Snapshotter) TakeDeltaSnapshot() error {
 		timeTaken := time.Now().Sub(startTime).Seconds()
 		metrics.SnapshotDurationSeconds.With(prometheus.Labels{metrics.LabelKind: snapstore.SnapshotKindDelta, metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(timeTaken)
 		ssr.logger.Errorf("Error saving delta snapshots. %v", err)
-		return err
+		return nil, err
 	}
 	timeTaken := time.Now().Sub(startTime).Seconds()
 	metrics.SnapshotDurationSeconds.With(prometheus.Labels{metrics.LabelKind: snapstore.SnapshotKindDelta, metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Observe(timeTaken)
@@ -333,7 +343,7 @@ func (ssr *Snapshotter) TakeDeltaSnapshot() error {
 	metrics.LatestSnapshotTimestamp.With(prometheus.Labels{metrics.LabelKind: ssr.prevSnapshot.Kind}).Set(float64(ssr.prevSnapshot.CreatedOn.Unix()))
 	metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: snapstore.SnapshotKindDelta}).Set(0)
 	ssr.logger.Infof("Successfully saved delta snapshot at: %s", path.Join(snap.SnapDir, snap.SnapName))
-	return nil
+	return snap, nil
 }
 
 // CollectEventsSincePrevSnapshot takes the first delta snapshot on etcd startup.
@@ -429,7 +439,8 @@ func (ssr *Snapshotter) handleDeltaWatchEvents(wr clientv3.WatchResponse) error 
 	ssr.logger.Debugf("Added events till revision: %d", ssr.lastEventRevision)
 	if len(ssr.events) >= int(ssr.config.DeltaSnapshotMemoryLimit) {
 		ssr.logger.Infof("Delta events memory crossed the memory limit: %d Bytes", len(ssr.events))
-		return ssr.takeDeltaSnapshotAndResetTimer()
+		_, err := ssr.takeDeltaSnapshotAndResetTimer()
+		return err
 	}
 	return nil
 }
@@ -445,27 +456,38 @@ func (ssr *Snapshotter) snapshotEventHandler(stopCh <-chan struct{}) error {
 	for {
 		select {
 		case <-ssr.fullSnapshotReqCh:
-			if err := ssr.TakeFullSnapshotAndResetTimer(); err != nil {
-				ssr.fullSnapshotAckCh <- err
+			s, err := ssr.TakeFullSnapshotAndResetTimer()
+			res := result{
+				Snapshot: s,
+				Err:      err,
+			}
+			if err != nil {
+				ssr.fullSnapshotAckCh <- res
 				return err
 			}
-			ssr.fullSnapshotAckCh <- nil
+			ssr.fullSnapshotAckCh <- res
 
 		case <-ssr.deltaSnapshotReqCh:
-			if err := ssr.takeDeltaSnapshotAndResetTimer(); err != nil {
-				ssr.deltaSnapshotAckCh <- err
+			s, err := ssr.takeDeltaSnapshotAndResetTimer()
+			res := result{
+				Snapshot: nil,
+				Err:      err,
+			}
+			if err != nil {
+				ssr.deltaSnapshotAckCh <- res
 				return err
 			}
-			ssr.deltaSnapshotAckCh <- nil
+			res.Snapshot = s
+			ssr.deltaSnapshotAckCh <- res
 
 		case <-ssr.fullSnapshotTimer.C:
-			if err := ssr.TakeFullSnapshotAndResetTimer(); err != nil {
+			if _, err := ssr.TakeFullSnapshotAndResetTimer(); err != nil {
 				return err
 			}
 
 		case <-ssr.deltaSnapshotTimer.C:
 			if ssr.config.DeltaSnapshotPeriod.Duration >= time.Second {
-				if err := ssr.takeDeltaSnapshotAndResetTimer(); err != nil {
+				if _, err := ssr.takeDeltaSnapshotAndResetTimer(); err != nil {
 					return err
 				}
 			}

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -235,7 +235,7 @@ var _ = Describe("Snapshotter", func() {
 						ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig)
 						Expect(err).ShouldNot(HaveOccurred())
 
-						err = ssr.TriggerDeltaSnapshot()
+						_, err = ssr.TriggerDeltaSnapshot()
 						Expect(err).Should(HaveOccurred())
 					})
 				})

--- a/pkg/snapshot/snapshotter/types.go
+++ b/pkg/snapshot/snapshotter/types.go
@@ -65,6 +65,7 @@ type Snapshotter struct {
 	schedule           cron.Schedule
 	prevSnapshot       *snapstore.Snapshot
 	PrevFullSnapshot   *snapstore.Snapshot
+	PrevDeltaSnapshots snapstore.SnapList
 	fullSnapshotReqCh  chan struct{}
 	deltaSnapshotReqCh chan struct{}
 	fullSnapshotAckCh  chan result

--- a/pkg/snapshot/snapshotter/types.go
+++ b/pkg/snapshot/snapshotter/types.go
@@ -67,8 +67,8 @@ type Snapshotter struct {
 	PrevFullSnapshot   *snapstore.Snapshot
 	fullSnapshotReqCh  chan struct{}
 	deltaSnapshotReqCh chan struct{}
-	fullSnapshotAckCh  chan error
-	deltaSnapshotAckCh chan error
+	fullSnapshotAckCh  chan result
+	deltaSnapshotAckCh chan result
 	fullSnapshotTimer  *time.Timer
 	deltaSnapshotTimer *time.Timer
 	events             []byte
@@ -94,4 +94,9 @@ type Config struct {
 type event struct {
 	EtcdEvent *clientv3.Event `json:"etcdEvent"`
 	Time      time.Time       `json:"time"`
+}
+
+type result struct {
+	Snapshot *snapstore.Snapshot `json:"snapshot"`
+	Err      error               `json:"error"`
 }

--- a/pkg/snapstore/types.go
+++ b/pkg/snapstore/types.go
@@ -77,13 +77,13 @@ const (
 
 // Snapshot structure represents the metadata of snapshot.s
 type Snapshot struct {
-	Kind          string //incr:incremental,full:full
-	StartRevision int64
-	LastRevision  int64 //latest revision on snapshot
-	CreatedOn     time.Time
-	SnapDir       string
-	SnapName      string
-	IsChunk       bool
+	Kind          string    `json:"kind"` //incr:incremental,full:full
+	StartRevision int64     `json:"startRevision"`
+	LastRevision  int64     `json:"lastRevision"` //latest revision on snapshot
+	CreatedOn     time.Time `json:"createdOn"`
+	SnapDir       string    `json:"snapDir"`
+	SnapName      string    `json:"snapName"`
+	IsChunk       bool      `json:"isChunk"`
 }
 
 // SnapList is list of snapshots.


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR enhances HTTP API to return snapshot metadata when triggering out-of-schedule full and delta snapshots. It also adds a new API at `/snapshot/latest` to fetch details of latest full and delta snapshots. The metadata is written in http response body in JSON format.

**Which issue(s) this PR fixes**:
Fixes #213 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
HTTP API for triggering out-of-schedule full and delta snapshots now returns snapshot metadata in response body in JSON format. 
```
```improvement user
Added new HTTP API for fetching details of latest full and delta snapshots, in JSON format. 
```
