### PR TITLE
Compress the snapshots(full as well as Incremental) before uploading to object store and decompress the snapshot before restoration.

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"io/ioutil"
 
+	"github.com/gardener/etcd-backup-restore/pkg/compressor"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/snapshotter"
 
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
@@ -184,6 +185,7 @@ func (c *validatorOptions) validate() error {
 
 type snapshotterOptions struct {
 	etcdConnectionConfig    *etcdutil.EtcdConnectionConfig
+	compressionConfig       *compressor.CompressionConfig
 	snapstoreConfig         *snapstore.Config
 	snapshotterConfig       *snapshotter.Config
 	defragmentationSchedule string
@@ -195,6 +197,7 @@ func newSnapshotterOptions() *snapshotterOptions {
 		etcdConnectionConfig:    etcdutil.NewEtcdConnectionConfig(),
 		snapstoreConfig:         snapstore.NewSnapstoreConfig(),
 		snapshotterConfig:       snapshotter.NewSnapshotterConfig(),
+		compressionConfig:       compressor.NewCompressorConfig(),
 		defragmentationSchedule: "0 0 */3 * *",
 	}
 }
@@ -204,6 +207,7 @@ func (c *snapshotterOptions) addFlags(fs *flag.FlagSet) {
 	c.etcdConnectionConfig.AddFlags(fs)
 	c.snapstoreConfig.AddFlags(fs)
 	c.snapshotterConfig.AddFlags(fs)
+	c.compressionConfig.AddFlags(fs)
 
 	// Miscellaneous
 	fs.StringVar(&c.defragmentationSchedule, "defragmentation-schedule", c.defragmentationSchedule, "schedule to defragment etcd data directory")
@@ -216,6 +220,10 @@ func (c *snapshotterOptions) validate() error {
 	}
 
 	if err := c.snapshotterConfig.Validate(); err != nil {
+		return err
+	}
+
+	if err := c.compressionConfig.Validate(); err != nil {
 		return err
 	}
 

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -49,7 +49,7 @@ storing snapshots on various cloud storage providers as well as local disk locat
 				logger.Fatalf("Failed to create snapstore from configured storage provider: %v", err)
 			}
 
-			ssr, err := snapshotter.NewSnapshotter(logger, opts.snapshotterConfig, ss, opts.etcdConnectionConfig)
+			ssr, err := snapshotter.NewSnapshotter(logger, opts.snapshotterConfig, ss, opts.etcdConnectionConfig, opts.compressionConfig)
 			if err != nil {
 				logger.Fatalf("Failed to create snapshotter: %v", err)
 			}

--- a/example/00-backup-restore-server-config.yaml
+++ b/example/00-backup-restore-server-config.yaml
@@ -43,3 +43,7 @@ restorationConfig:
   embeddedEtcdQuotaBytes: 8589934592
 
 defragmentationSchedule: "0 0 */3 * *"
+
+compressionConfig:
+   enabled: true
+   policy: "gzip"

--- a/pkg/compressor/compressor.go
+++ b/pkg/compressor/compressor.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compressor
+
+import (
+	"compress/gzip"
+	"compress/lzw"
+	"compress/zlib"
+	"fmt"
+	"io"
+
+	"github.com/sirupsen/logrus"
+)
+
+// CompressSnapshot takes uncompressed data as input and compress the data according to Compression Policy
+// and write the compressed data into one end of pipe.
+func CompressSnapshot(data io.ReadCloser, compressionPolicy string) (io.ReadCloser, error) {
+	pReader, pWriter := io.Pipe()
+
+	var gWriter io.WriteCloser
+	logger := logrus.New().WithField("actor", "compressor")
+	logger.Infof("start compressing the snapshot using %v Compression Policy", compressionPolicy)
+
+	switch compressionPolicy {
+	case GzipCompressionPolicy:
+		gWriter = gzip.NewWriter(pWriter)
+
+	case LzwCompressionPolicy:
+		gWriter = lzw.NewWriter(pWriter, lzw.LSB, LzwLiteralWidth)
+
+	case ZlibCompressionPolicy:
+		gWriter = zlib.NewWriter(pWriter)
+
+	// It is actually unreachable but just to be on safe side:
+	// for unsupported CompressionPolicy return the error
+	default:
+		return nil, fmt.Errorf("Unsupported Compression Policy")
+
+	}
+
+	go func() {
+		var err error
+		defer pWriter.CloseWithError(err)
+		defer gWriter.Close()
+		defer data.Close()
+		_, err = io.Copy(gWriter, data)
+		if err != nil {
+			logger.Infof("compression failed: %v", err)
+			return
+		}
+	}()
+
+	return pReader, nil
+}
+
+// DecompressSnapshot take compressed data and compressionPolicy as input and
+// it decompresses the data according to compression Policy and return uncompressed data.
+func DecompressSnapshot(data io.ReadCloser, compressionPolicy string) (io.ReadCloser, error) {
+	var deCompressedData io.ReadCloser
+	var err error
+
+	logger := logrus.New().WithField("actor", "de-compressor")
+	logger.Infof("start decompressing the snapshot with %v compressionPolicy", compressionPolicy)
+
+	switch compressionPolicy {
+	case ZlibCompressionPolicy:
+		deCompressedData, err = zlib.NewReader(data)
+		if err != nil {
+			logger.Infof("Unable to decompress: %v", err)
+			return data, err
+		}
+
+	case GzipCompressionPolicy:
+		deCompressedData, err = gzip.NewReader(data)
+		if err != nil {
+			logger.Infof("Unable to decompress: %v", err)
+			return data, err
+		}
+
+	case LzwCompressionPolicy:
+		deCompressedData = lzw.NewReader(data, lzw.LSB, LzwLiteralWidth)
+
+	// It is actually unreachable but just to be on safe side:
+	// for unsupported CompressionPolicy return the same data with error
+	default:
+		return data, fmt.Errorf("Unsupported Compression Policy")
+	}
+
+	return deCompressedData, nil
+}
+
+// GetCompressionSuffix returns the suffix for snapshot w.r.t Compression Policy
+// if compression is not enabled, it will simply return UnCompressSnapshotExtension(empty string).
+func GetCompressionSuffix(compressionEnabled bool, compressionPolicy string) (string, error) {
+
+	if !compressionEnabled {
+		return UnCompressSnapshotExtension, nil
+	}
+
+	switch compressionPolicy {
+	case ZlibCompressionPolicy:
+		return ZlibCompressionExtension, nil
+
+	case LzwCompressionPolicy:
+		return LzwCompressionExtension, nil
+
+	case GzipCompressionPolicy:
+		return GzipCompressionExtension, nil
+
+	// unreachable but just to be on safe side:
+	// for unsupported CompressionPolicy return the error
+	default:
+		return "", fmt.Errorf("Unsupported Compression Policy")
+
+	}
+}
+
+// IsSnapshotCompressed is helpful in determining whether the snapshot is compressed or not.
+// it will return boolean, compressionPolicy corresponding to compressionSuffix and error.
+func IsSnapshotCompressed(compressionSuffix string) (bool, string, error) {
+
+	switch compressionSuffix {
+	case ZlibCompressionExtension:
+		return true, ZlibCompressionPolicy, nil
+
+	case GzipCompressionExtension:
+		return true, GzipCompressionPolicy, nil
+
+	case LzwCompressionExtension:
+		return true, LzwCompressionPolicy, nil
+
+	case UnCompressSnapshotExtension:
+		return false, "", nil
+
+	// actually unreachable but just to be on safe side:
+	// for unsupported CompressionPolicy return the error
+	default:
+		return false, "", fmt.Errorf("Unsupported Compression Policy")
+	}
+}

--- a/pkg/compressor/init.go
+++ b/pkg/compressor/init.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compressor
+
+import (
+	"fmt"
+
+	flag "github.com/spf13/pflag"
+)
+
+// NewCompressorConfig returns the compression config.
+func NewCompressorConfig() *CompressionConfig {
+	return &CompressionConfig{
+		Enabled:           DefaultCompression,
+		CompressionPolicy: DefaultCompressionPolicy,
+	}
+}
+
+// AddFlags adds the flags to flagset.
+func (c *CompressionConfig) AddFlags(fs *flag.FlagSet) {
+
+	fs.BoolVar(&c.Enabled, "compress-snapshots", c.Enabled, "whether to compress the snapshots or not")
+	fs.StringVar(&c.CompressionPolicy, "compression-policy", c.CompressionPolicy, "Policy for compressing the snapshots")
+}
+
+// Validate validates the compression Config.
+func (c *CompressionConfig) Validate() error {
+
+	// if compression is not enabled then to check CompressionPolicy becomes irrelevant
+	if c.Enabled == false {
+		return nil
+	}
+
+	for _, policy := range []string{GzipCompressionPolicy, ZlibCompressionPolicy, LzwCompressionPolicy} {
+		if c.CompressionPolicy == policy {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s: Compression Policy is not supported", c.CompressionPolicy)
+
+}

--- a/pkg/compressor/types.go
+++ b/pkg/compressor/types.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compressor
+
+const (
+
+	// GzipCompressionPolicy is constant for gzip compression algorithm.
+	GzipCompressionPolicy = "gzip"
+	// LzwCompressionPolicy is constant for lzw compression algorithm.
+	LzwCompressionPolicy = "lzw"
+	// ZlibCompressionPolicy is constant for zlib compression algorithm.
+	ZlibCompressionPolicy = "zlib"
+
+	// DefaultCompression is constant used for whether to compress the snapshots or not.
+	DefaultCompression = false
+	// DefaultCompressionPolicy is constant for default compression algorithm(only if compression is enabled).
+	DefaultCompressionPolicy = "gzip"
+
+	// UnCompressSnapshotExtension is used for snapshot suffix when compression is not enabled.
+	UnCompressSnapshotExtension = ""
+	// GzipCompressionExtension is used for snapshot suffix when compressionPolicy is gzip.
+	GzipCompressionExtension = ".gz"
+	// LzwCompressionExtension is used for snapshot suffix when compressionPolicy is lzw.
+	LzwCompressionExtension = ".Z"
+	// ZlibCompressionExtension is used for snapshot suffix when compressionPolicy is zlib.
+	ZlibCompressionExtension = ".zlib"
+	// Reference: https://en.wikipedia.org/wiki/List_of_archive_formats
+
+	// LzwLiteralWidth is constant used as literal Width in lzw compressionPolicy.
+	LzwLiteralWidth = 8 //[2,8]
+)
+
+// CompressionConfig holds the compression configuration.
+type CompressionConfig struct {
+	Enabled           bool   `json:"enabled"`
+	CompressionPolicy string `json:"policy,omitempty"`
+}

--- a/pkg/initializer/validator/validator_suite_test.go
+++ b/pkg/initializer/validator/validator_suite_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gardener/etcd-backup-restore/pkg/compressor"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/snapshotter"
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
@@ -92,6 +93,7 @@ func runSnapshotter(logger *logrus.Entry, deltaSnapshotPeriod time.Duration, end
 		return err
 	}
 
+	compressionConfig := compressor.NewCompressorConfig()
 	etcdConnectionConfig := etcdutil.NewEtcdConnectionConfig()
 	etcdConnectionConfig.Endpoints = endpoints
 	etcdConnectionConfig.ConnectionTimeout.Duration = 10 * time.Second
@@ -102,7 +104,7 @@ func runSnapshotter(logger *logrus.Entry, deltaSnapshotPeriod time.Duration, end
 	snapshotterConfig.FullSnapshotSchedule = "0 0 1 1 *"
 	snapshotterConfig.MaxBackups = 1
 
-	ssr, err := snapshotter.NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig)
+	ssr, err := snapshotter.NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -129,7 +129,7 @@ func (b *BackupRestoreServer) runServerWithoutSnapshotter(ctx context.Context, r
 	b.runEtcdProbeLoopWithoutSnapshotter(ctx, handler)
 }
 
-// runServerWithoutSnapshotter runs the etcd-backup-restore
+// runServerWithSnapshotter runs the etcd-backup-restore
 // for the case where snapshotter is configured correctly
 func (b *BackupRestoreServer) runServerWithSnapshotter(ctx context.Context, restoreOpts *restorer.RestoreOptions) error {
 	ackCh := make(chan struct{})
@@ -143,7 +143,7 @@ func (b *BackupRestoreServer) runServerWithSnapshotter(ctx context.Context, rest
 	}
 
 	b.logger.Infof("Creating snapshotter...")
-	ssr, err := snapshotter.NewSnapshotter(b.logger, b.config.SnapshotterConfig, ss, b.config.EtcdConnectionConfig)
+	ssr, err := snapshotter.NewSnapshotter(b.logger, b.config.SnapshotterConfig, ss, b.config.EtcdConnectionConfig, b.config.CompressionConfig)
 	if err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func (b *BackupRestoreServer) runServerWithSnapshotter(ctx context.Context, rest
 	return nil
 }
 
-// runEtcdProbeLoopWithoutSnapshotter runs the etcd probe loop
+// runEtcdProbeLoopWithSnapshotter runs the etcd probe loop
 // for the case where snapshotter is configured correctly
 func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Context, handler *HTTPHandler, ssr *snapshotter.Snapshotter, ssrStopCh chan struct{}, ackCh chan struct{}) {
 	var (

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/gardener/etcd-backup-restore/pkg/compressor"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/restorer"
@@ -35,6 +36,7 @@ func NewBackupRestoreComponentConfig() *BackupRestoreComponentConfig {
 		SnapshotterConfig:       snapshotter.NewSnapshotterConfig(),
 		SnapstoreConfig:         snapstore.NewSnapstoreConfig(),
 		RestorationConfig:       restorer.NewRestorationConfig(),
+		CompressionConfig:       compressor.NewCompressorConfig(),
 		DefragmentationSchedule: defaultDefragmentationSchedule,
 	}
 }
@@ -46,6 +48,7 @@ func (c *BackupRestoreComponentConfig) AddFlags(fs *flag.FlagSet) {
 	c.SnapshotterConfig.AddFlags(fs)
 	c.SnapstoreConfig.AddFlags(fs)
 	c.RestorationConfig.AddFlags(fs)
+	c.CompressionConfig.AddFlags(fs)
 
 	// Miscellaneous
 	fs.StringVar(&c.DefragmentationSchedule, "defragmentation-schedule", c.DefragmentationSchedule, "schedule to defragment etcd data directory")
@@ -66,6 +69,9 @@ func (c *BackupRestoreComponentConfig) Validate() error {
 		return err
 	}
 	if err := c.RestorationConfig.Validate(); err != nil {
+		return err
+	}
+	if err := c.CompressionConfig.Validate(); err != nil {
 		return err
 	}
 	if _, err := cron.ParseStandard(c.DefragmentationSchedule); err != nil {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"github.com/gardener/etcd-backup-restore/pkg/compressor"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/restorer"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/snapshotter"
@@ -33,6 +34,7 @@ type BackupRestoreComponentConfig struct {
 	SnapshotterConfig       *snapshotter.Config            `json:"snapshotterConfig,omitempty"`
 	SnapstoreConfig         *snapstore.Config              `json:"snapstoreConfig,omitempty"`
 	RestorationConfig       *restorer.RestorationConfig    `json:"restorationConfig,omitempty"`
+	CompressionConfig       *compressor.CompressionConfig  `json:"compressionConfig,omitempty"`
 	DefragmentationSchedule string                         `json:"defragmentationSchedule"`
 }
 

--- a/pkg/snapshot/snapshotter/types.go
+++ b/pkg/snapshot/snapshotter/types.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gardener/etcd-backup-restore/pkg/compressor"
 	"github.com/gardener/etcd-backup-restore/pkg/wrappers"
 
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
@@ -61,6 +62,7 @@ type Snapshotter struct {
 	etcdConnectionConfig *etcdutil.EtcdConnectionConfig
 	store                snapstore.SnapStore
 	config               *Config
+	compressionConfig    *compressor.CompressionConfig
 
 	schedule           cron.Schedule
 	prevSnapshot       *snapstore.Snapshot

--- a/pkg/snapstore/types.go
+++ b/pkg/snapstore/types.go
@@ -81,13 +81,14 @@ const (
 
 // Snapshot structure represents the metadata of snapshot.s
 type Snapshot struct {
-	Kind          string    `json:"kind"` //incr:incremental,full:full
-	StartRevision int64     `json:"startRevision"`
-	LastRevision  int64     `json:"lastRevision"` //latest revision on snapshot
-	CreatedOn     time.Time `json:"createdOn"`
-	SnapDir       string    `json:"snapDir"`
-	SnapName      string    `json:"snapName"`
-	IsChunk       bool      `json:"isChunk"`
+	Kind              string    `json:"kind"` //incr:incremental,full:full
+	StartRevision     int64     `json:"startRevision"`
+	LastRevision      int64     `json:"lastRevision"` //latest revision on snapshot
+	CreatedOn         time.Time `json:"createdOn"`
+	SnapDir           string    `json:"snapDir"`
+	SnapName          string    `json:"snapName"`
+	IsChunk           bool      `json:"isChunk"`
+	CompressionSuffix string    `json:"compressionSuffix"` // CompressionSuffix depends on compessionPolicy
 }
 
 // SnapList is list of snapshots.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR added the compression/decompression feature. So, it compress/decompress the snapshots(full as well as Incremental) before/after uploading/downloading to/from object store. 
It also supports the backward compatibility for restoring from non-compressed snapshots as well as when different compressionPolicy were used to take the snapshot.

**Which issue(s) this PR fixes**:
Fixes #255 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
--> 
```noteworthy user
Add support for snapshot compression/decompression. Compression and compression policy can be configured through flags:  `--compress-snapshots` and `--compression-policy` respectively. Supported compression policies currently are `gzip` (default), `lzw` and `zlib`. Snapshot compression is disabled by default.
```
