### PR TITLE
add Dell EMC ECS S3 snapstore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 *.so
 *.dylib
 
+# Temporary files
+*.swp
+
 # Test binary, build with `go test -c`
 *.test
 

--- a/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
@@ -29,5 +29,15 @@ data:
   endpoint: {{ .Values.backup.oss.endpoint | b64enc }}
   accessKeySecret: {{ .Values.backup.oss.accessKeySecret | b64enc }}
   accessKeyID: {{ .Values.backup.oss.accessKeyID | b64enc }}
+{{- else if eq .Values.backup.storageProvider "ECS" }}
+  endpoint: {{ .Values.backup.ecs.endpoint | b64enc }}
+  accessKeyID: {{ .Values.backup.ecs.accessKeyID | b64enc }}
+  secretAccessKey: {{ .Values.backup.ecs.secretAccessKey | b64enc  }}
+  {{- if .Values.backup.ecs.disableSsl }}
+  disableSsl: {{ .Values.backup.ecs.disableSsl | b64enc}}
+  {{- end }}
+  {{- if .Values.backup.ecs.insecureSkipVerify }}
+  insecureSkipVerify: {{ .Values.backup.ecs.insecureSkipVerify | b64enc }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -198,7 +198,7 @@ spec:
               name: {{ .Release.Name }}-etcd-backup
               key: "tenantName"
 {{- else if eq .Values.backup.storageProvider "OSS" }}
-        - name: ""ALICLOUD_ENDPOINT""
+        - name: "ALICLOUD_ENDPOINT"
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-etcd-backup
@@ -213,6 +213,36 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-etcd-backup
               key: "accessKeyID"
+{{- else if eq .Values.backup.storageProvider "ECS" }}
+        - name: "ECS_ENDPOINT"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-etcd-backup
+              key: "endpoint"
+        - name: "ECS_ACCESS_KEY_ID"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-etcd-backup
+              key: "accessKeyID"
+        - name: "ECS_SECRET_ACCESS_KEY"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-etcd-backup
+              key: "secretAccessKey"
+  {{- if .Values.backup.ecs.disableSsl }}
+        - name: "ECS_DISABLE_SSL"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-etcd-backup
+              key: "disableSsl"
+  {{- end }}
+  {{- if .Values.backup.ecs.insecureSkipVerify }}
+        - name: "ECS_INSECURE_SKIP_VERIFY"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-etcd-backup
+              key: "insecureSkipVerify"
+  {{- end }}
 {{- end }}
         volumeMounts:
         - name: {{ .Release.Name }}-etcd

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -60,7 +60,7 @@ backup:
   storageContainer: ""
 
   # storageProvider indicate the type of backup storage provider.
-  # Supported values are ABS,GCS,S3,Swift,OSS,Local, empty means no backup.
+  # Supported values are ABS,GCS,S3,Swift,OSS,ECS,Local, empty means no backup.
   storageProvider: "Local"
 
   # failBelowRevision indicates the revision below which the validation of etcd will fail and restore will not be triggered in case
@@ -87,6 +87,12 @@ backup:
   #   endpoint: oss-endpoint-url
   #   accessKeySecret: secret-access-key-with-object-storage-privileges
   #   accessKeyID: access-key-id-with-object-storage-privileges
+  # ecs:
+  #   endpoint: ecs-endpoint-url
+  #   secretAccessKey: secret-access-key-with-object-storage-privileges
+  #   accessKeyID: access-key-id-with-object-storage-privileges
+  #   disableSsl: "false"         # optional
+  #   insecureSkipVerify: "false" # optional
 
 # etcdAuth field contains the pre-created username-password pair
 # for etcd. Comment this whole section if you dont want to use

--- a/doc/usage/getting_started.md
+++ b/doc/usage/getting_started.md
@@ -20,6 +20,8 @@ The procedure to provide credentials to access the cloud provider object store v
 
 * For `Alicloud OSS`, `ALICLOUD_ENDPOINT`, `ALICLOUD_ACCESS_KEY_ID`, `ALICLOUD_ACCESS_KEY_SECRET` should be made available as environment variables.
 
+* For `Dell EMC ECS`, `ECS_ENDPOINT`, `ECS_ACCESS_KEY_ID`, `ECS_SECRET_ACCESS_KEY` should be made available as environment variables. For development purposes, the environment variables `ECS_DISABLE_SSL` and `ECS_INSECURE_SKIP_VERIFY` can also be set to "true" or "false".
+
 ### Taking scheduled snapshot
 
 Sub-command `snapshot` takes scheduled backups, or `snapshots` of a running `etcd` cluster, which are pushed to one of the storage providers specified above (please note that `etcd` should already be running). One can apply standard cron format scheduling for regular backup of etcd. The cron schedule is used to take full backups. The delta snapshots are taken at regular intervals in the period in between full snapshots as indicated by the `delta-snapshot-period` flag. The default for the same is 20 seconds.

--- a/pkg/snapstore/ecs_s3_snapstore.go
+++ b/pkg/snapstore/ecs_s3_snapstore.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapstore
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+const (
+	// ECS does not support regions and always returns the default region: US-Standard.
+	ecsDefaultRegion             string = "US-Standard"
+	ecsDefaultDisableSSL         bool   = false
+	ecsDefaultInsecureSkipVerify bool   = false
+
+	ecsEndPoint           string = "ECS_ENDPOINT"
+	ecsDisableSSL         string = "ECS_DISABLE_SSL"
+	ecsInsecureSkipVerify string = "ECS_INSECURE_SKIP_VERIFY"
+	ecsAccessKeyID        string = "ECS_ACCESS_KEY_ID"
+	ecsSecretAccessKey    string = "ECS_SECRET_ACCESS_KEY"
+)
+
+// A ecsAuthOptions groups all the required options to authenticate again ECS
+type ecsAuthOptions struct {
+	endpoint           string
+	region             string
+	disableSSL         bool
+	insecureSkipVerify bool
+	accessKeyID        string
+	secretAccessKey    string
+}
+
+// NewECSSnapStore create new S3SnapStore from shared configuration with specified bucket
+func NewECSSnapStore(bucket, prefix, tempDir string, maxParallelChunkUploads uint) (*S3SnapStore, error) {
+	ao, err := ecsAuthOptionsFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	return newECSFromAuthOpt(bucket, prefix, tempDir, maxParallelChunkUploads, ao)
+}
+
+// newECSFromAuthOpt will create the new S3 snapstore object from ECS S3 authentication options
+func newECSFromAuthOpt(bucket, prefix, tempDir string, maxParallelChunkUploads uint, ao ecsAuthOptions) (*S3SnapStore, error) {
+	httpClient := http.DefaultClient
+	if !ao.disableSSL {
+		httpClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: ao.insecureSkipVerify},
+		}
+	}
+
+	sess, err := session.NewSession(&aws.Config{
+		Credentials:      credentials.NewStaticCredentials(ao.accessKeyID, ao.secretAccessKey, ""),
+		Endpoint:         aws.String(ao.endpoint),
+		Region:           aws.String(ecsDefaultRegion),
+		DisableSSL:       aws.Bool(ao.disableSSL),
+		S3ForcePathStyle: aws.Bool(true),
+		HTTPClient:       httpClient,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("new ECS S3 session failed: %v", err)
+	}
+	cli := s3.New(sess)
+	return NewS3FromClient(bucket, prefix, tempDir, maxParallelChunkUploads, cli), nil
+}
+
+// ecsAuthOptionsFromEnv will get provider configuration from environment variables
+func ecsAuthOptionsFromEnv() (ecsAuthOptions, error) {
+	endpoint, err := GetEnvVarOrError(ecsEndPoint)
+	if err != nil {
+		return ecsAuthOptions{}, err
+	}
+	accessKeyID, err := GetEnvVarOrError(ecsAccessKeyID)
+	if err != nil {
+		return ecsAuthOptions{}, err
+	}
+	secretAccessKey, err := GetEnvVarOrError(ecsSecretAccessKey)
+	if err != nil {
+		return ecsAuthOptions{}, err
+	}
+	disableSSL, err := GetEnvVarToBool(ecsDisableSSL)
+	if err != nil {
+		disableSSL = ecsDefaultDisableSSL
+	}
+	insecureSkipVerify, err := GetEnvVarToBool(ecsInsecureSkipVerify)
+	if err != nil {
+		insecureSkipVerify = ecsDefaultInsecureSkipVerify
+	}
+
+	ao := ecsAuthOptions{
+		endpoint:           endpoint,
+		disableSSL:         disableSSL,
+		insecureSkipVerify: insecureSkipVerify,
+		accessKeyID:        accessKeyID,
+		secretAccessKey:    secretAccessKey,
+	}
+
+	return ao, nil
+}

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -94,6 +94,11 @@ var _ = Describe("Snapstore", func() {
 				multiPartUploads: map[string]*[][]byte{},
 				bucketName:       bucket,
 			}),
+			"ECS": NewS3FromClient(bucket, prefix, "/tmp", 5, &mockS3Client{
+				objects:          objectMap,
+				prefix:           prefix,
+				multiPartUploads: map[string]*[][]byte{},
+			}),
 		}
 	})
 

--- a/pkg/snapstore/types.go
+++ b/pkg/snapstore/types.go
@@ -20,7 +20,7 @@ import (
 )
 
 // SnapStore is the interface to be implemented for different
-// storage backend like local file system, S3, ABS, GCS, Swift, OSS etc.
+// storage backend like local file system, S3, ABS, GCS, Swift, OSS, ECS etc.
 // Only purpose of these implementation to provide CPI layer to
 // access files.
 type SnapStore interface {
@@ -49,6 +49,8 @@ const (
 	SnapstoreProviderSwift = "Swift"
 	// SnapstoreProviderOSS is constant for Alicloud OSS storage provider.
 	SnapstoreProviderOSS = "OSS"
+	// SnapstoreProviderECS is constant for Dell EMC ECS S3 storage provider.
+	SnapstoreProviderECS = "ECS"
 	// SnapstoreProviderFakeFailed is constant for fake failed storage provider.
 	SnapstoreProviderFakeFailed = "FAILED"
 


### PR DESCRIPTION
Signed-off-by: lcavajani <lcavajani@suse.com>

**What this PR does / why we need it**:

This PRs adds `Dell EMC ECS` Snapstore for `S3` protocol. 

It is fully compatible with AWS-SDK S3 so I have reused the existing S3 snapstore.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Add support for **Dell EMC ECS** object store with `S3` protocol
```
