### PR TITLE
Switch test flavor from coreos to gardenlinux

### DIFF
--- a/testmachinery/flavors/min-shoot-flavor.yaml
+++ b/testmachinery/flavors/min-shoot-flavor.yaml
@@ -13,7 +13,7 @@ flavors:
       machine:
         type: m5.large
         image:
-          name: coreos
+          name: gardenlinux
           version: latest
       minimum: 1
       maximum: 2
@@ -44,7 +44,7 @@ flavors:
 #       machine:
 #         type: Standard_D2_v3
 #         image:
-#           name: coreos
+#           name: gardenlinux
 #           version: latest
 #       minimum: 2
 #       maximum: 2
@@ -95,7 +95,7 @@ flavors:
 #       machine:
 #         type: medium_2_4
 #         image:
-#           name: coreos
+#           name: gardenlinux
 #           version: latest
 #       minimum: 2
 #       maximum: 2


### PR DESCRIPTION
**What this PR does / why we need it**:
I saw a coreos Shoot being created from this test flavor.
Starting from September 22, 2020, coreos AMIs are no longer available - ref https://stable.release.core-os.net/index.html.

/kind cleanup

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
