### PR TITLE
Fix missing alternate full snapshots

### DIFF
--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -199,7 +199,11 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 		// TODO: write code to find out if prev full snapshot is older than it is
 		// supposed to be, according to the given cron schedule, instead of the
 		// hard-coded "24 hours" full snapshot interval
-		const recentFullSnapshotPeriodInHours = 24
+
+		// Temporary fix for missing alternate full snapshots for Gardener shoots
+		// with hibernation schedule set: change value from 24 ot 23.5 to
+		// accommodate for slight pod spin-up delays on shoot wake-up
+		const recentFullSnapshotPeriodInHours = 23.5
 		initialDeltaSnapshotTaken = false
 		if ssr.PrevFullSnapshot != nil && time.Since(ssr.PrevFullSnapshot.CreatedOn).Hours() <= recentFullSnapshotPeriodInHours {
 			ssrStopped, err := ssr.CollectEventsSincePrevSnapshot(ssrStopCh)


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR fixes missing full snapshots on shoot unhibernation. Setting the previous full snapshot existence check to 23.5 hours provides a buffer of 30 minutes for the pod to become ready to take the first full snapshot everyday in the case where full snapshot schedule lies within the shoot's hibernation period.

**Which issue(s) this PR fixes**:
Fixes #258 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fix missing alternate full snapshots for some unhibernating shoots.
```
