### PR TITLE
Double check latest revision by starting an embedded etcd if revision check based on data dir fails during data validation 

### DIFF
--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -51,6 +51,7 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 		metrics.ValidationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Now().Sub(start).Seconds())
 		return fmt.Errorf("failed to initialize since fail below revision check failed")
 	}
+
 	metrics.ValidationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Observe(time.Now().Sub(start).Seconds())
 
 	if dataDirStatus != validator.DataDirectoryValid {
@@ -77,8 +78,9 @@ func NewInitializer(options *restorer.RestoreOptions, snapstoreConfig *snapstore
 		},
 		Validator: &validator.DataValidator{
 			Config: &validator.Config{
-				DataDir:         options.Config.RestoreDataDir,
-				SnapstoreConfig: snapstoreConfig,
+				DataDir:                options.Config.RestoreDataDir,
+				EmbeddedEtcdQuotaBytes: options.Config.EmbeddedEtcdQuotaBytes,
+				SnapstoreConfig:        snapstoreConfig,
 			},
 			Logger:    logger,
 			ZapLogger: zapLogger,

--- a/pkg/initializer/validator/types.go
+++ b/pkg/initializer/validator/types.go
@@ -15,6 +15,8 @@
 package validator
 
 import (
+	"time"
+
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
@@ -36,12 +38,14 @@ const (
 	DataDirectoryStatusUnknown
 	// RevisionConsistencyError indicates current etcd revision is inconsistent with latest snapshot revision.
 	RevisionConsistencyError
-	//FailBelowRevisionConsistencyError indicates the current etcd revision is inconsistent with failBelowRevision.
+	// FailBelowRevisionConsistencyError indicates the current etcd revision is inconsistent with failBelowRevision.
 	FailBelowRevisionConsistencyError
 )
 
 const (
-	snapSuffix = ".snap"
+	snapSuffix                    = ".snap"
+	connectionTimeout             = time.Duration(10 * time.Second)
+	embeddedEtcdPingLimitDuration = 60 * time.Second
 )
 
 // Mode is the Validation mode passed on to the DataValidator
@@ -56,8 +60,9 @@ const (
 
 // Config store configuration for DataValidator.
 type Config struct {
-	DataDir         string
-	SnapstoreConfig *snapstore.Config
+	DataDir                string
+	EmbeddedEtcdQuotaBytes int64
+	SnapstoreConfig        *snapstore.Config
 }
 
 // DataValidator contains implements Validator interface to perform data validation.

--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -73,7 +73,7 @@ func (r *Restorer) Restore(ro RestoreOptions) error {
 		return nil
 	}
 	r.logger.Infof("Starting embedded etcd server...")
-	e, err := startEmbeddedEtcd(r.logger, ro)
+	e, err := StartEmbeddedEtcd(r.logger, ro.Config.RestoreDataDir, ro.Config.EmbeddedEtcdQuotaBytes)
 	if err != nil {
 		return err
 	}
@@ -307,10 +307,10 @@ func makeWALAndSnap(logger *zap.Logger, waldir, snapdir string, cl *membership.R
 	return w.SaveSnapshot(walpb.Snapshot{Index: commit, Term: term})
 }
 
-// startEmbeddedEtcd starts the embedded etcd server.
-func startEmbeddedEtcd(logger *logrus.Entry, ro RestoreOptions) (*embed.Etcd, error) {
+// StartEmbeddedEtcd starts the embedded etcd server.
+func StartEmbeddedEtcd(logger *logrus.Entry, dataDir string, embeddedEtcdQuotaBytes int64) (*embed.Etcd, error) {
 	cfg := embed.NewConfig()
-	cfg.Dir = filepath.Join(ro.Config.RestoreDataDir)
+	cfg.Dir = filepath.Join(dataDir)
 	DefaultListenPeerURLs := "http://localhost:0"
 	DefaultListenClientURLs := "http://localhost:0"
 	DefaultInitialAdvertisePeerURLs := "http://localhost:0"
@@ -324,7 +324,7 @@ func startEmbeddedEtcd(logger *logrus.Entry, ro RestoreOptions) (*embed.Etcd, er
 	cfg.APUrls = []url.URL{*apurl}
 	cfg.ACUrls = []url.URL{*acurl}
 	cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name)
-	cfg.QuotaBackendBytes = ro.Config.EmbeddedEtcdQuotaBytes
+	cfg.QuotaBackendBytes = embeddedEtcdQuotaBytes
 	cfg.Logger = "zap"
 	e, err := embed.StartEtcd(cfg)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
WALs file can have data revisions which are ahead of data revisions present in DB file, if etcd terminates abnormally and fails to flush the changes from WALs to Bolt DB ,this lead to  unnecessary data restoration.
This PR eliminates this unnecessary data restoration. Starting the embedded etcd on data dir, ping the embedded etcd for 60s to get the latest revision from etcd, after that compare this latest revision and latest revision of back-up data.

**Which issue(s) this PR fixes**:
Fixes #260 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Validator now double checks latest revision by starting an embedded etcd if DB-based revision check fails. This can potentially avoid unnecessary data restoration when etcd terminates abnormally.
```
