### PR TITLE
Update pileline definition to use golang 1.16

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -34,13 +34,13 @@ etcd-backup-restore:
                 build: ~
     steps:
       check:
-        image: 'golang:1.14'
+        image: 'golang:1.16'
       unit_test:
-        image: 'golang:1.14'
+        image: 'golang:1.16'
       integration_test:
         image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:0.205.0'
       build:
-        image: 'golang:1.14'
+        image: 'golang:1.16'
         output_dir: 'binary'
 
   jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated pipeline definition to use golang:1.16 image to run our tests instead is golang:1.14
This is needed due to recent changes made in the ginkgo package used for tests in light of support being dropped for go 1.15 and below ([see here](https://github.com/onsi/ginkgo/pull/846))

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Logs attached for local runs of `make check`, `make build`, and `make test`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
[make_check.txt](https://github.com/gardener/etcd-backup-restore/files/7343275/make_check.txt)
[make_build.txt](https://github.com/gardener/etcd-backup-restore/files/7343276/make_build.txt)
[make_test.txt](https://github.com/gardener/etcd-backup-restore/files/7343277/make_test.txt)

