### PR TITLE
Fixed a bug that updates member leases only if snapstore config is given

### DIFF
--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -142,6 +142,10 @@ func (b *BackupRestoreServer) runServerWithoutSnapshotter(ctx context.Context, r
 	// after each successful data defragmentation
 	go defragmentor.DefragDataPeriodically(ctx, b.config.EtcdConnectionConfig, b.defragmentationSchedule, nil, b.logger)
 
+	if b.config.HealthConfig.MemberLeaseRenewalEnabled {
+		go heartbeat.RenewMemberLeasePeriodically(ctx, b.config.HealthConfig, b.logger, b.config.EtcdConnectionConfig)
+	}
+
 	b.runEtcdProbeLoopWithoutSnapshotter(ctx, handler)
 }
 


### PR DESCRIPTION
add functionality to update member leases when snapstore config is not configured

**What this PR does / why we need it**:
Fixed a bug that does not update the member lease if a snapstore config is not configured

**Which issue(s) this PR fixes**:
Fixes #392 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
