### PR TITLE
Updated number of chunks while uploading to never exceed the cloud provider limits.

### DIFF
--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -43,7 +43,8 @@ type GCSSnapStore struct {
 }
 
 const (
-	gcsNoOfChunk int64 = 32
+	// Total number of chunks to be uploaded must be one less than maximum limit allowed.
+	gcsNoOfChunk int64 = 31
 )
 
 // NewGCSSnapStore create new GCSSnapStore from shared configuration with specified bucket.

--- a/pkg/snapstore/oss_snapstore.go
+++ b/pkg/snapstore/oss_snapstore.go
@@ -40,7 +40,8 @@ type OSSBucket interface {
 }
 
 const (
-	ossNoOfChunk    int64 = 10000
+	// Total number of chunks to be uploaded must be one less than maximum limit allowed.
+	ossNoOfChunk    int64 = 9999
 	ossEndPoint           = "ALICLOUD_ENDPOINT"
 	accessKeyID           = "ALICLOUD_ACCESS_KEY_ID"
 	accessKeySecret       = "ALICLOUD_ACCESS_KEY_SECRET"

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -34,7 +34,8 @@ import (
 )
 
 const (
-	s3NoOfChunk int64 = 10000 //Default configuration in swift installation
+	// Total number of chunks to be uploaded must be one less than maximum limit allowed.
+	s3NoOfChunk int64 = 9999
 )
 
 // S3SnapStore is snapstore with AWS S3 object store as backend

--- a/pkg/snapstore/swift_snapstore.go
+++ b/pkg/snapstore/swift_snapstore.go
@@ -46,7 +46,8 @@ type SwiftSnapStore struct {
 }
 
 const (
-	swiftNoOfChunk int64 = 1000 //Default configuration in swift installation
+	// Total number of chunks to be uploaded must be one less than maximum limit allowed.
+	swiftNoOfChunk int64 = 999 //Default configuration in swift installation
 )
 
 // NewSwiftSnapStore create new SwiftSnapStore from shared configuration with specified bucket


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated the total number of chunks to one less than the maximum permitted value by each backup provider so that the number never goes beyond the permitted value.
**Which issue(s) this PR fixes**:
Fixes https://github.tools.sap/kubernetes-canary/issues-canary/issues/817
**Special notes for your reviewer**:
Hotfix to ETCD backup restore version 0.12.0
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Updated number of chunks while uploading to never exceed the cloud provider limits.
```
