### PR TITLE
Added new metric to capture any snapshotter error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ default.etcd*
 # developers workspace
 tmp
 dev
+*.DS_Store

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -31,10 +31,13 @@ const (
 	ValueSucceededFalse = "false"
 	// LabelKind is a metrics label indicates kind of snapshot associated with metric.
 	LabelKind = "kind"
+	//LabelError is a metric error to indicate error occured
+	LabelError = "error"
 
-	namespaceEtcdBR    = "etcdbr"
-	subsystemSnapshot  = "snapshot"
-	subsystemSnapstore = "snapstore"
+	namespaceEtcdBR      = "etcdbr"
+	subsystemSnapshot    = "snapshot"
+	subsystemSnapstore   = "snapstore"
+	subsystemSnapshotter = "snapshotter"
 )
 
 var (
@@ -152,6 +155,17 @@ var (
 			Help:      "Total number of revisions stored in delta snapshots taken since the latest full snapshot.",
 		},
 		[]string{},
+	)
+
+	//SnapshotterOperationFailure is metric to count the number of snapshotter operations that have errored out
+	SnapshotterOperationFailure = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespaceEtcdBR,
+			Subsystem: subsystemSnapshotter,
+			Name:      "failure",
+			Help:      "Total number of snapshotter errors.",
+		},
+		[]string{LabelError},
 	)
 )
 
@@ -319,6 +333,9 @@ func init() {
 	// SnapstoreLatestDeltasSize
 	SnapstoreLatestDeltasRevisionsTotal.With(prometheus.Labels(map[string]string{}))
 
+	//SnapshotterOperationFailure
+	SnapshotterOperationFailure.With(prometheus.Labels(map[string]string{LabelError: ""}))
+
 	// Metrics have to be registered to be exposed:
 	prometheus.MustRegister(GCSnapshotCounter)
 
@@ -333,4 +350,6 @@ func init() {
 
 	prometheus.MustRegister(SnapstoreLatestDeltasTotal)
 	prometheus.MustRegister(SnapstoreLatestDeltasRevisionsTotal)
+
+	prometheus.MustRegister(SnapshotterOperationFailure)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding a new metric `etcdbr_snapshotter_failure` used as a blanket metric to capture any snapshotter error. This will be used to add an alert to the gardener prometheus dashboard to alert the DoD of any backup sidecar error wrt any snapshotter operation failure.
This is a precursor to allowing etcd to serve traffic when the backup sidecar is starting up/restarting 

**Which issue(s) this PR fixes**:
Fixes partially #325 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Added a new metric `etcdbr_snapshotter_failure` used as a blanket metric to capture any snapshotter error. 
```
