### PR TITLE
Set the auto-compaction fields for Embedded-Etcd.

### DIFF
--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -81,6 +81,8 @@ func StartEmbeddedEtcd(logger *logrus.Entry, ro *brtypes.RestoreOptions) (*embed
 	cfg.QuotaBackendBytes = ro.Config.EmbeddedEtcdQuotaBytes
 	cfg.MaxRequestBytes = ro.Config.MaxRequestBytes
 	cfg.MaxTxnOps = ro.Config.MaxTxnOps
+	cfg.AutoCompactionMode = ro.Config.AutoCompactionMode
+	cfg.AutoCompactionRetention = ro.Config.AutoCompactionRetention
 	cfg.Logger = "zap"
 	e, err := embed.StartEtcd(cfg)
 	if err != nil {

--- a/pkg/snapshot/restorer/restorer_test.go
+++ b/pkg/snapshot/restorer/restorer_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Running Restorer", func() {
 		maxTxnOps                      = 2 * 1024
 		embeddedEtcdQuotaBytes  int64  = 8 * 1024 * 1024 * 1024
 		autoCompactionMode      string = "periodic"
-		autoCompactionRetention string = "2m"
+		autoCompactionRetention string = "5m"
 	)
 
 	BeforeEach(func() {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -65,6 +65,8 @@ func StartEmbeddedEtcd(ctx context.Context, etcdDir string, logger *logrus.Entry
 	cfg.ACUrls = []url.URL{*acurl}
 	cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name)
 	cfg.Logger = "zap"
+	cfg.AutoCompactionMode = "periodic"
+	cfg.AutoCompactionRetention = "5m"
 	e, err := embed.StartEtcd(cfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Set the auto-compaction fields for Embedded-Etcd which were somehow got removed  in this  [commit](https://github.com/gardener/etcd-backup-restore/commit/1134755c1a5ca0626b2e9815e796b6d107c74fe8#diff-9547d8cc0c155be97c8e3a057b9351b6bf83108543f957fb8bac1adf111ccfaaL353-L354) of this [PR](https://github.com/gardener/etcd-backup-restore/pull/301). I think it happened while moving [StartEmbeddedEtcd](https://github.com/gardener/etcd-backup-restore/commit/1134755c1a5ca0626b2e9815e796b6d107c74fe8#diff-d67a01c5aa3ff7bb12c7e9945be604ac31bd8a766f5962760de4d8223e639aedR65-R99) to a different [package](https://github.com/gardener/etcd-backup-restore/blob/master/pkg/miscellaneous/miscellaneous.go).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```improvement operator
NONE
```
