### PR TITLE
Enabled check script to run on mac and for normal user.

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -16,11 +16,16 @@ set -e
 
 # For the check step concourse will set the following environment variables:
 # SOURCE_PATH - path to component repository root directory.
+if [[ $(uname) == 'Darwin' ]]; then
+  READLINK_BIN="greadlink"
+else
+  READLINK_BIN="readlink"
+fi
 
 if [[ -z "${SOURCE_PATH}" ]]; then
-  export SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
+  export SOURCE_PATH="$(${READLINK_BIN} -f "$(dirname ${0})/..")"
 else
-  export SOURCE_PATH="$(readlink -f ${SOURCE_PATH})"
+  export SOURCE_PATH="$(${READLINK_BIN} -f ${SOURCE_PATH})"
 fi
 
 VCS="github.com"
@@ -35,7 +40,10 @@ GO111MODULE=off go get -u golang.org/x/lint/golint
 # Install Helm from binary.
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 chmod 700 get_helm.sh
-./get_helm.sh --no-sudo
+if [ $(id -u) = 0 ]; then
+   ./get_helm.sh --no-sudo
+fi
+./get_helm.sh 
 rm get_helm.sh
 
 ###############################################################################


### PR DESCRIPTION
Check script was showing error when the user was not root. This
commit fixes that. Also, the check script was not running on mac
due to readlink error. The error is fixed as well.

**What this PR does / why we need it**:

Check script was showing error when the user was not root. This
commit fixes that. Also, the check script was not running on mac
due to readlink error. The error is fixed as well.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
