### PR TITLE
Propagated data directory from user flags to compaction.

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -59,7 +59,11 @@ func (cp *Compactor) Compact(ro *brtypes.RestoreOptions, needDefragmentation boo
 	}
 
 	// Set a temporary etcd data directory for embedded etcd
-	cmpctDir, err := ioutil.TempDir("/tmp", "compactor-")
+	prefix := cmpctOptions.Config.RestoreDataDir
+	if prefix == "" {
+		prefix = "/tmp"
+	}
+	cmpctDir, err := ioutil.TempDir(prefix, "compactor-")
 	if err != nil {
 		cp.logger.Errorf("Unable to create temporary etcd directory for compaction: %s", err.Error())
 		return nil, err

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -63,15 +63,16 @@ var _ = Describe("Running Compactor", func() {
 			cptr = compactor.NewCompactor(store, logger)
 			restoreOpts = &brtypes.RestoreOptions{
 				Config: &brtypes.RestorationConfig{
-					InitialClusterToken:      restoreClusterToken,
 					InitialCluster:           restoreCluster,
-					Name:                     restoreName,
+					InitialClusterToken:      restoreClusterToken,
+					RestoreDataDir:           "/tmp",
 					InitialAdvertisePeerURLs: restorePeerURLs,
+					Name:                     restoreName,
 					SkipHashCheck:            skipHashCheck,
 					MaxFetchers:              maxFetchers,
-					MaxCallSendMsgSize:       maxCallSendMsgSize,
 					MaxRequestBytes:          maxRequestBytes,
 					MaxTxnOps:                maxTxnOps,
+					MaxCallSendMsgSize:       maxCallSendMsgSize,
 					EmbeddedEtcdQuotaBytes:   embeddedEtcdQuotaBytes,
 				},
 				ClusterURLs: clusterUrlsMap,


### PR DESCRIPTION
**What this PR does / why we need it**:
So far, users are provided with `--data-dir` flag for compaction subcommand but that was not really propagated to compaction as it was using it was setting it's own data-dir [https://github.com/gardener/etcd-backup-restore/blob/1638bef219bef7c5367875d78f8cd6a83ca5c539/pkg/compactor/compactor.go#L70](https://github.com/gardener/etcd-backup-restore/blob/1638bef219bef7c5367875d78f8cd6a83ca5c539/pkg/compactor/compactor.go#L70)

This PR propagates the options provided through `--data-dir` flag and propagate to compaction.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
