### PR TITLE
Ensure integration tests can be executed locally

### DIFF
--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -56,6 +56,11 @@ ETCD_DATA_DIR=
 TEST_DIR=
 TEST_RESULT=
 
+set +e
+test -d "${HOME}/.aws"
+USE_EXISTING_AWS_SECRET=$?
+set -e
+
 function setup_test_environment() {
   setup_ginkgo
   setup_etcd
@@ -71,8 +76,18 @@ function setup_ginkgo() {
 }
 
 function setup_etcd(){
-    echo "Downloading and installing etcd..."
-    export ETCD_VER=v3.3.8
+  echo "Downloading and installing etcd..."
+  export ETCD_VER=v3.3.8
+  if [[ $(uname) == 'Darwin' ]]; then
+    curl -L https://storage.googleapis.com/etcd/${ETCD_VER}/etcd-${ETCD_VER}-darwin-amd64.zip -o etcd-${ETCD_VER}-darwin-amd64.zip
+    unzip etcd-${ETCD_VER}-darwin-amd64.zip
+    chmod +x ./etcd-${ETCD_VER}-darwin-amd64/etcd
+    chmod +x ./etcd-${ETCD_VER}-darwin-amd64/etcdctl
+    mv ./etcd-${ETCD_VER}-darwin-amd64/etcdctl ${GOBIN}/etcdctl
+    mv ./etcd-${ETCD_VER}-darwin-amd64/etcd ${GOBIN}/etcd
+    rm -rf ./etcd-${ETCD_VER}-darwin-amd64
+    rm -rf etcd-${ETCD_VER}-darwin-amd64.zip
+  else
     curl -L https://storage.googleapis.com/etcd/${ETCD_VER}/etcd-${ETCD_VER}-linux-amd64.tar.gz -o etcd-${ETCD_VER}-linux-amd64.tar.gz
     tar xzvf etcd-${ETCD_VER}-linux-amd64.tar.gz
     chmod +x ./etcd-${ETCD_VER}-linux-amd64/etcd
@@ -81,7 +96,8 @@ function setup_etcd(){
     mv ./etcd-${ETCD_VER}-linux-amd64/etcd ${GOBIN}/etcd
     rm -rf ./etcd-${ETCD_VER}-linux-amd64
     rm -rf etcd-${ETCD_VER}-linux-amd64.tar.gz
-    echo "Successfully installed etcd."
+  fi
+  echo "Successfully installed etcd."
 }
 
 function setup_etcdbrctl(){
@@ -164,7 +180,9 @@ function delete_s3_bucket() {
 
 function setup-aws-infrastructure() {
   echo "Setting up AWS infrastructure..."
-  create_aws_secret
+  if [[ "${USE_EXISTING_AWS_SECRET}" == "1" ]]; then
+    create_aws_secret
+  fi
   create_s3_bucket
   echo "AWS infrastructure setup completed."
 }
@@ -172,7 +190,9 @@ function setup-aws-infrastructure() {
 function cleanup-aws-infrastructure() {
   echo "Cleaning up AWS infrastructure..."
   delete_s3_bucket
-  delete_aws_secret
+  if [[ "${USE_EXISTING_AWS_SECRET}" == "1" ]]; then
+    delete_aws_secret
+  fi
   echo "AWS infrastructure cleanup completed."
 }
 
@@ -231,6 +251,11 @@ function run_test_as_processes() {
   echo "Deleting test enviornment..."
   cleanup_test_environment
   echo "Successfully completed all tests."
+
+  if [ ${TEST_RESULT} -ne 0 ]; then
+    echo "Printing etcdbrctl.log:"
+    cat ${TEST_DIR}/etcdbrctl.log
+  fi
 }
 
 function run_test_on_cluster() {

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ test:
 perf-regression-test:
 	@.ci/performance_regression_test
 
+.PHONY: integration-test
+integration-test:
+	@.ci/integration_test
+
 .PHONY: integration-test-cluster
 integration-test-cluster:
 	@.ci/integration_test cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
Improves the integration tests in the following way:
* Ensures the integration tests can be executed locally by adding proper support for Darwin and using the existing credentials in the `$HOME/.aws` directory if the directory exists.
* If the tests fail, outputs the `etcdbrctl` logs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
While working on #383, I had some failing integration tests, but it was very difficult to tell the reason for the failures. It took me some time to adapt the `integration_test` script to be able to execute them locally, but even then I had no clue because they just passed. I had to add the `etcdbrctl` logs to the test output in order to be able to understand and fix the issue.

To run the integration tests locally:
* Ensure that AWS credentials exist in `$HOME/.aws` by running `aws configure`
* Run the integration tests via `.ci/integration_test` or `make integration-test`

**Release note**:

```improvement operator
NONE
```
