### PR TITLE
Moved client factory implementation to etcdutil to avoid potential cyclic imports later.

### DIFF
--- a/pkg/etcdutil/client/types.go
+++ b/pkg/etcdutil/client/types.go
@@ -17,7 +17,6 @@ package client
 import (
 	"io"
 
-	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 	"go.etcd.io/etcd/clientv3"
 )
 
@@ -45,33 +44,4 @@ type Factory interface {
 	NewKV() (KVCloser, error)
 	NewMaintenance() (MaintenanceCloser, error)
 	NewWatcher() (clientv3.Watcher, error) // clientv3.Watcher already supports io.Closer
-}
-
-// NewFactory returns a Factory that constructs new clients using the supplied ETCD client configuration.
-func NewFactory(cfg etcdutil.EtcdConnectionConfig) Factory {
-	var f = factoryImpl(cfg)
-	return &f
-}
-
-// factoryImpl implements the Factory by constructing new client objects.
-type factoryImpl etcdutil.EtcdConnectionConfig
-
-func (f *factoryImpl) NewClient() (*clientv3.Client, error) {
-	return etcdutil.GetTLSClientForEtcd((*etcdutil.EtcdConnectionConfig)(f))
-}
-
-func (f *factoryImpl) NewCluster() (ClusterCloser, error) {
-	return f.NewClient()
-}
-
-func (f *factoryImpl) NewKV() (KVCloser, error) {
-	return f.NewClient()
-}
-
-func (f *factoryImpl) NewMaintenance() (MaintenanceCloser, error) {
-	return f.NewClient()
-}
-
-func (f *factoryImpl) NewWatcher() (clientv3.Watcher, error) {
-	return f.NewClient()
 }

--- a/pkg/etcdutil/etcdutil.go
+++ b/pkg/etcdutil/etcdutil.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gardener/etcd-backup-restore/pkg/compressor"
 	"github.com/gardener/etcd-backup-restore/pkg/errors"
+	"github.com/gardener/etcd-backup-restore/pkg/etcdutil/client"
 	"github.com/gardener/etcd-backup-restore/pkg/metrics"
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
 	"github.com/prometheus/client_golang/prometheus"
@@ -32,6 +33,35 @@ import (
 
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 )
+
+// NewFactory returns a Factory that constructs new clients using the supplied ETCD client configuration.
+func NewFactory(cfg EtcdConnectionConfig) client.Factory {
+	var f = factoryImpl(cfg)
+	return &f
+}
+
+// factoryImpl implements the client.Factory interface by constructing new client objects.
+type factoryImpl EtcdConnectionConfig
+
+func (f *factoryImpl) NewClient() (*clientv3.Client, error) {
+	return GetTLSClientForEtcd((*EtcdConnectionConfig)(f))
+}
+
+func (f *factoryImpl) NewCluster() (client.ClusterCloser, error) {
+	return f.NewClient()
+}
+
+func (f *factoryImpl) NewKV() (client.KVCloser, error) {
+	return f.NewClient()
+}
+
+func (f *factoryImpl) NewMaintenance() (client.MaintenanceCloser, error) {
+	return f.NewClient()
+}
+
+func (f *factoryImpl) NewWatcher() (clientv3.Watcher, error) {
+	return f.NewClient()
+}
 
 // GetTLSClientForEtcd creates an etcd client using the TLS config params.
 func GetTLSClientForEtcd(tlsConfig *EtcdConnectionConfig) (*clientv3.Client, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

[Some](https://github.com/gardener/etcd-backup-restore/blob/master/pkg/etcdutil/etcdutil.go#L91) [functions](https://github.com/gardener/etcd-backup-restore/blob/master/pkg/etcdutil/etcdutil.go#L122) in the `etcdutil` package will have to start using the `etcdutil/client`'s `Factory` interface introduced in #374. This might lead to circular imports because `etcdutil/client` already imports `etcdutil` for the `factoryImpl` struct.

This PR moves the `factoryImpl` implementation to the `etcdutil` package so that `etcdutil/client` no longer needs to import `etcdutil`, thus avoiding the potential circular imports.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Credits: @ishan16696 for pointing out this problem.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
