### PR TITLE
Temporarily drop TM tests from pipeline

### DIFF
--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -42,6 +42,10 @@ export GOBIN="${SOURCE_PATH}/bin"
 export PATH="${GOBIN}:${PATH}"
 cd "${SOURCE_PATH}"
 
+if [ "$USE_CC_SERVER_CACHE" == true ] ; then
+  export CC_CACHE_FILE_FLAG="--cache-file dev/server.cache"
+fi
+
 ##############################################################################
 
 # Declare global variables
@@ -59,9 +63,10 @@ function setup_test_environment() {
   setup_awscli
 }
 
-function setup_ginkgo(){
+function setup_ginkgo() {
     echo "Installing Ginkgo..."
     GO111MODULE=off go get -u github.com/onsi/ginkgo/ginkgo
+    ginkgo version
     echo "Successfully installed Ginkgo."
 }
 
@@ -133,9 +138,9 @@ EOF
 
 function create_aws_secret() {
   echo "Fetching aws credentials from secret server..."
-  export ACCESS_KEY_ID=`/cc/utils/cli.py config attribute --cfg-type aws --cfg-name etcd-backup-restore --key access_key_id`
-  export SECRET_ACCESS_KEY=`/cc/utils/cli.py config attribute --cfg-type aws --cfg-name etcd-backup-restore --key secret_access_key`
-  export REGION=`/cc/utils/cli.py config attribute --cfg-type aws --cfg-name etcd-backup-restore --key region`
+  export ACCESS_KEY_ID=`/cc/utils/cli.py config $CC_CACHE_FILE_FLAG attribute --cfg-type aws --cfg-name etcd-backup-restore --key access_key_id`
+  export SECRET_ACCESS_KEY=`/cc/utils/cli.py config $CC_CACHE_FILE_FLAG attribute --cfg-type aws --cfg-name etcd-backup-restore --key secret_access_key`
+  export REGION=`/cc/utils/cli.py config $CC_CACHE_FILE_FLAG attribute --cfg-type aws --cfg-name etcd-backup-restore --key region`
   echo "Successfully fetched aws credentials from secret server."
 
   write_aws_secret "${ACCESS_KEY_ID}" "${SECRET_ACCESS_KEY}" "${REGION}"
@@ -239,10 +244,10 @@ function run_test_on_cluster() {
     setup-aws-infrastructure
   fi
 
-  export ETCD_VERSION=${ETCD_VERSION:-"v3.4.13-bootstrap"}
+  export ETCD_VERSION=${ETCD_VERSION:-"v3.4.13-bootstrap-1"}
   echo "Etcd version: ${ETCD_VERSION}"
 
-  export ETCDBR_VERSION=${ETCDBR_VERSION:-${ETCDBR_VER:-"v0.12.0"}}
+  export ETCDBR_VERSION=${ETCDBR_VERSION:-${ETCDBR_VER:-"v0.12.1"}}
   echo "Etcd-backup-restore version: ${ETCDBR_VERSION}"
 
   echo "Starting integration tests on k8s cluster."
@@ -250,7 +255,7 @@ function run_test_on_cluster() {
   set +e
 
   if [ -r "$INTEGRATION_TEST_KUBECONFIG" ]; then
-    KUBECONFIG=$INTEGRATION_TEST_KUBECONFIG STORAGE_CONTAINER=$TEST_ID ginkgo -v -timeout=15m -mod=vendor test/e2e/integrationcluster
+    KUBECONFIG=$INTEGRATION_TEST_KUBECONFIG ginkgo -v -timeout=15m -mod=vendor test/e2e/integrationcluster
     TEST_RESULT=$?
     echo "Successfully completed all tests."
   else

--- a/.ci/performance_regression_test
+++ b/.ci/performance_regression_test
@@ -41,7 +41,7 @@ if [ "$PERF_TEST_KUBECONFIG" == "" ]; then
   PERF_TEST_KUBECONFIG=$TM_KUBECONFIG_PATH/shoot.config
 fi
 
-ETCD_VERSION=${ETCD_VERSION:-"v3.4.13-bootstrap"}
+ETCD_VERSION=${ETCD_VERSION:-"v3.4.13-bootstrap-1"}
 if [ "$ETCD_VERSION" != "" ]; then
   ETCD_IMAGE=${ETCD_IMAGE:-"eu.gcr.io/gardener-project/gardener/etcd:$ETCD_VERSION"}
 fi

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -48,15 +48,9 @@ etcd-backup-restore:
       traits:
         component_descriptor: ~
         draft_release: ~
-      steps:
-        tm_test:
-          <<: *tm_test_default
     pull-request:
       traits:
         pull-request: ~
-      steps:
-        tm_test:
-          <<: *tm_test_default
     release:
       traits:
         version:
@@ -70,6 +64,3 @@ etcd-backup-restore:
               channel_name: 'C0177NLL8V9' # gardener-etcd
               slack_cfg_name: 'scp_workspace'
         component_descriptor: ~
-      steps:
-        tm_test:
-          <<: *tm_test_default

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -2,12 +2,12 @@ images:
   # etcd image to use
   etcd:
     repository: eu.gcr.io/gardener-project/gardener/etcd
-    tag: v3.4.13-bootstrap
+    tag: v3.4.13-bootstrap-1
     pullPolicy: IfNotPresent
   # etcd-backup-restore image to use
   etcdBackupRestore:
     repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-    tag: v0.12.0
+    tag: v0.12.1
     pullPolicy: IfNotPresent
 
 resources:

--- a/doc/development/testing_and_dependencies.md
+++ b/doc/development/testing_and_dependencies.md
@@ -42,8 +42,8 @@ make integration-test-cluster
 :warning: Prerequisite for this command is to set the following environment variables:
 
 - INTEGRATION_TEST_KUBECONFIG: kubeconfig to the cluster on which you wish to run the test
-- ETCD_VERSION: optional, defaults to `v3.4.13-bootstrap`
-- ETCDBR_VERSION: optional, defaults to `v0.12.0`
+- ETCD_VERSION: optional, defaults to `v3.4.13-bootstrap-1`
+- ETCDBR_VERSION: optional, defaults to `v0.12.1`
 - ACCESS_KEY_ID: S3 credentials
 - SECRET_ACCESS_KEY: S3 credentials
 - REGION: S3 credentials


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
Due to issues with pulling secrets for running TM tests in the pipeline, this PR will temporarily drop TM tests from the pipeline to unblock the tests and releases on the repo. Also added better support to run cluster-based integration test locally.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
For future PR merges, please run the cluster-based integration tests locally and attach the logs in the PR before merging.  

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
