### PR TITLE
Added support for running tests suites from user specified packages.

### DIFF
--- a/.ci/unit_test
+++ b/.ci/unit_test
@@ -54,7 +54,12 @@ function test_with_coverage() {
 
 ################################################################################
 
-TEST_PACKAGES="cmd pkg"
+# To run a specific package, run TEST_PACKAGES=<PATH_TO_PACKAGE> make test
+TEST_PACKAGES=${TEST_PACKAGES:-""}
+if [[ -z "${TEST_PACKAGES}" ]]; then
+  TEST_PACKAGES="cmd pkg"
+fi
+
 GINKGO_COMMON_FLAGS="-r -timeout=1h0m0s --progress -slowSpecThreshold=180 -mod=vendor"
 
 if [ -z $COVER ] || [ "$COVER" = false ] ; then


### PR DESCRIPTION
Currently, tests  run for `cmd` and `pkg` . But there is no provision to run tests just on any package of etcd-backup-retstore. This PR adds the support. It makes easier for developer to write/modify packages and test on just that package iteratively.