### PR TITLE
Add UDS listener for start and status

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-bootstrap-configmap.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-bootstrap-configmap.yaml
@@ -10,18 +10,8 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 data:
   bootstrap.sh: |-
-    #!/bin/sh
+    #!/bin/bash
     VALIDATION_MARKER=/var/etcd/data/validation_marker
-
-{{- if .Values.backupRestoreTLS }}
-    # Add self-signed CA to list of root CA-certificates
-    cat /var/etcdbr/ssl/ca/ca.crt >> /etc/ssl/cert.pem
-    if [ $? -ne 0 ]
-    then
-      echo "failed to update root certificate list"
-      exit 1
-    fi
-{{- end }}
 
     trap_and_propagate() {
         PID=$1
@@ -45,15 +35,20 @@ data:
     check_and_start_etcd(){
           while true;
           do
-            wget "http{{ if .Values.backupRestoreTLS }}s{{ end }}://localhost:{{ .Values.servicePorts.backupRestore }}/initialization/status" -S -O status;
+            touch status
+            echo "Getting status..."
+            curl -S -s -o status --unix-socket /var/run/etcdbrctl/etcdbrctl.socket http://localhost/initialization/status;
             STATUS=`cat status`;
             case $STATUS in
             "New")
-                  wget "http{{ if .Values.backupRestoreTLS }}s{{ end }}://localhost:{{ .Values.servicePorts.backupRestore }}/initialization/start?mode=$1{{- if .Values.backup.failBelowRevision }}&failbelowrevision={{ int $.Values.backup.failBelowRevision }}{{- end }}" -S -O - ;;
+                  echo "Status is New. Starting...";
+                  curl -S -s -o /dev/stdout --unix-socket /var/run/etcdbrctl/etcdbrctl.socket "http://localhost/initialization/start?mode=$1{{- if .Values.backup.failBelowRevision }}&failbelowrevision={{ int $.Values.backup.failBelowRevision }}{{- end }}";;
             "Progress")
+                  echo "Status is Progress. Waiting...";
                   sleep 1;
                   continue;;
             "Failed")
+                  echo "Status is Failed. Retrying...";
                   sleep 1;
                   continue;;
             "Successful")
@@ -62,6 +57,7 @@ data:
                   break
                   ;;
             *)
+                  echo "Status is Unknown. Retrying...";
                   sleep 1;
                   ;;
             esac;
@@ -75,7 +71,7 @@ data:
           check_and_start_etcd full
     else
           echo "$VALIDATION_MARKER file present. Check return status and decide on initialization"
-          run_status=`cat $VALIDATION_MARKER`
+          run_status=$(cat $VALIDATION_MARKER)
           echo "$VALIDATION_MARKER content: $run_status"
           if [ $run_status == '143' ] || [ $run_status == '130' ] || [ $run_status == '0' ] ; then
                 echo "Requesting sidecar to perform sanity validation"

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -78,6 +78,8 @@ spec:
           mountPath: /var/etcd/bin/
         - name: etcd-config-file
           mountPath: /var/etcd/config/
+        - name: uds
+          mountPath: /var/run/etcdbrctl
 {{- if .Values.etcdTLS }}
         - name: ca-etcd
           mountPath: /var/etcd/ssl/ca
@@ -93,6 +95,7 @@ spec:
         - etcdbrctl
         - server
         - --schedule={{ .Values.backup.schedule }}
+        - --uds-path=/var/run/etcdbrctl/etcdbrctl.socket
 {{- if eq .Values.backup.garbageCollectionPolicy "LimitBased" }}
         - --max-backups={{ .Values.backup.maxBackups }}
         - --garbage-collection-policy={{ .Values.backup.garbageCollectionPolicy }}
@@ -254,6 +257,8 @@ spec:
           mountPath: /var/etcd/data/
         - name: etcd-config-file
           mountPath: /var/etcd/config/
+        - name: uds
+          mountPath: /var/run/etcdbrctl
 {{- if .Values.etcdTLS }}
         - name: ca-etcd
           mountPath: /var/etcd/ssl/ca
@@ -285,6 +290,8 @@ spec:
           items:
           - key: etcd.conf.yaml
             path: etcd.conf.yaml
+      - name: uds
+        emptyDir: {}
 {{- if .Values.etcdTLS }}
       - name: ca-etcd
         secret:

--- a/doc/usage/getting_started.md
+++ b/doc/usage/getting_started.md
@@ -36,7 +36,7 @@ If using `LimitBased` policy, the `max-backups` flag should be provided to indic
 ```console
 $ ./bin/etcdbrctl snapshot  \
 --storage-provider="S3" \
---etcd-endpoints http://localhost:2379 \
+--endpoints http://localhost:2379 \
 --schedule "*/1 * * * *" \
 --store-container="etcd-backup" \
 --delta-snapshot-period=10s \

--- a/example/00-backup-restore-server-config.yaml
+++ b/example/00-backup-restore-server-config.yaml
@@ -15,6 +15,7 @@ serverConfig:
   # enableProfiling: true
   # server-cert: "ssl/etcdbr/tls.crt"
   # server-key: "ssl/etcdbr/tls.key"
+  # uds-path "/var/run/etcdbrctl/etcdbrctl.socket"
 
 snapshotterConfig:
   schedule: "0 */1 * * *"

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -92,6 +92,7 @@ func (b *BackupRestoreServer) startHTTPServer(initializer initializer.Initialize
 	// and running before setting the status to OK.
 	handler := &HTTPHandler{
 		Port:              b.config.ServerConfig.Port,
+		UDSPath:           b.config.ServerConfig.UDSPath,
 		Initializer:       initializer,
 		Snapshotter:       ssr,
 		Logger:            b.logger,

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -23,6 +23,7 @@ import (
 )
 
 const (
+	defaultUDSPath                 = "/var/run/etcdbrctl/etcdbrctl.socket"
 	defaultServerPort              = 8080
 	defaultDefragmentationSchedule = "0 0 */3 * *"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Add UDS listener for start and status. This would allow for the etcd to talk to the backup sidecar without TCP via Unix Domain Socket.

The old behavior still exists and it's not changed.

**Which issue(s) this PR fixes**:

Partially #285 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The server now listens on Unix Domain Socket (UDS) and serves `initialization/status` and `initialization/start` resources. This allows for the etcd bootstrap to use that socket directly without TLS/TCP. 
The socket path can be configured with `--uds-path` flag. It defaults to `/var/run/etcdbrctl/etcdbrctl.socket`.
```
