### PR TITLE
Fixed the issue with consecutive restoration.

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -18,16 +18,22 @@ set -e
 # For the build step concourse will set the following environment variables:
 # SOURCE_PATH - path to component repository root directory.
 # BINARY_PATH - path to an existing (empty) directory to place build results into.
-if [[ -z "${SOURCE_PATH}" ]]; then
-  export SOURCE_PATH="$(readlink -f $(dirname ${0})/..)"
+if [[ $(uname) == 'Darwin' ]]; then
+  READLINK_BIN="greadlink"
 else
-  export SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
+  READLINK_BIN="readlink"
+fi
+
+if [[ -z "${SOURCE_PATH}" ]]; then
+  export SOURCE_PATH="$(${READLINK_BIN} -f $(dirname ${0})/..)"
+else
+  export SOURCE_PATH="$(${READLINK_BIN} -f "${SOURCE_PATH}")"
 fi
 
 if [[ -z "${BINARY_PATH}" ]]; then
   export BINARY_PATH="${SOURCE_PATH}/bin"
 else
-  export BINARY_PATH="$(readlink -f "${BINARY_PATH}")/bin"
+  export BINARY_PATH="$(${READLINK_BIN} -f "${BINARY_PATH}")/bin"
 fi
 
 VCS="github.com"
@@ -40,7 +46,7 @@ cd "${SOURCE_PATH}"
 
 ###############################################################################
 
-VERSION_FILE="$(readlink  -f "${SOURCE_PATH}/VERSION")"
+VERSION_FILE="$(${READLINK_BIN}  -f "${SOURCE_PATH}/VERSION")"
 VERSION="$(cat "${VERSION_FILE}")"
 GIT_SHA=$(git rev-parse --short HEAD || echo "GitNotFound")
 

--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -16,11 +16,16 @@ set -e
 
 # For the test step concourse will set the following environment variables:
 # SOURCE_PATH - path to component repository root directory.
+if [[ $(uname) == 'Darwin' ]]; then
+  READLINK_BIN="greadlink"
+else
+  READLINK_BIN="readlink"
+fi
 
 if [[ -z "${SOURCE_PATH}" ]]; then
-  export SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
+  export SOURCE_PATH="$(${READLINK_BIN} -f "$(dirname ${0})/..")"
 else
-  export SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
+  export SOURCE_PATH="$(${READLINK_BIN} -f "${SOURCE_PATH}")"
 fi
 
 VCS="github.com"
@@ -28,7 +33,7 @@ ORGANIZATION="gardener"
 PROJECT="etcd-backup-restore"
 REPOSITORY=${VCS}/${ORGANIZATION}/${PROJECT}
 URL=https://${REPOSITORY}.git
-VERSION_FILE="$(readlink -f "${SOURCE_PATH}/VERSION")"
+VERSION_FILE="$(${READLINK_BIN} -f "${SOURCE_PATH}/VERSION")"
 VERSION="$(cat "${VERSION_FILE}")"
 TEST_ID_PREFIX="etcdbr-test"
 TM_TEST_ID_PREFIX="etcdbr-tm-test"

--- a/.ci/unit_test
+++ b/.ci/unit_test
@@ -16,10 +16,16 @@ set -e
 
 # For the test step concourse will set the following environment variables:
 # SOURCE_PATH - path to component repository root directory.
-if [[ -z "${SOURCE_PATH}" ]]; then
-  export SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
+if [[ $(uname) == 'Darwin' ]]; then
+  READLINK_BIN="greadlink"
 else
-  export SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
+  READLINK_BIN="readlink"
+fi
+
+if [[ -z "${SOURCE_PATH}" ]]; then
+  export SOURCE_PATH="$(${READLINK_BIN} -f "$(dirname ${0})/..")"
+else
+  export SOURCE_PATH="$(${READLINK_BIN} -f "${SOURCE_PATH}")"
 fi
 
 VCS="github.com"

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -92,7 +92,8 @@ func NewInitializer(options *restorer.RestoreOptions, snapstoreConfig *snapstore
 // bootstrapping a new data directory or if restoration failed
 func (e *EtcdInitializer) restoreCorruptData() (bool, error) {
 	logger := e.Logger
-	dataDir := e.Config.RestoreOptions.Config.RestoreDataDir
+	tempRestoreOptions := *(e.Config.RestoreOptions.DeepCopy())
+	dataDir := tempRestoreOptions.Config.RestoreDataDir
 
 	if e.Config.SnapstoreConfig == nil || len(e.Config.SnapstoreConfig.Provider) == 0 {
 		logger.Warnf("No snapstore storage provider configured.")
@@ -116,9 +117,8 @@ func (e *EtcdInitializer) restoreCorruptData() (bool, error) {
 		return e.restoreWithEmptySnapstore()
 	}
 
-	e.Config.RestoreOptions.BaseSnapshot = *baseSnap
-	e.Config.RestoreOptions.DeltaSnapList = deltaSnapList
-	tempRestoreOptions := *e.Config.RestoreOptions
+	tempRestoreOptions.BaseSnapshot = *baseSnap
+	tempRestoreOptions.DeltaSnapList = deltaSnapList
 	tempRestoreOptions.Config.RestoreDataDir = fmt.Sprintf("%s.%s", tempRestoreOptions.Config.RestoreDataDir, "part")
 
 	if err := e.removeDir(tempRestoreOptions.Config.RestoreDataDir); err != nil {

--- a/pkg/snapshot/restorer/types_test.go
+++ b/pkg/snapshot/restorer/types_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restorer_test
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/coreos/etcd/pkg/types"
+	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
+	. "github.com/gardener/etcd-backup-restore/pkg/snapshot/restorer"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("restorer types", func() {
+	var (
+		makeRestorationConfig = func(s string, b bool, i int) *RestorationConfig {
+			return &RestorationConfig{
+				InitialCluster: s,
+				InitialClusterToken: s,
+				RestoreDataDir: s,
+				InitialAdvertisePeerURLs: []string{ s, s },
+				Name: s,
+				SkipHashCheck: b,
+				MaxFetchers: uint(i),
+				EmbeddedEtcdQuotaBytes: int64(i),
+			}
+		}
+		makeSnap = func(s string, i int, t time.Time, b bool) snapstore.Snapshot {
+			return snapstore.Snapshot{
+				Kind: s,
+				StartRevision: int64(i),
+				LastRevision: int64(i),
+				CreatedOn: t,
+				SnapDir: s,
+				SnapName: s,
+				IsChunk: b,
+			}
+		}
+		makeSnapList = func(s string, i int, t time.Time, b bool) snapstore.SnapList {
+			var s1, s2 = makeSnap(s, i, t, b), makeSnap(s, i, t, b)
+			return snapstore.SnapList{ &s1, &s2 }
+		}
+		makeURL = func(s string, b bool) url.URL {
+			return url.URL{
+				Scheme: s,
+				Opaque: s,
+				User: url.UserPassword(s, s),
+				Host: s,
+				Path: s,
+				RawPath: s,
+				ForceQuery: b,
+				Fragment: s,
+			}
+		}
+		makeURLs = func(s string, b bool) types.URLs {
+			return types.URLs{ makeURL(s, b), makeURL(s, b) }
+		}
+		makeURLsMap = func(s string, b bool) types.URLsMap {
+			var out = types.URLsMap{}
+			for _, v := range []int{1, 2} {
+				out[fmt.Sprintf("%s-%d", s, v)] = makeURLs(s, b)
+			}
+			return out
+		}
+		makeRestoreOptions = func(s string, i int, t time.Time, b bool) *RestoreOptions {
+			return &RestoreOptions{
+				Config: makeRestorationConfig(s, b, i),
+				ClusterURLs: makeURLsMap(s, b),
+				PeerURLs: makeURLs(s, b),
+				BaseSnapshot: makeSnap(s, i, t, b),
+				DeltaSnapList: makeSnapList(s, i, t, b),
+			}
+		}
+	)
+
+	Describe("RestorationConfig", func() {
+		var (
+			makeA = func() *RestorationConfig { return makeRestorationConfig("a", false, 1) }
+			makeB = func() *RestorationConfig { return makeRestorationConfig("b", true, 2) }
+		)
+		Describe("DeepCopyInto", func() {
+			It("new out", func() {
+				var a, in, out = makeA(), makeA(), new(RestorationConfig)
+				in.DeepCopyInto(out)
+				Expect(out).To(Equal(in))
+				Expect(out).ToNot(BeIdenticalTo(in))
+				Expect(in).To(Equal(a))
+				Expect(in).ToNot(BeIdenticalTo(a))
+			})
+			It("existing out", func() {
+				var a, in, b, out = makeA(), makeA(), makeB(), makeB()
+				in.DeepCopyInto(out)
+				Expect(out).To(Equal(in))
+				Expect(out).ToNot(BeIdenticalTo(in))
+				Expect(in).To(Equal(a))
+				Expect(in).ToNot(BeIdenticalTo(a))
+				Expect(out).ToNot(Equal(b))
+			})
+		})
+		Describe("DeepCopy", func() {
+			It("out", func() {
+				var a, in = makeA(), makeA()
+				var out = in.DeepCopy()
+				Expect(out).ToNot(BeNil())
+				Expect(out).To(Equal(in))
+				Expect(out).ToNot(BeIdenticalTo(in))
+				Expect(in).To(Equal(a))
+				Expect(in).ToNot(BeIdenticalTo(a))
+			})
+		})
+	})
+
+	Describe("SnapList", func() {
+		var (
+			now = time.Now()
+			makeA = func() snapstore.SnapList { return makeSnapList("a", 1, now, false) }
+		)
+		Describe("DeepCopySnapList", func() {
+			It("out", func() {
+				var a, in = makeA(), makeA()
+				var out = DeepCopySnapList(in)
+				Expect(out).ToNot(BeNil())
+				Expect(out).To(Equal(in))
+				Expect(out).ToNot(BeIdenticalTo(in))
+				Expect(in).To(Equal(a))
+				Expect(in).ToNot(BeIdenticalTo(a))
+			})
+		})
+	})
+
+	Describe("URL", func() {
+		var (
+			makeA = func() *url.URL { var u = makeURL("a", false); return &u }
+		)
+		Describe("DeepCopyURL", func() {
+			It("out", func() {
+				var a, in = makeA(), makeA()
+				var out = DeepCopyURL(in)
+				Expect(out).ToNot(BeNil())
+				Expect(out).To(Equal(in))
+				Expect(out).ToNot(BeIdenticalTo(in))
+				Expect(in).To(Equal(a))
+				Expect(in).ToNot(BeIdenticalTo(a))
+			})
+		})
+	})
+
+	Describe("URLs", func() {
+		var (
+			makeA = func() types.URLs { return makeURLs("a", false) }
+		)
+		Describe("DeepCopyURLs", func() {
+			It("out", func() {
+				var a, in = makeA(), makeA()
+				var out = DeepCopyURLs(in)
+				Expect(out).ToNot(BeNil())
+				Expect(out).To(Equal(in))
+				Expect(out).ToNot(BeIdenticalTo(in))
+				Expect(in).To(Equal(a))
+				Expect(in).ToNot(BeIdenticalTo(a))
+			})
+		})
+	})
+
+	Describe("RestoreOptions", func() {
+		var (
+			now = time.Now()
+			makeA = func() *RestoreOptions { return makeRestoreOptions("a", 1, now, false) }
+			makeB = func() *RestoreOptions { return makeRestoreOptions("b", 2, now.Add(-1*time.Hour), true) }
+		)
+		Describe("DeepCopyInto", func() {
+			It("new out", func() {
+				var a, in, out = makeA(), makeA(), new(RestoreOptions)
+				in.DeepCopyInto(out)
+				Expect(out).To(Equal(in))
+				Expect(out).ToNot(BeIdenticalTo(in))
+				Expect(in).To(Equal(a))
+				Expect(in).ToNot(BeIdenticalTo(a))
+			})
+			It("existing out", func() {
+				var a, in, b, out = makeA(), makeA(), makeB(), makeB()
+				in.DeepCopyInto(out)
+				Expect(out).To(Equal(in))
+				Expect(out).ToNot(BeIdenticalTo(in))
+				Expect(in).To(Equal(a))
+				Expect(in).ToNot(BeIdenticalTo(a))
+				Expect(out).ToNot(Equal(b))
+			})
+		})
+		Describe("DeepCopy", func() {
+			It("out", func() {
+				var a, in = makeA(), makeA()
+				var out = in.DeepCopy()
+				Expect(out).ToNot(BeNil())
+				Expect(out).To(Equal(in))
+				Expect(out).ToNot(BeIdenticalTo(in))
+				Expect(in).To(Equal(a))
+				Expect(in).ToNot(BeIdenticalTo(a))
+			})
+		})
+	})
+
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed the issue with consecutive restoration if backup-restore sidecar doesn't restart in between.

**Which issue(s) this PR fixes**:
The copy of the `e.Config.RestoreOptions` was a [shallow copy](https://github.com/gardener/etcd-backup-restore/blob/d4db4661562d91584ddfb12274b8a10c244b6082/pkg/initializer/initializer.go#L121) which means that the following [_temporary_ change](https://github.com/gardener/etcd-backup-restore/blob/d4db4661562d91584ddfb12274b8a10c244b6082/pkg/initializer/initializer.go#L122) to the restoration directory is actually a change to the original configuration and a bit more permanent than intended. I.e. a subsequent restoration (without an intervening backup-restore process restart) will use the _temporary_ folder as the final folder to restore to leading to the actual main etcd to potentially start on an empty data directory!

**Special notes for your reviewer**:
- I have [added](https://github.com/gardener/etcd-backup-restore/pull/259/files#diff-05a18b354b5313cd379e4239a7ccf765) and executed unit tests.
- I have [enhanced](https://github.com/gardener/etcd-backup-restore/pull/259/files#diff-6fd411f95db5f2b7f039b82f296b7ee0R354-R386) [integration](https://github.com/gardener/etcd-backup-restore/pull/259/files#diff-3486b0d3a2f6a6f58da0b782e6a7d2a1R274-R321) tests to try consecutive restorations. The tests also have succeeded. @shreyas-s-rao Thanks a lot for the automatic CICD pipeline integration for the tests 💯 ❤️

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixed the issue with consecutive restoration if backup-restore sidecar doesn't restart in between.
```
