### PR TITLE
Added Auto-Compaction for embedded Etcd and Update helm-charts to run auto-compaction on Etcd.

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-bootstrap-configmap.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-bootstrap-configmap.yaml
@@ -113,6 +113,18 @@ data:
     # Initial cluster state ('new' or 'existing').
     initial-cluster-state: 'new'
 
+    {{- if .Values.autoCompaction }}
+    # auto-compaction-mode ("periodic" or "revision").
+    {{- if .Values.autoCompaction.mode }}
+    auto-compaction-mode: {{ .Values.autoCompaction.mode }}
+    {{- end }}
+
+    # auto-compaction-retention defines Auto compaction retention length for etcd.
+    {{- if .Values.autoCompaction.retentionLength }}
+    auto-compaction-retention: {{ .Values.autoCompaction.retentionLength }}
+    {{- end }}
+    {{- end }}
+
 {{- if .Values.etcdTLS }}
     client-transport-security:
       # Path to the client server TLS cert file.

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -138,6 +138,14 @@ spec:
         - --compression-policy={{ .Values.backup.compression.policy }}
         {{- end }}
 {{- end }}
+{{- if .Values.autoCompaction }}
+        {{- if .Values.autoCompaction.mode }}
+        - --auto-compaction-mode={{ .Values.autoCompaction.mode }}
+        {{- end }}
+        {{- if .Values.autoCompaction.retentionLength }}
+        - --auto-compaction-retention={{ .Values.autoCompaction.retentionLength }}
+        {{- end }}
+{{- end }}
         image: {{ .Values.images.etcdBackupRestore.repository }}:{{ .Values.images.etcdBackupRestore.tag }}
         imagePullPolicy: {{ .Values.images.etcdBackupRestore.pullPolicy }}
         ports:

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -33,6 +33,12 @@ servicePorts:
 
 storageCapacity: 20Gi
 
+# auto-compaction mode for etcd: 'periodic' mode or 'revision' mode.
+# auto-compaction retention length for etcd.
+autoCompaction:
+  mode: periodic
+  retentionLength: "5m"
+
 backup:
   # schedule is cron standard schedule to take full snapshots.
   schedule: "0 */1 * * *"

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -7,7 +7,7 @@ images:
   # etcd-backup-restore image to use
   etcdBackupRestore:
     repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-    tag: v0.12.0-dev-e6df91b7463cf784f651bd6cc6ac7fc4d2e5a70b
+    tag: v0.12.0-dev-34f854c06838d14d6e7b08099d6cfa6fca2ad50d
     pullPolicy: IfNotPresent
 
 resources:
@@ -33,11 +33,12 @@ servicePorts:
 
 storageCapacity: 20Gi
 
-# auto-compaction mode for etcd: 'periodic' mode or 'revision' mode.
-# auto-compaction retention length for etcd.
+# autoCompaction defines the specification to be used by Etcd as well as by embedded-Etcd of backup-restore sidecar during restoration.
+# auto-compaction mode for etcd and embedded-Etcd: 'periodic' mode or 'revision' mode.
+# auto-compaction retention length for etcd as well as for  embedded-Etcd of backup-restore sidecar.
 autoCompaction:
   mode: periodic
-  retentionLength: "5m"
+  retentionLength: "30m"
 
 backup:
   # schedule is cron standard schedule to take full snapshots.

--- a/example/00-backup-restore-server-config.yaml
+++ b/example/00-backup-restore-server-config.yaml
@@ -42,7 +42,7 @@ restorationConfig:
   maxFetchers: 6
   embeddedEtcdQuotaBytes: 8589934592
   autoCompactionMode: "periodic"
-  autoCompactionRetention: "5m"
+  autoCompactionRetention: "30m"
 
 defragmentationSchedule: "0 0 */3 * *"
 

--- a/example/00-backup-restore-server-config.yaml
+++ b/example/00-backup-restore-server-config.yaml
@@ -41,6 +41,8 @@ restorationConfig:
   skipHashCheck: false
   maxFetchers: 6
   embeddedEtcdQuotaBytes: 8589934592
+  autoCompactionMode: "periodic"
+  autoCompactionRetention: "5m"
 
 defragmentationSchedule: "0 0 */3 * *"
 

--- a/pkg/snapshot/restorer/init.go
+++ b/pkg/snapshot/restorer/init.go
@@ -36,6 +36,8 @@ func NewRestorationConfig() *RestorationConfig {
 		MaxRequestBytes:          defaultMaxRequestBytes,
 		MaxTxnOps:                defaultMaxTxnOps,
 		EmbeddedEtcdQuotaBytes:   int64(defaultEmbeddedEtcdQuotaBytes),
+		AutoCompactionMode:       defaultAutoCompactionMode,
+		AutoCompactionRetention:  defaultAutoCompactionRetention,
 	}
 }
 
@@ -52,6 +54,8 @@ func (c *RestorationConfig) AddFlags(fs *flag.FlagSet) {
 	fs.UintVar(&c.MaxRequestBytes, "max-request-bytes", c.MaxRequestBytes, "Maximum client request size in bytes the server will accept")
 	fs.UintVar(&c.MaxTxnOps, "max-txn-ops", c.MaxTxnOps, "Maximum number of operations permitted in a transaction")
 	fs.Int64Var(&c.EmbeddedEtcdQuotaBytes, "embedded-etcd-quota-bytes", c.EmbeddedEtcdQuotaBytes, "maximum backend quota for the embedded etcd used for applying delta snapshots")
+	fs.StringVar(&c.AutoCompactionMode, "auto-compaction-mode", c.AutoCompactionMode, "mode for auto-compaction: 'periodic' for duration based retention. 'revision' for revision number based retention.")
+	fs.StringVar(&c.AutoCompactionRetention, "auto-compaction-retention", c.AutoCompactionRetention, "Auto-compaction retention length.")
 }
 
 // Validate validates the config.
@@ -70,6 +74,9 @@ func (c *RestorationConfig) Validate() error {
 	}
 	if c.EmbeddedEtcdQuotaBytes <= 0 {
 		return fmt.Errorf("Etcd Quota size for etcd must be greater than 0")
+	}
+	if c.AutoCompactionMode != "periodic" && c.AutoCompactionMode != "revision" {
+		return fmt.Errorf("UnSupported auto-compaction-mode")
 	}
 	c.RestoreDataDir = path.Clean(c.RestoreDataDir)
 	return nil

--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -350,6 +350,8 @@ func StartEmbeddedEtcd(logger *logrus.Entry, ro *RestoreOptions) (*embed.Etcd, e
 	cfg.MaxRequestBytes = ro.Config.MaxRequestBytes
 	cfg.MaxTxnOps = ro.Config.MaxTxnOps
 	cfg.Logger = "zap"
+	cfg.AutoCompactionMode = ro.Config.AutoCompactionMode
+	cfg.AutoCompactionRetention = ro.Config.AutoCompactionRetention
 	e, err := embed.StartEtcd(cfg)
 	if err != nil {
 		return nil, err

--- a/pkg/snapshot/restorer/restorer_test.go
+++ b/pkg/snapshot/restorer/restorer_test.go
@@ -49,17 +49,17 @@ var _ = Describe("Running Restorer", func() {
 		wg              *sync.WaitGroup
 	)
 	const (
-		restoreName                    string = "default"
-		restoreClusterToken            string = "etcd-cluster"
-		restoreCluster                 string = "default=http://localhost:2380"
-		skipHashCheck                  bool   = false
-		maxFetchers                    uint   = 6
-		maxCallSendMsgSize                    = 2 * 1024 * 1024 //2Mib
-		maxRequestBytes                       = 2 * 1024 * 1024 //2Mib
-		maxTxnOps                             = 2 * 1024
-		embeddedEtcdQuotaBytes         int64  = 8 * 1024 * 1024 * 1024
-		defaultAutoCompactionMode      string = "periodic"
-		defaultAutoCompactionRetention string = "2m"
+		restoreName             string = "default"
+		restoreClusterToken     string = "etcd-cluster"
+		restoreCluster          string = "default=http://localhost:2380"
+		skipHashCheck           bool   = false
+		maxFetchers             uint   = 6
+		maxCallSendMsgSize             = 2 * 1024 * 1024 //2Mib
+		maxRequestBytes                = 2 * 1024 * 1024 //2Mib
+		maxTxnOps                      = 2 * 1024
+		embeddedEtcdQuotaBytes  int64  = 8 * 1024 * 1024 * 1024
+		autoCompactionMode      string = "periodic"
+		autoCompactionRetention string = "2m"
 	)
 
 	BeforeEach(func() {
@@ -98,8 +98,8 @@ var _ = Describe("Running Restorer", func() {
 					MaxRequestBytes:          maxRequestBytes,
 					MaxTxnOps:                maxTxnOps,
 					EmbeddedEtcdQuotaBytes:   embeddedEtcdQuotaBytes,
-					AutoCompactionMode:       defaultAutoCompactionMode,
-					AutoCompactionRetention:  defaultAutoCompactionRetention,
+					AutoCompactionMode:       autoCompactionMode,
+					AutoCompactionRetention:  autoCompactionRetention,
 				},
 				BaseSnapshot:  *baseSnapshot,
 				DeltaSnapList: deltaSnapList,
@@ -150,6 +150,15 @@ var _ = Describe("Running Restorer", func() {
 		Context("with zero fetchers", func() {
 			It("should return error", func() {
 				restoreOpts.Config.MaxFetchers = 0
+
+				err = restoreOpts.Config.Validate()
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+
+		Context("with some random auto-compaction mode", func() {
+			It("should return error", func() {
+				restoreOpts.Config.AutoCompactionMode = "someRandomMode"
 
 				err = restoreOpts.Config.Validate()
 				Expect(err).Should(HaveOccurred())
@@ -248,8 +257,8 @@ var _ = Describe("Running Restorer", func() {
 				MaxRequestBytes:          maxRequestBytes,
 				MaxTxnOps:                maxTxnOps,
 				EmbeddedEtcdQuotaBytes:   embeddedEtcdQuotaBytes,
-				AutoCompactionMode:       defaultAutoCompactionMode,
-				AutoCompactionRetention:  defaultAutoCompactionRetention,
+				AutoCompactionMode:       autoCompactionMode,
+				AutoCompactionRetention:  autoCompactionRetention,
 			}
 		})
 

--- a/pkg/snapshot/restorer/restorer_test.go
+++ b/pkg/snapshot/restorer/restorer_test.go
@@ -49,15 +49,17 @@ var _ = Describe("Running Restorer", func() {
 		wg              *sync.WaitGroup
 	)
 	const (
-		restoreName            string = "default"
-		restoreClusterToken    string = "etcd-cluster"
-		restoreCluster         string = "default=http://localhost:2380"
-		skipHashCheck          bool   = false
-		maxFetchers            uint   = 6
-		maxCallSendMsgSize            = 2 * 1024 * 1024 //2Mib
-		maxRequestBytes               = 2 * 1024 * 1024 //2Mib
-		maxTxnOps                     = 2 * 1024
-		embeddedEtcdQuotaBytes int64  = 8 * 1024 * 1024 * 1024
+		restoreName                    string = "default"
+		restoreClusterToken            string = "etcd-cluster"
+		restoreCluster                 string = "default=http://localhost:2380"
+		skipHashCheck                  bool   = false
+		maxFetchers                    uint   = 6
+		maxCallSendMsgSize                    = 2 * 1024 * 1024 //2Mib
+		maxRequestBytes                       = 2 * 1024 * 1024 //2Mib
+		maxTxnOps                             = 2 * 1024
+		embeddedEtcdQuotaBytes         int64  = 8 * 1024 * 1024 * 1024
+		defaultAutoCompactionMode      string = "periodic"
+		defaultAutoCompactionRetention string = "2m"
 	)
 
 	BeforeEach(func() {
@@ -96,6 +98,8 @@ var _ = Describe("Running Restorer", func() {
 					MaxRequestBytes:          maxRequestBytes,
 					MaxTxnOps:                maxTxnOps,
 					EmbeddedEtcdQuotaBytes:   embeddedEtcdQuotaBytes,
+					AutoCompactionMode:       defaultAutoCompactionMode,
+					AutoCompactionRetention:  defaultAutoCompactionRetention,
 				},
 				BaseSnapshot:  *baseSnapshot,
 				DeltaSnapList: deltaSnapList,
@@ -244,6 +248,8 @@ var _ = Describe("Running Restorer", func() {
 				MaxRequestBytes:          maxRequestBytes,
 				MaxTxnOps:                maxTxnOps,
 				EmbeddedEtcdQuotaBytes:   embeddedEtcdQuotaBytes,
+				AutoCompactionMode:       defaultAutoCompactionMode,
+				AutoCompactionRetention:  defaultAutoCompactionRetention,
 			}
 		})
 

--- a/pkg/snapshot/restorer/types.go
+++ b/pkg/snapshot/restorer/types.go
@@ -37,6 +37,8 @@ const (
 	defaultMaxRequestBytes          = 10 * 1024 * 1024 //10Mib
 	defaultMaxTxnOps                = 10 * 1024
 	defaultEmbeddedEtcdQuotaBytes   = 8 * 1024 * 1024 * 1024 //8Gib
+	defaultAutoCompactionMode       = "periodic"             // only 2 mode is supported: 'periodic' or 'revision'
+	defaultAutoCompactionRetention  = "5m"
 )
 
 // Restorer is a struct for etcd data directory restorer
@@ -71,6 +73,8 @@ type RestorationConfig struct {
 	MaxTxnOps                uint     `json:"MaxTxnOps,omitempty"`
 	MaxCallSendMsgSize       int      `json:"maxCallSendMsgSize,omitempty"`
 	EmbeddedEtcdQuotaBytes   int64    `json:"embeddedEtcdQuotaBytes,omitempty"`
+	AutoCompactionMode       string   `json:"autoCompactionMode,omitempty"`
+	AutoCompactionRetention  string   `json:"autoCompactionRetention,omitempty"`
 }
 
 type initIndex int

--- a/pkg/snapshot/restorer/types.go
+++ b/pkg/snapshot/restorer/types.go
@@ -38,7 +38,7 @@ const (
 	defaultMaxTxnOps                = 10 * 1024
 	defaultEmbeddedEtcdQuotaBytes   = 8 * 1024 * 1024 * 1024 //8Gib
 	defaultAutoCompactionMode       = "periodic"             // only 2 mode is supported: 'periodic' or 'revision'
-	defaultAutoCompactionRetention  = "5m"
+	defaultAutoCompactionRetention  = "30m"
 )
 
 // Restorer is a struct for etcd data directory restorer


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce the auto-compaction-mode and auto-compaction-retention CLI flags for embedded ETCD to use auto-compaction during restoration.

Updated the helm-charts to run auto-compaction on Etcd as well as on embedded-Etcd of etcd-backup-restore sidecar.

**Which issue(s) this PR fixes**:
Fixes  # [136](https://github.com/gardener/etcd-druid/issues/136) (Partially)

**Special notes for your reviewer**:

**Release note**:
```improvement user
Added CLI flags `--auto-compaction-mode` and `--auto-compaction-retention` to configure auto-compaction for embedded etcd. Default values: auto-compaction-mode="periodic" and auto-compaction-retention="30m"
```
