### PR TITLE
Close etcd clients to fix potential memory leaks

### DIFF
--- a/pkg/defragmentor/defrag_test.go
+++ b/pkg/defragmentor/defrag_test.go
@@ -47,9 +47,9 @@ var _ = Describe("Defrag", func() {
 		BeforeEach(func() {
 			now := time.Now().Unix()
 			client, err := etcdutil.GetTLSClientForEtcd(etcdConnectionConfig)
+			Expect(err).ShouldNot(HaveOccurred())
 			defer client.Close()
 			logger.Infof("etcdConnectionConfig %v, Endpoint %v", etcdConnectionConfig, endpoints)
-			Expect(err).ShouldNot(HaveOccurred())
 			for index := 0; index <= 1000; index++ {
 				ctx, cancel := context.WithTimeout(testCtx, etcdConnectionConfig.ConnectionTimeout.Duration)
 				client.Put(ctx, fmt.Sprintf("%s%d%d", keyPrefix, now, index), valuePrefix)

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -298,6 +298,7 @@ func (b *BackupRestoreServer) probeEtcd(ctx context.Context) error {
 			Message: fmt.Sprintf("failed to create etcd client: %v", err),
 		}
 	}
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(ctx, b.config.EtcdConnectionConfig.ConnectionTimeout.Duration)
 	defer cancel()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a memory leak in the etcd probe loop resulting from not closing the etcd client in the `probeEtcd` function. Also close unclosed etcd clients in other parts of the code.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
