### PR TITLE
Fixed an issue when fresh etcd-backup-restore tries to take 2 full snapshot.

### DIFF
--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -244,7 +244,7 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 		gcStopCh := make(chan struct{})
 		go ssr.RunGarbageCollector(gcStopCh)
 		b.logger.Infof("Starting snapshotter...")
-		startWithFullSnapshot := ssr.PrevFullSnapshot == nil || !(initialDeltaSnapshotTaken && time.Since(ssr.PrevFullSnapshot.CreatedOn).Hours() <= recentFullSnapshotPeriodInHours)
+		startWithFullSnapshot := ssr.PrevFullSnapshot == nil || !(time.Since(ssr.PrevFullSnapshot.CreatedOn).Hours() <= recentFullSnapshotPeriodInHours)
 		if err := ssr.Run(ssrStopCh, startWithFullSnapshot); err != nil {
 			if etcdErr, ok := err.(*errors.EtcdError); ok == true {
 				b.logger.Errorf("Snapshotter failed with etcd error: %v", etcdErr)


### PR DESCRIPTION
Fixed an issue with backup-restore-server when it tries to take 2 full snapshots on starting of a fresh etcd-backup-restore.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #313 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
