### PR TITLE
Fixed an error in unit test cases that appears due to use of latest golang.

### DIFF
--- a/pkg/snapstore/oss_snapstore_test.go
+++ b/pkg/snapstore/oss_snapstore_test.go
@@ -99,7 +99,7 @@ func (m *mockOSSBucket) UploadPart(imur oss.InitiateMultipartUploadResult, reade
 	(*m.multiPartUploads[imur.UploadID])[partNumber-1] = content
 	m.multiPartUploadsMutex.Unlock()
 
-	eTag := string(partNumber)
+	eTag := fmt.Sprint(partNumber)
 	return oss.UploadPart{
 		PartNumber: partNumber,
 		ETag:       eTag,

--- a/pkg/snapstore/s3_snapstore_test.go
+++ b/pkg/snapstore/s3_snapstore_test.go
@@ -113,7 +113,7 @@ func (m *mockS3Client) UploadPartWithContext(ctx aws.Context, in *s3.UploadPartI
 	(*m.multiPartUploads[*in.UploadId])[*in.PartNumber-1] = content
 	m.multiPartUploadsMutex.Unlock()
 
-	eTag := string(*in.PartNumber)
+	eTag := fmt.Sprint(*in.PartNumber)
 	out := &s3.UploadPartOutput{
 		ETag: &eTag,
 	}

--- a/pkg/snapstore/swift_snapstore_test.go
+++ b/pkg/snapstore/swift_snapstore_test.go
@@ -123,7 +123,7 @@ func handleListObjectNames(w http.ResponseWriter, r *http.Request) {
 			contents = append(contents, key)
 		}
 	}
-	w.Header().Set("X-Container-Object-Count", string(len(contents)))
+	w.Header().Set("X-Container-Object-Count", fmt.Sprint(len(contents)))
 	w.Header().Set("Content-Type", "text/plain")
 	list := strings.Join(contents, "\n")
 	w.Write([]byte(list))


### PR DESCRIPTION
An error is appearing printing this: conversion from int to string yields a
string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
This error is appearing while running unit tests with golang version
1.15 . This error is fixed in this PR.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
