### PR TITLE
Cleanup pipeline definitions

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,4 +1,18 @@
 etcd-backup-restore:
+  inherit:
+    tm_test_default: &tm_test_default
+      trait_depends:
+      - publish
+      image: eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable
+      execute:
+      - tm-tests-playground
+      - --flavor-tm-chart=etcd
+      - --landscape=playground
+      - --tm-landscape=external
+      - --
+      - --testrun-prefix=playground
+      - --set=projectNamespace=garden-it
+
   template: 'default'
   base_definition:
     repo: ~
@@ -36,20 +50,13 @@ etcd-backup-restore:
         draft_release: ~
       steps:
         tm_test:
-          trait_depends:
-          - publish
-          image: eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable
-          execute:
-          - tm-tests-playground
-          - --flavor-tm-chart=etcd
-          - --landscape=playground
-          - --tm-landscape=external
-          - --
-          - --testrun-prefix=playground
-          - --set=projectNamespace=garden-it
+          <<: *tm_test_default
     pull-request:
       traits:
         pull-request: ~
+      steps:
+        tm_test:
+          <<: *tm_test_default
     release:
       traits:
         version:
@@ -65,14 +72,4 @@ etcd-backup-restore:
         component_descriptor: ~
       steps:
         tm_test:
-          trait_depends:
-          - publish
-          image: eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable
-          execute:
-          - tm-tests-playground
-          - --flavor-tm-chart=etcd
-          - --landscape=playground
-          - --tm-landscape=external
-          - --
-          - --testrun-prefix=playground
-          - --set=projectNamespace=garden-it
+          <<: *tm_test_default

--- a/doc/usage/generating_ssl_certificates.md
+++ b/doc/usage/generating_ssl_certificates.md
@@ -103,10 +103,11 @@ subjectAltName = @alt_names
 
 [ alt_names ]
 DNS.1 = main-etcd-0
-DNS.2 = main-etcd-client
-DNS.3 = main-etcd-client.mynamespace
-DNS.4 = main-etcd-client.mynamespace.svc
-DNS.5 = main-etcd-client.mynamespace.svc.cluster.local
+DNS.2 = main-etcd-local
+DNS.3 = main-etcd-client
+DNS.4 = main-etcd-client.mynamespace
+DNS.5 = main-etcd-client.mynamespace.svc
+DNS.6 = main-etcd-client.mynamespace.svc.cluster.local
 
 [ v3_ext ]
 keyUsage=critical,digitalSignature,keyEncipherment
@@ -139,10 +140,11 @@ Follow the same steps as [generating TLS key-pair for etcd](#generating-tls-key-
 [ alt_names ]
 DNS.1 = localhost
 DNS.2 = main-backup-0
-DNS.3 = main-backup-client
-DNS.4 = main-backup-client.mynamespace
-DNS.5 = main-backup-client.mynamespace.svc
-DNS.6 = main-backup-client.mynamespace.svc.cluster.local
+DNS.3 = main-backup-local
+DNS.4 = main-backup-client
+DNS.5 = main-backup-client.mynamespace
+DNS.6 = main-backup-client.mynamespace.svc
+DNS.7 = main-backup-client.mynamespace.svc.cluster.local
 ```
 
 Here, we add `localhost` to the DNS entries so that the etcd bootstrap script may be allowed to trigger data initialization on the backup sidecar via HTTPS.


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR cleans up the pipeline definitions by introducing yaml anchors for the `tm_test` step to avoid redundancy.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
