### PR TITLE
Fixed a bug that was creating a different directory for delta snapshots.

### DIFF
--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -388,7 +388,6 @@ func (ssr *Snapshotter) TakeDeltaSnapshot() (*brtypes.Snapshot, error) {
 		return nil, fmt.Errorf("failed to get compressionSuffix: %v", err)
 	}
 	snap := snapstore.NewSnapshot(brtypes.SnapshotKindDelta, ssr.prevSnapshot.LastRevision+1, ssr.lastEventRevision, compressionSuffix)
-	snap.SnapDir = ssr.prevSnapshot.SnapDir
 
 	// compute hash
 	hash := sha256.New()


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a bug in compaction PR. When you upgrade the garden cluster from older ETCDBR image to new ETCD image that has compaction PR and folder structure change, delta snapshots are still saved in older directories. This PR fixed the bug so that delta snapshots are saved only under `v2` prefix.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
