### PR TITLE
depend on publish-trait rather than injected step(s)

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -36,7 +36,7 @@ etcd-backup-restore:
         draft_release: ~
       steps:
         tm_test:
-          depends:
+          trait_depends:
           - publish
           image: eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable
           execute:
@@ -65,7 +65,7 @@ etcd-backup-restore:
         component_descriptor: ~
       steps:
         tm_test:
-          depends:
+          trait_depends:
           - publish
           image: eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable
           execute:


### PR DESCRIPTION
**What this PR does / why we need it**:
prepares switch to kaniko-builder

**Special notes for your reviewer**:

