### PR TITLE
[Bug] Moved leaseUpdateCtx to not create the context multiple times

### DIFF
--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -571,9 +571,9 @@ func newEvent(e *clientv3.Event) *event {
 }
 
 func (ssr *Snapshotter) snapshotEventHandler(stopCh <-chan struct{}) error {
+	leaseUpdateCtx, leaseUpdateCancel := context.WithCancel(context.TODO())
+	defer leaseUpdateCancel()
 	for {
-		leaseUpdateCtx, leaseUpdateCancel := context.WithCancel(context.TODO())
-		defer leaseUpdateCancel()
 		select {
 		case isFinal := <-ssr.fullSnapshotReqCh:
 			s, err := ssr.TakeFullSnapshotAndResetTimer(isFinal)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug that sees the `leaseUpdateCtx` being created multiple times without being cancelled. This causes a memory leak without the contexts being cancelled

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Took care of a bug where contexts were created multiple times without being cancelled
```
