### PR TITLE
Use testmachinery base image for integration_tests

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -24,7 +24,7 @@ etcd-backup-restore:
       unit_test:
         image: 'golang:1.14'
       integration_test:
-        image: 'eu.gcr.io/gardener-project/cc/job-image-golang:0.12.0'
+        image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'
       build:
         image: 'golang:1.14'
         output_dir: 'binary'


### PR DESCRIPTION
**What this PR does / why we need it**:
Use testmachinery base image for integration_tests

**Which issue(s) this PR fixes**:
Fix the integration tests pipeline step.
```
Traceback (most recent call last):
  File "/cc/utils/cli.py", line 230, in <module>
    main()
  File "/cc/utils/cli.py", line 99, in main
    parsed.func(parsed)
  File "/cc/utils/cli.py", line 219, in function_runner
    function(*function_args)
  File "/cc/utils/cli/gardener_ci/config.py", line 54, in attribute
    raw = _retrieve_model_element(cfg_type=cfg_type, cfg_name=cfg_name).raw
  File "/cc/utils/cli/gardener_ci/config.py", line 25, in _retrieve_model_element
    cfg_factory = ctx().cfg_factory()
  File "/usr/local/lib/python3.8/dist-packages/ctx.py", line 183, in cfg_factory
    factory = _cfg_factory_from_secrets_server()
  File "/usr/local/lib/python3.8/dist-packages/ctx.py", line 171, in _cfg_factory_from_secrets_server
    raw_dict = _secrets_server_client().retrieve_secrets()
  File "/usr/local/lib/python3.8/dist-packages/ccc/secrets_server.py", line 89, in retrieve_secrets
    return response.json()
  File "/usr/local/lib/python3.8/dist-packages/requests/models.py", line 898, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.8/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.8/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
