### PR TITLE
Mitigate timeout while taking FullSnapshot and while etcd defrag call

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -125,6 +125,8 @@ spec:
         - --defragmentation-schedule={{ .Values.backup.defragmentationSchedule }}
 {{- end }}
         - --etcd-connection-timeout={{ .Values.backup.etcdConnectionTimeout }}
+        - --etcd-snapshot-timeout={{ .Values.backup.etcdSnapshotTimeout }}
+        - --etcd-defrag-timeout={{ .Values.backup.etcdDefragTimeout}}
         - --delta-snapshot-period={{ .Values.backup.deltaSnapshotPeriod }}
         - --delta-snapshot-memory-limit={{ int $.Values.backup.deltaSnapshotMemoryLimit }}
 {{- if and .Values.etcdAuth.username .Values.etcdAuth.password }}

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -60,6 +60,8 @@ backup:
   garbageCollectionPeriod: "1m"
 
   etcdConnectionTimeout: "30s"
+  etcdSnapshotTimeout: "8m"
+  etcdDefragTimeout: "8m"
   # etcdQuotaBytes used to Raise alarms when backend DB size exceeds the given quota bytes
   etcdQuotaBytes: 8589934592 #8GB
 

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -129,7 +129,7 @@ func (c *initializerOptions) complete() {
 
 type compactOptions struct {
 	*restorerOptions
-	needDefragmentation bool
+	compactorConfig *brtypes.CompactorConfig
 }
 
 // newCompactOptions returns the validation config.
@@ -139,7 +139,7 @@ func newCompactOptions() *compactOptions {
 			restorationConfig: brtypes.NewRestorationConfig(),
 			snapstoreConfig:   snapstore.NewSnapstoreConfig(),
 		},
-		needDefragmentation: true,
+		compactorConfig: brtypes.NewCompactorConfig(),
 	}
 }
 
@@ -147,7 +147,12 @@ func newCompactOptions() *compactOptions {
 func (c *compactOptions) addFlags(fs *flag.FlagSet) {
 	c.restorationConfig.AddFlags(fs)
 	c.snapstoreConfig.AddFlags(fs)
-	fs.BoolVar(&c.needDefragmentation, "defragment", c.needDefragmentation, "defragment after compaction")
+	c.compactorConfig.AddFlags(fs)
+}
+
+// Validate validates the config.
+func (c *compactOptions) validate() error {
+	return c.compactorConfig.Validate()
 }
 
 type restorerOptions struct {

--- a/example/00-backup-restore-server-config.yaml
+++ b/example/00-backup-restore-server-config.yaml
@@ -4,6 +4,8 @@ etcdConnectionConfig:
   # username: admin
   # password: admin
   connectionTimeout: 10s
+  snapshotTimeout: 8m
+  defragTimeout: 8m
   # insecureTransport: true
   # insecureSkipVerify: true
   # certFile: "ssl/etcd/tls.crt"

--- a/pkg/defragmentor/defrag.go
+++ b/pkg/defragmentor/defrag.go
@@ -51,7 +51,7 @@ func (d *defragmentorJob) Run() {
 	}
 	defer client.Close()
 
-	defragCtx, defragCancel := context.WithTimeout(d.ctx, d.etcdConnectionConfig.ConnectionTimeout.Duration)
+	defragCtx, defragCancel := context.WithTimeout(d.ctx, d.etcdConnectionConfig.DefragTimeout.Duration)
 	err = etcdutil.DefragmentData(defragCtx, client, d.etcdConnectionConfig.Endpoints, d.logger)
 	defragCancel()
 	if err != nil {

--- a/pkg/defragmentor/defrag_test.go
+++ b/pkg/defragmentor/defrag_test.go
@@ -41,6 +41,8 @@ var _ = Describe("Defrag", func() {
 		etcdConnectionConfig = etcdutil.NewEtcdConnectionConfig()
 		etcdConnectionConfig.Endpoints = endpoints
 		etcdConnectionConfig.ConnectionTimeout.Duration = 30 * time.Second
+		etcdConnectionConfig.SnapshotTimeout.Duration = 30 * time.Second
+		etcdConnectionConfig.DefragTimeout.Duration = 30 * time.Second
 	})
 
 	Context("Defragmentation", func() {
@@ -89,7 +91,7 @@ var _ = Describe("Defrag", func() {
 		})
 
 		It("should keep size of DB same in case of timeout", func() {
-			etcdConnectionConfig.ConnectionTimeout.Duration = time.Microsecond
+			etcdConnectionConfig.DefragTimeout.Duration = time.Microsecond
 			client, err := etcdutil.GetTLSClientForEtcd(etcdConnectionConfig)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer client.Close()

--- a/pkg/etcdutil/types.go
+++ b/pkg/etcdutil/types.go
@@ -23,8 +23,12 @@ import (
 const (
 	defaultEtcdConnectionEndpoint string = "127.0.0.1:2379"
 
-	// DefaultDefragConnectionTimeout for timeout during ETCD defrag call
-	DefaultDefragConnectionTimeout time.Duration = 30 * time.Second
+	// DefaultEtcdConnectionTimeout defines default timeout duration for etcd client connection.
+	DefaultEtcdConnectionTimeout time.Duration = 30 * time.Second
+	// DefaultDefragConnectionTimeout defines default timeout duration for ETCD defrag call.
+	DefaultDefragConnectionTimeout time.Duration = 8 * time.Minute
+	// DefaultSnapshotTimeout defines default timeout duration for taking FullSnapshot.
+	DefaultSnapshotTimeout time.Duration = 8 * time.Minute
 )
 
 // EtcdConnectionConfig holds the etcd connection config.
@@ -35,6 +39,8 @@ type EtcdConnectionConfig struct {
 	Username           string            `json:"username,omitempty"`
 	Password           string            `json:"password,omitempty"`
 	ConnectionTimeout  wrappers.Duration `json:"connectionTimeout,omitempty"`
+	SnapshotTimeout    wrappers.Duration `json:"snapshotTimeout,omitempty"`
+	DefragTimeout      wrappers.Duration `json:"defragTimeout,omitempty"`
 	InsecureTransport  bool              `json:"insecureTransport,omitempty"`
 	InsecureSkipVerify bool              `json:"insecureSkipVerify,omitempty"`
 	CertFile           string            `json:"certFile,omitempty"`

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -290,7 +290,8 @@ func (ssr *Snapshotter) takeFullSnapshot() (*brtypes.Snapshot, error) {
 	if ssr.prevSnapshot.Kind == brtypes.SnapshotKindFull && ssr.prevSnapshot.LastRevision == lastRevision {
 		ssr.logger.Infof("There are no updates since last snapshot, skipping full snapshot.")
 	} else {
-		ctx, cancel = context.WithTimeout(context.TODO(), ssr.etcdConnectionConfig.ConnectionTimeout.Duration)
+		// Note: As FullSnapshot size can be very large, so to avoid context timeout use "SnapshotTimeout" in context.WithTimeout()
+		ctx, cancel = context.WithTimeout(context.TODO(), ssr.etcdConnectionConfig.SnapshotTimeout.Duration)
 		defer cancel()
 		// compressionSuffix is useful in backward compatibility(restoring from uncompressed snapshots).
 		// it is also helpful in inferring which compression Policy to be used to decompress the snapshot.

--- a/pkg/types/compactor.go
+++ b/pkg/types/compactor.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gardener/etcd-backup-restore/pkg/wrappers"
+	flag "github.com/spf13/pflag"
+)
+
+const (
+	// defaultDefragTimeout defines default timeout duration for ETCD defrag call during compaction of snapshots.
+	defaultDefragTimeout time.Duration = 8 * time.Minute
+	// defaultSnapshotTimeout defines default timeout duration for taking compacted FullSnapshot.
+	defaultSnapshotTimeout time.Duration = 8 * time.Minute
+)
+
+// CompactOptions holds all configurable options of compact.
+type CompactOptions struct {
+	*RestoreOptions
+	*CompactorConfig
+}
+
+// CompactorConfig holds all configuration options related to `compact` subcommand.
+type CompactorConfig struct {
+	NeedDefragmentation bool              `json:"needDefrag,omitempty"`
+	SnapshotTimeout     wrappers.Duration `json:"snapshotTimeout,omitempty"`
+	DefragTimeout       wrappers.Duration `json:"defragTimeout,omitempty"`
+}
+
+// NewCompactorConfig returns the CompactorConfig.
+func NewCompactorConfig() *CompactorConfig {
+	return &CompactorConfig{
+		NeedDefragmentation: true,
+		SnapshotTimeout:     wrappers.Duration{Duration: defaultSnapshotTimeout},
+		DefragTimeout:       wrappers.Duration{Duration: defaultDefragTimeout},
+	}
+}
+
+// AddFlags adds the flags to flagset.
+func (c *CompactorConfig) AddFlags(fs *flag.FlagSet) {
+	fs.BoolVar(&c.NeedDefragmentation, "defragment", c.NeedDefragmentation, "defragment after compaction")
+	fs.DurationVar(&c.SnapshotTimeout.Duration, "etcd-snapshot-timeout", c.SnapshotTimeout.Duration, "timeout duration for taking compacted full snapshots")
+	fs.DurationVar(&c.DefragTimeout.Duration, "etcd-defrag-timeout", c.DefragTimeout.Duration, "timeout duration for etcd defrag call during compaction.")
+}
+
+// Validate validates the config.
+func (c *CompactorConfig) Validate() error {
+	if c.SnapshotTimeout.Duration <= 0 {
+		return fmt.Errorf("snapshot timeout should be greater than zero")
+
+	}
+	if c.DefragTimeout.Duration <= 0 {
+		return fmt.Errorf("etcd defrag timeout should be greater than zero")
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
As FullSnapshot can be very large, so to avoid timeout in `context.WithTimeout()` and to configure a longer context timeout we have Introduced `--etcd-snapshot-timeout`  CLI flag in both `server` subcommand and in `compact` subcommand to take large etcd FullSnapshots and to take large compacted FullSnapshots, respectively.

As Etcd Defragmentation call can also be time taking for big `Etcd`, so to avoid timeout in `context.WithTimeout()` and to configure a longer context timeout we have Introduced `--etcd-defrag-timeout` CLI flags in both `server` subcommand and in `compact` subcommand for etcd defrag call.


**Which issue(s) this PR fixes**:
Fixes #360 
Fixes #366 

**Special notes for your reviewer**:
Default values for all the flags are set to `8m`.

**Release note**:
```improvement operator
Added '--etcd-snapshot-timeout' and '--etcd-defrag-timeout' CLI flags in 'server' and 'compact' subcommands
```
