### PR TITLE
Integrate with Test Machinery

### DIFF
--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -27,8 +27,10 @@ VCS="github.com"
 ORGANIZATION="gardener"
 PROJECT="etcd-backup-restore"
 REPOSITORY=${VCS}/${ORGANIZATION}/${PROJECT}
+URL=https://${REPOSITORY}.git
 VERSION_FILE="$(readlink -f "${SOURCE_PATH}/VERSION")"
 VERSION="$(cat "${VERSION_FILE}")"
+TEST_ID_PREFIX="etcdbr-test"
 
 export GOBIN="${SOURCE_PATH}/bin"
 export PATH="${GOBIN}:${PATH}"
@@ -39,6 +41,7 @@ cd "${SOURCE_PATH}"
 # Declare global variables
 TEST_ID=
 ETCD_VER=
+ETCDBR_VER=
 ETCD_DATA_DIR=
 TEST_DIR=
 TEST_RESULT=
@@ -96,7 +99,14 @@ function setup_awscli() {
 
 function get_test_id() {
   git_commit=`git show -s --format="%H"`
-  export TEST_ID=etcdbr-test-${git_commit}
+  export TEST_ID=${TEST_ID_PREFIX}-${git_commit}
+  echo "Test id: ${TEST_ID}"
+}
+
+function get_latest_commit_test_id() {
+  git_commit_remote=`echo \`git ls-remote $URL HEAD\` | cut -d' ' -f 1`
+  export ETCDBR_VER=${VERSION}-${git_commit_remote}
+  export TEST_ID=${TEST_ID_PREFIX}-${git_commit_remote}
   echo "Test id: ${TEST_ID}"
 }
 
@@ -109,6 +119,20 @@ function create_etcd_data_directory() {
 #        AWS Setup          #
 #############################
 
+function write_aws_secret() {
+  echo "Creating aws credentials for API access..."
+  mkdir ${HOME}/.aws
+  cat << EOF > ${HOME}/.aws/credentials
+[default]
+aws_access_key_id = $1
+aws_secret_access_key = $2
+EOF
+  cat << EOF > ${HOME}/.aws/config
+[default]
+region = $3
+EOF
+}
+
 function create_aws_secret() {
   echo "Fetching aws credentials from secret server..."
   export ACCESS_KEY_ID=`/cc/utils/cli.py config attribute --cfg-type aws --cfg-name etcd-backup-restore --key access_key_id`
@@ -116,18 +140,8 @@ function create_aws_secret() {
   export REGION=`/cc/utils/cli.py config attribute --cfg-type aws --cfg-name etcd-backup-restore --key region`
   echo "Successfully fetched aws credentials from secret server."
 
+  write_aws_secret "${ACCESS_KEY_ID}" "${SECRET_ACCESS_KEY}" "${REGION}"
 
-  echo "Creating aws credentials for API access..."
-  mkdir ${HOME}/.aws
-  cat << EOF > ${HOME}/.aws/credentials
-[default]
-aws_access_key_id = ${ACCESS_KEY_ID}
-aws_secret_access_key = ${SECRET_ACCESS_KEY}
-EOF
-cat << EOF > ${HOME}/.aws/config
-[default]
-region = $REGION
-EOF
   echo "Successfully created aws credentials."
 }
 
@@ -136,7 +150,13 @@ function delete_aws_secret() {
 }
 
 function create_s3_bucket() {
-    aws s3api create-bucket --bucket ${TEST_ID} --region ${REGION} --create-bucket-configuration LocationConstraint=${REGION}
+  echo "Creating S3 bucket ${TEST_ID} in region ${REGION}"
+  aws s3api create-bucket --bucket ${TEST_ID} --region ${REGION} --create-bucket-configuration LocationConstraint=${REGION}
+}
+
+function delete_s3_bucket() {
+  echo "Deleting S3 bucket ${TEST_ID}"
+  aws s3 rb s3://${TEST_ID} --force
 }
 
 function setup-aws-infrastructure() {
@@ -147,8 +167,10 @@ function setup-aws-infrastructure() {
 }
 
 function cleanup-aws-infrastructure() {
-  aws s3 rb s3://${TEST_ID} --force
+  echo "Cleaning up AWS infrastructure..."
+  delete_s3_bucket
   delete_aws_secret
+  echo "AWS infrastructure cleanup completed."
 }
 
 #############################
@@ -219,13 +241,13 @@ function run_test_on_cluster() {
     setup-aws-infrastructure
   fi
 
-  echo "Starting integration tests on k8s cluster."
-
-  if [ "$INTEGRATION_TEST_KUBECONFIG" == "" ]; then
-    INTEGRATION_TEST_KUBECONFIG=$TM_KUBECONFIG_PATH/shoot.config
-  fi
   export ETCD_VERSION=${ETCD_VERSION:-"v3.3.17"}
-  export ETCDBR_VERSION=${ETCDBR_VERSION:-"v0.9.1"}
+  echo "Etcd version: ${ETCD_VERSION}"
+
+  export ETCDBR_VERSION=${ETCDBR_VERSION:-${ETCDBR_VER:-"v0.9.1"}}
+  echo "Etcd-backup-restore version: ${ETCDBR_VERSION}"
+
+  echo "Starting integration tests on k8s cluster."
 
   set +e
 
@@ -248,10 +270,36 @@ function run_test_on_cluster() {
   fi
 }
 
-if [ "$1" == "cluster" ]; then
+function run_test_on_tm() {
+  if [ "$ACCESS_KEY_ID" == "" ] || [ "$SECRET_ACCESS_KEY" == "" ] || [ "$AWS_REGION" == "" ] ; then
+    echo "AWS S3 credentials unavailable. Exiting."
+    exit 1
+  fi
+  export REGION=$AWS_REGION
+
+  get_latest_commit_test_id
+  export STORAGE_CONTAINER=$TEST_ID
+  setup_awscli
+  write_aws_secret "${ACCESS_KEY_ID}" "${SECRET_ACCESS_KEY}" "${REGION}"
+  create_s3_bucket
+
+  INTEGRATION_TEST_KUBECONFIG=$TM_KUBECONFIG_PATH/shoot.config
+  echo "Starting integration tests on TM cluster $PROJECT_NAMESPACE/$SHOOT_NAME."
   run_test_on_cluster
-else
-  run_test_as_processes
-fi
+  echo "Done with integration test on TM cluster."
+  delete_s3_bucket
+}
+
+case $1 in
+  tm)
+    run_test_on_tm
+    ;;
+  cluster)
+    run_test_on_cluster
+    ;;
+  *)
+    run_test_as_processes
+    ;;
+esac
 
 exit $TEST_RESULT

--- a/.test-defs/IntegrationTest.yaml
+++ b/.test-defs/IntegrationTest.yaml
@@ -1,0 +1,15 @@
+kind: TestDefinition
+metadata:
+  name: etcdbr-integration-test
+spec:
+  owner: shreyas.sriganesh.rao@sap.com
+  description: Tests the deployment and functioning of etcd-backup-restore.
+
+  activeDeadlineSeconds: 1200
+  labels: ["playground"]
+
+  command: [bash, -c]
+  args:
+  - >-
+    .ci/integration_test tm
+  image: eu.gcr.io/gardener-project/cc/job-image-golang:0.11.0

--- a/go.sum
+++ b/go.sum
@@ -952,6 +952,9 @@ k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c h1:/KUFqjjqAcY4Us6luF5RDN
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/kubectl v0.18.0 h1:hu52Ndq/d099YW+3sS3VARxFz61Wheiq8K9S7oa82Dk=
 k8s.io/kubectl v0.18.0/go.mod h1:LOkWx9Z5DXMEg5KtOjHhRiC1fqJPLyCr3KtQgEolCkU=
+k8s.io/kubectl v0.18.5 h1:htctXnWqcF1VBkuzbWINqnwx/rM7byH9o2ZuHntlbJo=
+k8s.io/kubectl v0.18.6 h1:IFPNuLPkZ59vSGQzynXY8XGz9yuOSRpkJupnobdYvO4=
+k8s.io/kubelet v0.16.8/go.mod h1:mzDpnryQg2dlB6V3/WAgb1baIamiICtWpXMFrPOFh6I=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/metrics v0.18.0/go.mod h1:8aYTW18koXqjLVKL7Ds05RPMX9ipJZI3mywYvBOxXd4=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 h1:d4vVOjXm687F1iLSP2q3lyPPuyvTUt3aVoBpi2DqRsU=


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR adds support for running integration tests on [TestMachinery](https://github.com/gardener/test-infra) framework. The tests can be triggered from the TM Concourse dashboard, so that integration tests are run on a shoot cluster spawned by TestMachinery.

**Which issue(s) this PR fixes**:
Fixes #107 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Add TestMachinery integration.
```
