### PR TITLE
Fix endpoints parameters in document

### DIFF
--- a/doc/usage/getting_started.md
+++ b/doc/usage/getting_started.md
@@ -36,7 +36,7 @@ If using `LimitBased` policy, the `max-backups` flag should be provided to indic
 ```console
 $ ./bin/etcdbrctl snapshot  \
 --storage-provider="S3" \
---etcd-endpoints http://localhost:2379 \
+--endpoints http://localhost:2379 \
 --schedule "*/1 * * * *" \
 --store-container="etcd-backup" \
 --delta-snapshot-period=10s \


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix command parameters **endpoints** in getting started documents.
When I tried the `snapshot` command, it showed the error message "Error: unknown flag: --etcd-endpoints". I checked the code and tested it, the flag should be `--endpoints`. 

**Which issue(s) this PR fixes**:
NONE.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
