### PR TITLE
Update the helm charts for etcdbr-compression feature.

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -130,6 +130,14 @@ spec:
         - --server-cert=/var/etcdbr/ssl/tls/tls.crt
         - --server-key=/var/etcdbr/ssl/tls/tls.key
 {{- end }}
+{{- if .Values.backup.compression }}
+        {{- if .Values.backup.compression.enabled }}
+        - --compress-snapshots={{ .Values.backup.compression.enabled }}
+        {{- end }}
+        {{- if .Values.backup.compression.policy }}        
+        - --compression-policy={{ .Values.backup.compression.policy }}
+        {{- end }}
+{{- end }}
         image: {{ .Values.images.etcdBackupRestore.repository }}:{{ .Values.images.etcdBackupRestore.tag }}
         imagePullPolicy: {{ .Values.images.etcdBackupRestore.pullPolicy }}
         ports:

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -7,7 +7,7 @@ images:
   # etcd-backup-restore image to use
   etcdBackupRestore:
     repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-    tag: v0.10.0
+    tag: v0.12.0-dev-e6df91b7463cf784f651bd6cc6ac7fc4d2e5a70b
     pullPolicy: IfNotPresent
 
 resources:
@@ -63,6 +63,12 @@ backup:
   # storageProvider indicate the type of backup storage provider.
   # Supported values are ABS,GCS,S3,Swift,OSS,ECS,Local, empty means no backup.
   storageProvider: "Local"
+
+  # compression defines the specification to compress the snapshots(full as well as delta).
+  # it only supports 3 compression Policy: gzip(default), zlib, lzw.
+  compression:
+    enabled: true
+    policy: "gzip"
 
   # failBelowRevision indicates the revision below which the validation of etcd will fail and restore will not be triggered in case
   # there is no snapshot on configured backup bucket.


### PR DESCRIPTION
**What this PR does / why we need it**:
It updates the helm-charts for [etcdbr-compression feature](https://github.com/gardener/etcd-backup-restore/pull/293).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
etcdbr-compression specification can be configured through helm-charts.
```
