### PR TITLE
Fix TM test infra credential fetching

### DIFF
--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -270,24 +270,26 @@ function run_test_on_cluster() {
 }
 
 function run_test_on_tm() {
-  if [ "$ACCESS_KEY_ID" == "" ] || [ "$SECRET_ACCESS_KEY" == "" ] || [ "$AWS_REGION" == "" ] ; then
+  if [ "$ACCESS_KEY_ID" == "" ] || [ "$SECRET_ACCESS_KEY_B64" == "" ] || [ "$AWS_REGION" == "" ] ; then
     echo "AWS S3 credentials unavailable. Exiting."
     exit 1
   fi
+  export SECRET_ACCESS_KEY=`echo $SECRET_ACCESS_KEY_B64 | base64 -d`
   export REGION=$AWS_REGION
 
   get_tm_test_id
   export STORAGE_CONTAINER=$TEST_ID
   export ETCDBR_VER=$EFFECTIVE_VERSION
+
   setup_awscli
   write_aws_secret "${ACCESS_KEY_ID}" "${SECRET_ACCESS_KEY}" "${REGION}"
   create_s3_bucket
 
-  INTEGRATION_TEST_KUBECONFIG=$TM_KUBECONFIG_PATH/shoot.config
+  export INTEGRATION_TEST_KUBECONFIG=$TM_KUBECONFIG_PATH/shoot.config
   echo "Starting integration tests on TM cluster $PROJECT_NAMESPACE/$SHOOT_NAME."
   run_test_on_cluster
   echo "Done with integration test on TM cluster."
-  delete_s3_bucket
+  cleanup-aws-infrastructure
 }
 
 case $1 in

--- a/.ci/tm-tests-playground
+++ b/.ci/tm-tests-playground
@@ -8,6 +8,14 @@ TM_LANDSCAPE="external"
 LANDSCAPE=""
 ARGUMENTS=""
 
+function fetch_aws_secret() {
+  echo "Fetching aws credentials from secret server..."
+  export ACCESS_KEY_ID=`cli.py config attribute --cfg-type aws --cfg-name etcd-backup-restore --key access_key_id`
+  export SECRET_ACCESS_KEY=`cli.py config attribute --cfg-type aws --cfg-name etcd-backup-restore --key secret_access_key`
+  export SECRET_ACCESS_KEY_B64=`echo $SECRET_ACCESS_KEY | base64`
+  export REGION=`cli.py config attribute --cfg-type aws --cfg-name etcd-backup-restore --key region`
+  echo "Successfully fetched aws credentials from secret server."
+}
 
 for i in "$@"
 do
@@ -76,6 +84,8 @@ echo "Testmachinery landscape: ${TM_LANDSCAPE}"
 echo "Arguments: ${ARGUMENTS}"
 echo "EFFECTIVE_VERSION: ${EFFECTIVE_VERSION}"
 
+fetch_aws_secret
+
 export SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
 mkdir -p /tm
 TM_CLUSTER=/tm/kubeconfig
@@ -110,4 +120,7 @@ kubectl cluster-info
     --flavored-testruns-chart-path=$FLAVOR_TESTRUN_CHART_PATH \
     --flavor-config=$SOURCE_PATH/testmachinery/flavors/$FLAVOR_CONFIG \
     --set=shoot.effectiveVersion=$EFFECTIVE_VERSION \
+    --set=etcdbr.aws.accessKeyId=$ACCESS_KEY_ID \
+    --set=etcdbr.aws.secretAccessKey=$SECRET_ACCESS_KEY_B64 \
+    --set=etcdbr.aws.region=$REGION \
     $ARGUMENTS

--- a/testmachinery/testruns/etcd/templates/testrun.yaml
+++ b/testmachinery/testruns/etcd/templates/testrun.yaml
@@ -58,19 +58,13 @@ spec:
     value: {{ .Values.shoot.effectiveVersion }}
   - name: ACCESS_KEY_ID
     type: env
-    valueFrom:
-      secretKeyRef:
-        name: shoot-operator-aws
-        key: accessKeyID
-  - name: SECRET_ACCESS_KEY
+    value: {{ .Values.etcdbr.aws.accessKeyId }}
+  - name: SECRET_ACCESS_KEY_B64
     type: env
-    valueFrom:
-      secretKeyRef:
-        name: shoot-operator-aws
-        key: secretAccessKey
+    value: {{ .Values.etcdbr.aws.secretAccessKey }}
   - name: AWS_REGION
     type: env
-    value: eu-west-1
+    value: {{ .Values.etcdbr.aws.region }}
 
   # the execution flow:
   testflow:

--- a/testmachinery/testruns/etcd/values.yaml
+++ b/testmachinery/testruns/etcd/values.yaml
@@ -21,6 +21,12 @@ shoot:
   floatingPoolName: ""
   loadbalancerProvider: ""
 
+etcdbr:
+  aws:
+    accessKeyId: ""
+    secretAccessKey: ""
+    region: ""
+
 kubeconfigs:
   gardener: ""
   seed: ""


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR changes the infra secrets used for TM tests to the default CC secrets, due to recent permission-related changes to TM secrets.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
