### PR TITLE
Adding copy operation and additional authentication parameters forsource and target

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/gardener/etcd-backup-restore/pkg/snapshot/copier"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// NewCopyCommand creates a cobra command for copy.
+func NewCopyCommand(ctx context.Context) *cobra.Command {
+	opts := newCopierOptions()
+	var command = &cobra.Command{
+		Use:   "copy",
+		Short: "copy data between buckets",
+		Long:  `Copy data between buckets`,
+		Run: func(cmd *cobra.Command, args []string) {
+			printVersionInfo()
+			logger := logrus.NewEntry(logrus.New())
+			if err := opts.validate(); err != nil {
+				logger.Fatalf("failed to validate the options: %v", err)
+			}
+			opts.complete()
+
+			sourceStorage, destStorage, err := copier.GetSourceAndDestinationStores(opts.sourceSnapStoreConfig, opts.snapstoreConfig)
+			if err != nil {
+				logger.Fatalf("Could not get source and destination snapstores: %v", err)
+			}
+
+			copier := copier.NewCopier(sourceStorage, destStorage, logger, opts.maxBackups, opts.maxBackupAge)
+			if err := copier.Run(); err != nil {
+				logger.Fatalf("Copy operation failed: %v", err)
+			}
+
+			logger.Info("Shutting down...")
+		},
+	}
+	opts.addFlags(command.Flags())
+	return command
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,7 @@ from previously taken snapshot.`,
 		NewRestoreCommand(ctx),
 		NewCompactCommand(ctx),
 		NewInitializeCommand(ctx),
-		NewServerCommand(ctx))
+		NewServerCommand(ctx),
+		NewCopyCommand(ctx))
 	return RootCmd
 }

--- a/doc/usage/getting_started.md
+++ b/doc/usage/getting_started.md
@@ -144,3 +144,35 @@ INFO[0008] Successfully restored the etcd data directory.
 ### Etcdbrctl server
 
 With sub-command `server` you can start a http server which exposes an endpoint to initialize etcd over REST interface. The server also keeps the backup schedule thread running to keep taking periodic backups. This is mainly made available to manage an etcd instance running in a Kubernetes cluster. You can deploy the example [helm chart](../../chart/etcd-backup-restore) on a Kubernetes cluster to have a fault-resilient, self-healing etcd cluster.
+
+## Etcdbrctl copy
+
+With sub-command `copy` you can copy all snapshots (Full and Delta) fom one snapstore to another. Using the two filter parameters `max-backups-to-copy` and `max-backup-age` you can also limit the number of snapshots that will be copied or target only the newest snapshots.
+
+```console
+$ ./bin/etcdbrctl copy \
+--storage-provider="GCS" \
+--snapstore-temp-directory="/temp" \
+--store-prefix="target-prefix" \
+--store-container="target-container" \
+--source-store-prefix="prefix" \
+--source-store-container="container" \
+--source-storage-provider="GCS" \
+--max-backup-age=15 \
+INFO[0000] etcd-backup-restore Version: v0.14.0-dev     
+INFO[0000] Git SHA: b821ee55                            
+INFO[0000] Go Version: go1.16.5                         
+INFO[0000] Go OS/Arch: darwin/amd64                     
+INFO[0000] Getting source backups...                     actor=copier
+...
+INFO[0026] Copying Incr snapshot Incr-ID.gz...  actor=copier
+INFO[0027] Uploading snapshot of size: 123456, chunkSize: 123456, noOfChunks: 1
+INFO[0027] Triggered chunk upload for all chunks, total: 1
+INFO[0027] No of Chunks:= 1
+INFO[0027] Uploading chunk with offset : 0, attempt: 0
+INFO[0027] Received chunk result for id: 1, offset: 0
+INFO[0027] Received successful chunk result for all chunks. Stopping workers.
+INFO[0027] All chunk uploaded successfully. Uploading composite object.
+INFO[0027] Composite object uploaded successfully.
+INFO[0027] Shutting down...
+```

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	k8s.io/api v0.18.0
 	k8s.io/apimachinery v0.18.0
 	k8s.io/client-go v11.0.0+incompatible
+	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
 	rsc.io/letsencrypt v0.0.3 // indirect
 )
 

--- a/pkg/miscellaneous/miscellaneous_suite_test.go
+++ b/pkg/miscellaneous/miscellaneous_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package miscellaneous
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestRestorer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Miscellaneous")
+}

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package miscellaneous
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"time"
+
+	"github.com/gardener/etcd-backup-restore/pkg/types"
+	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	snapList types.SnapList
+	ds       DummyStore
+)
+
+const (
+	generatedSnaps = 20
+)
+
+var _ = Describe("Filtering snapshots", func() {
+	BeforeEach(func() {
+		snapList = generateSnapshotList(generatedSnaps)
+		ds = NewDummyStore(snapList)
+
+	})
+	It("should return the whole snaplist", func() {
+		snaps, err := GetFilteredBackups(&ds, -1, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(snaps)).To(Equal(len(snapList)))
+	})
+	It("should get the last 3 snapshots and its deltas", func() {
+		n := 3
+		snaps, err := GetFilteredBackups(&ds, n, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(snaps)).To(Equal(n * 2))
+		expectedSnapID := 0
+		for i := 0; i < n; i++ {
+			if reflect.DeepEqual(snaps[i].Kind, types.SnapshotKindFull) {
+				Expect(snaps[i].SnapName).To(Equal(fmt.Sprintf("%s-%d", types.SnapshotKindFull, expectedSnapID)))
+				Expect(snaps[i+1].SnapName).To(Equal(fmt.Sprintf("%s-%d", types.SnapshotKindDelta, expectedSnapID)))
+				expectedSnapID++
+			}
+		}
+	})
+	It("should get the last backups created in the past 5 days", func() {
+		n := 5
+		backups, err := GetFilteredBackups(&ds, n, func(snap types.Snapshot) bool {
+			return snap.CreatedOn.After(time.Now().UTC().AddDate(0, 0, -n))
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(backups)).To(Equal(n * 2))
+		for i := 0; i < n; i++ {
+			if reflect.DeepEqual(backups[i].Kind, types.SnapshotKindFull) {
+				backups[i].CreatedOn.After(time.Now().UTC().AddDate(0, 0, -n))
+			}
+		}
+	})
+})
+
+func generateSnapshotList(n int) types.SnapList {
+	snapList := types.SnapList{}
+	for i := 0; i < n; i++ {
+		fullSnap := &types.Snapshot{
+			SnapName:  fmt.Sprintf("%s-%d", types.SnapshotKindFull, i),
+			Kind:      types.SnapshotKindFull,
+			CreatedOn: time.Now().UTC().AddDate(0, 0, -i),
+		}
+		deltaSnap := &types.Snapshot{
+			SnapName:  fmt.Sprintf("%s-%d", types.SnapshotKindDelta, i),
+			Kind:      types.SnapshotKindDelta,
+			CreatedOn: time.Now().UTC().AddDate(0, 0, -i),
+		}
+		snapList = append(snapList, fullSnap, deltaSnap)
+	}
+	return snapList
+}
+
+type DummyStore struct {
+	SnapList types.SnapList
+}
+
+func NewDummyStore(snapList types.SnapList) DummyStore {
+	return DummyStore{SnapList: snapList}
+}
+
+func (ds *DummyStore) List() (types.SnapList, error) {
+	return ds.SnapList, nil
+}
+
+func (ds *DummyStore) Delete(s brtypes.Snapshot) error {
+	return nil
+}
+
+func (ds *DummyStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
+	return nil
+}
+
+func (ds *DummyStore) Fetch(snap brtypes.Snapshot) (io.ReadCloser, error) {
+	return nil, nil
+}

--- a/pkg/snapshot/copier/copier.go
+++ b/pkg/snapshot/copier/copier.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package copier
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
+	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
+	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetSourceAndDestinationStores returns the source and destination stores for the given source and destination and store configs.
+func GetSourceAndDestinationStores(sourceSnapStoreConfig *brtypes.SnapstoreConfig, destSnapStoreConfig *brtypes.SnapstoreConfig) (brtypes.SnapStore, brtypes.SnapStore, error) {
+	sourceSnapStore, err := snapstore.GetSnapstore(sourceSnapStoreConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not get source snapstore: %v", err)
+	}
+
+	destSnapStore, err := snapstore.GetSnapstore(destSnapStoreConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not get destination snapstore: %v", err)
+	}
+
+	return sourceSnapStore, destSnapStore, nil
+}
+
+// Copier can be used to copy backups from a source to a destination store.
+type Copier struct {
+	logger          *logrus.Entry
+	sourceSnapStore brtypes.SnapStore
+	destSnapStore   brtypes.SnapStore
+	maxBackups      int
+	maxBackupAge    int
+}
+
+// NewCopier creates a new copier.
+func NewCopier(sourceSnapStore brtypes.SnapStore, destSnapStore brtypes.SnapStore, logger *logrus.Entry, maxBackups int, maxBackupAge int) *Copier {
+	return &Copier{
+		logger:          logger.WithField("actor", "copier"),
+		sourceSnapStore: sourceSnapStore,
+		destSnapStore:   destSnapStore,
+		maxBackups:      maxBackups,
+		maxBackupAge:    maxBackupAge,
+	}
+}
+
+// Run executes the copy command.
+func (c *Copier) Run() error {
+	return c.CopyBackups()
+}
+
+// CopyBackups copies all backups from the source store to the destination store.
+func (c *Copier) CopyBackups() error {
+	// Get source backups
+	c.logger.Info("Getting source backups...")
+	sourceSnapshot, err := c.getSnapshots()
+	if err != nil {
+		return fmt.Errorf("could not get source backups: %v", err)
+	}
+
+	// If there are no source backups, do nothing
+	if len(sourceSnapshot) == 0 {
+		c.logger.Info("No source backups found")
+		return nil
+	}
+
+	// Get destination snapshots and build a map keyed by name
+	c.logger.Info("Getting destination snapshots...")
+	destSnapshots, err := c.destSnapStore.List()
+	if err != nil {
+		return fmt.Errorf("could not get destination snapshots: %v", err)
+	}
+	destSnapshotsMap := make(map[string]*brtypes.Snapshot)
+	for _, snapshot := range destSnapshots {
+		destSnapshotsMap[snapshot.SnapName] = snapshot
+	}
+
+	for _, snapshot := range sourceSnapshot {
+		// Copy all the snapshots (if not already copied)
+		if _, ok := destSnapshotsMap[snapshot.SnapName]; !ok {
+			c.logger.Infof("Copying %s snapshot %s...", snapshot.Kind, snapshot.SnapName)
+			if err := c.copySnapshot(snapshot); err != nil {
+				return err
+			}
+		} else {
+			c.logger.Infof("Skipping %s snapshot %s as it already exists", snapshot.Kind, snapshot.SnapName)
+		}
+	}
+	return nil
+}
+
+func (c *Copier) getSnapshots() (brtypes.SnapList, error) {
+	if c.maxBackupAge >= 0 {
+		return miscellaneous.GetFilteredBackups(c.sourceSnapStore, c.maxBackups, func(snap brtypes.Snapshot) bool {
+			return snap.CreatedOn.After(time.Now().UTC().AddDate(0, 0, -c.maxBackupAge))
+		})
+	}
+	return miscellaneous.GetFilteredBackups(c.sourceSnapStore, c.maxBackups, nil)
+}
+
+func (c *Copier) copySnapshot(snapshot *brtypes.Snapshot) error {
+	rc, err := c.sourceSnapStore.Fetch(*snapshot)
+	if err != nil {
+		return fmt.Errorf("could not fetch snapshot %s from source store: %v", snapshot.SnapName, err)
+	}
+
+	if err := c.destSnapStore.Save(*snapshot, rc); err != nil {
+		return fmt.Errorf("could not save snapshot %s to destination store: %v", snapshot.SnapName, err)
+	}
+
+	return nil
+}

--- a/pkg/snapshot/copier/copier_suite_test.go
+++ b/pkg/snapshot/copier/copier_suite_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package copier_test
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gardener/etcd-backup-restore/pkg/compressor"
+	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+	"github.com/gardener/etcd-backup-restore/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"go.etcd.io/etcd/embed"
+)
+
+const (
+	outputDir          = "../../../test/output"
+	etcdDir            = outputDir + "/default.etcd"
+	snapstoreDir       = outputDir + "/snapshotter.bkp"
+	targetSnapstoreDir = outputDir + "/snapshotter-target.bkp"
+)
+
+var (
+	testCtx   = context.Background()
+	logger    = logrus.New().WithField("suite", "copier")
+	etcd      *embed.Etcd
+	err       error
+	keyTo     int
+	endpoints []string
+)
+
+func TestRestorer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Copier Suite")
+}
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	var (
+		data []byte
+	)
+
+	err = os.RemoveAll(outputDir)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger)
+	Expect(err).ShouldNot(HaveOccurred())
+	endpoints = []string{etcd.Clients[0].Addr().String()}
+	logger.Infof("endpoints: %s", endpoints)
+
+	Expect(err).ShouldNot(HaveOccurred())
+	defer func() {
+		etcd.Server.Stop()
+		etcd.Close()
+	}()
+	populatorCtx, cancelPopulator := context.WithTimeout(testCtx, 15*time.Second)
+	defer cancelPopulator()
+	resp := &utils.EtcdDataPopulationResponse{}
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go utils.PopulateEtcdWithWaitGroup(populatorCtx, wg, logger, endpoints, resp)
+
+	deltaSnapshotPeriod := time.Second
+	ctx := utils.ContextWithWaitGroupFollwedByGracePeriod(populatorCtx, wg, deltaSnapshotPeriod+2*time.Second)
+
+	compressionConfig := compressor.NewCompressorConfig()
+	snapstoreConfig := brtypes.SnapstoreConfig{Container: snapstoreDir, Provider: "Local"}
+	err = utils.RunSnapshotter(logger, snapstoreConfig, deltaSnapshotPeriod, endpoints, ctx.Done(), true, compressionConfig)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	keyTo = resp.KeyTo
+	return data
+}, func(data []byte) {})
+
+var _ = SynchronizedAfterSuite(func() {}, cleanUp)
+
+func cleanUp() {
+	err = os.RemoveAll(etcdDir)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	err = os.RemoveAll(snapstoreDir)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	err = os.RemoveAll(targetSnapstoreDir)
+	Expect(err).ShouldNot(HaveOccurred())
+}

--- a/pkg/snapshot/copier/copier_test.go
+++ b/pkg/snapshot/copier/copier_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package copier_test
+
+import (
+	"os"
+
+	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
+	. "github.com/gardener/etcd-backup-restore/pkg/snapshot/copier"
+	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+var (
+	sourceSnapstoreConfig *brtypes.SnapstoreConfig
+	destSnapstoreConfig   *brtypes.SnapstoreConfig
+	ss                    brtypes.SnapStore
+	ds                    brtypes.SnapStore
+	copier                *Copier
+)
+
+var _ = Describe("Running Copier", func() {
+	BeforeEach(func() {
+		sourceSnapstoreConfig = &brtypes.SnapstoreConfig{
+			MaxParallelChunkUploads: 5,
+			TempDir:                 "/tmp",
+			Provider:                "Local",
+			Container:               snapstoreDir,
+		}
+		destSnapstoreConfig = &brtypes.SnapstoreConfig{
+			MaxParallelChunkUploads: 5,
+			TempDir:                 "/tmp",
+			Provider:                "Local",
+			Container:               targetSnapstoreDir,
+		}
+
+		var err error
+		ss, ds, err = GetSourceAndDestinationStores(sourceSnapstoreConfig, destSnapstoreConfig)
+		Expect(err).ToNot(HaveOccurred())
+		copier = NewCopier(ss, ds, logger, -1, -1)
+	})
+	AfterEach(func() {
+		err = os.RemoveAll(targetSnapstoreDir)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+	It("should run the copy command succesfully", func() {
+		fullSourceStoreSnapshot, deltaSrourceStoreSnapList, err := miscellaneous.GetLatestFullSnapshotAndDeltaSnapList(ss)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(copier.Run()).ToNot(HaveOccurred())
+		fullTargetStoreSnapshot, deltaTargetStoreSnapList, err := miscellaneous.GetLatestFullSnapshotAndDeltaSnapList(ds)
+		chekIfSnapsAreTheSame(fullSourceStoreSnapshot, fullTargetStoreSnapshot)
+		Expect(len(deltaSrourceStoreSnapList)).To(Equal(len(deltaTargetStoreSnapList)))
+		for i, ssnap := range deltaSrourceStoreSnapList {
+			chekIfSnapsAreTheSame(ssnap, deltaSrourceStoreSnapList[i])
+		}
+	})
+})
+
+func chekIfSnapsAreTheSame(s1 *brtypes.Snapshot, s2 *brtypes.Snapshot) {
+	//SnapName and Prefix could be different after the copy operation.
+	logger.Logger.Infof("Comparing snaps: %v %v", s1, s2)
+	Expect(*s1).To(MatchFields(IgnoreExtras, Fields{
+		"Kind":              Equal(s2.Kind),
+		"StartRevision":     Equal(s2.StartRevision),
+		"LastRevision":      Equal(s2.LastRevision),
+		"CreatedOn":         Equal(s2.CreatedOn),
+		"SnapName":          Equal(s2.SnapName),
+		"IsChunk":           Equal(s2.IsChunk),
+		"CompressionSuffix": Equal(s2.CompressionSuffix),
+	}))
+}

--- a/pkg/snapstore/ecs_s3_snapstore.go
+++ b/pkg/snapstore/ecs_s3_snapstore.go
@@ -14,6 +14,8 @@
 
 package snapstore
 
+import brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+
 const (
 	// ECS does not support regions and always uses the default region US-Standard.
 	ecsDefaultRegion             string = "US-Standard"
@@ -28,12 +30,12 @@ const (
 )
 
 // NewECSSnapStore creates a new S3SnapStore from shared configuration with the specified bucket.
-func NewECSSnapStore(bucket, prefix, tempDir string, maxParallelChunkUploads uint) (*S3SnapStore, error) {
+func NewECSSnapStore(config *brtypes.SnapstoreConfig) (*S3SnapStore, error) {
 	ao, err := ecsAuthOptionsFromEnv()
 	if err != nil {
 		return nil, err
 	}
-	return newGenericS3FromAuthOpt(bucket, prefix, tempDir, maxParallelChunkUploads, ao)
+	return newGenericS3FromAuthOpt(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads, ao)
 }
 
 // ecsAuthOptionsFromEnv gets ECS provider configuration from environment variables.

--- a/pkg/snapstore/local_snapstore.go
+++ b/pkg/snapstore/local_snapstore.go
@@ -70,7 +70,7 @@ func (s *LocalSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
 	return f.Sync()
 }
 
-// List will list the snapshots from store
+// List will return sorted list with all snapshot files on store.
 func (s *LocalSnapStore) List() (brtypes.SnapList, error) {
 	prefixTokens := strings.Split(s.prefix, "/")
 	// Last element of the tokens is backup version

--- a/pkg/snapstore/ocs_s3_snapstore.go
+++ b/pkg/snapstore/ocs_s3_snapstore.go
@@ -14,6 +14,8 @@
 
 package snapstore
 
+import brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+
 const (
 	ocsDefaultDisableSSL         bool = false
 	ocsDefaultInsecureSkipVerify bool = false
@@ -27,12 +29,12 @@ const (
 )
 
 // NewOCSSnapStore creates a new S3SnapStore from shared configuration with the specified bucket.
-func NewOCSSnapStore(bucket, prefix, tempDir string, maxParallelChunkUploads uint) (*S3SnapStore, error) {
+func NewOCSSnapStore(config *brtypes.SnapstoreConfig) (*S3SnapStore, error) {
 	ao, err := ocsAuthOptionsFromEnv()
 	if err != nil {
 		return nil, err
 	}
-	return newGenericS3FromAuthOpt(bucket, prefix, tempDir, maxParallelChunkUploads, ao)
+	return newGenericS3FromAuthOpt(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads, ao)
 }
 
 // ocsAuthOptionsFromEnv gets OCS provider configuration from environment variables.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1068,6 +1068,7 @@ k8s.io/kubectl/pkg/util/templates
 k8s.io/kubectl/pkg/util/term
 k8s.io/kubectl/pkg/validation
 # k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/exec
 k8s.io/utils/integer


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Additional command `copy` is added with the following syntax and parameters. This command can copy data between two buckets.
`$ etcdbrctl copy [flags]`
>    --max-parallel-chunk-uploads uint   maximum number of parallel chunk uploads allowed  (default 5)
      --snapstore-temp-directory string   temporary directory for processing (default "/tmp")
      --source-storage-provider string    source snapshot storage provider
      --source-store-container string     source container which will be used as snapstore
      --source-store-prefix string        source prefix or directory inside container under which snapstore is created
      --storage-provider string           snapshot storage provider
      --store-container string            container which will be used as snapstore
      --store-prefix string               prefix or directory inside container under which snapstore is created


2.  The `ABS`, `S3`, `GCS` `SWIFT` and `OSS` snap stores are enhanced  to accept `SOURCE_` environment variables in order to be able to authenticate to the `source` and `target` snapstores that will be used for the copy operation.

More information about this feature and why it is needed [Issue 356](https://github.com/gardener/etcd-backup-restore/issues/356)
**Which issue(s) this PR fixes**:
Fixes #356 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
