### PR TITLE
Renew snapshot leases even if snapshot skipped

### DIFF
--- a/pkg/health/heartbeat/heartbeat.go
+++ b/pkg/health/heartbeat/heartbeat.go
@@ -192,7 +192,7 @@ func UpdateFullSnapshotLease(ctx context.Context, logger *logrus.Entry, fullSnap
 		renewedLease := fullSnapLease.DeepCopy()
 		renewedTime := time.Now()
 		renewedLease.Spec.RenewTime = &metav1.MicroTime{Time: renewedTime}
-		// Update revisions in deltaSnapLease.Spec.HolderIdentity only when its value is less than latest deltaSnap.LastRevision
+		// Update revisions in fullSnapLease.Spec.HolderIdentity only when its value is less than latest fullSnap.LastRevision
 		if fullSnapLease.Spec.HolderIdentity == nil || rev < fullSnapshot.LastRevision {
 			actor := strconv.FormatInt(fullSnapshot.LastRevision, 10)
 			renewedLease.Spec.HolderIdentity = &actor
@@ -260,7 +260,7 @@ func UpdateDeltaSnapshotLease(ctx context.Context, logger *logrus.Entry, prevDel
 			renewedLease.Spec.HolderIdentity = &actor
 			logString += " with revision " + actor
 		}
-	} else if len(prevDeltaSnapshots) == 0 && deltaSnapLease.Spec.HolderIdentity == nil {
+	} else if deltaSnapLease.Spec.HolderIdentity == nil {
 		// Special case: Set revisions in deltaSnapLease.Spec.HolderIdentity to 0 if no delta snaps taken at all
 		actor := strconv.FormatInt(0, 10)
 		renewedLease.Spec.HolderIdentity = &actor

--- a/pkg/health/heartbeat/heartbeat.go
+++ b/pkg/health/heartbeat/heartbeat.go
@@ -260,6 +260,10 @@ func UpdateDeltaSnapshotLease(ctx context.Context, logger *logrus.Entry, prevDel
 			renewedLease.Spec.HolderIdentity = &actor
 			logString += " with revision " + actor
 		}
+	} else if len(prevDeltaSnapshots) == 0 && deltaSnapLease.Spec.HolderIdentity == nil {
+		// Special case: Set revision number to 0 if no delta snaps taken at all
+		actor := strconv.FormatInt(0, 10)
+		renewedLease.Spec.HolderIdentity = &actor
 	}
 
 	err = k8sClientset.Patch(ctx, renewedLease, client.MergeFrom(deltaSnapLease))

--- a/pkg/health/heartbeat/heartbeat.go
+++ b/pkg/health/heartbeat/heartbeat.go
@@ -192,7 +192,7 @@ func UpdateFullSnapshotLease(ctx context.Context, logger *logrus.Entry, fullSnap
 		renewedLease := fullSnapLease.DeepCopy()
 		renewedTime := time.Now()
 		renewedLease.Spec.RenewTime = &metav1.MicroTime{Time: renewedTime}
-		//Update revision number only if revisions in existing lease is lower
+		// Update revisions in deltaSnapLease.Spec.HolderIdentity only when its value is less than latest deltaSnap.LastRevision
 		if fullSnapLease.Spec.HolderIdentity == nil || rev < fullSnapshot.LastRevision {
 			actor := strconv.FormatInt(fullSnapshot.LastRevision, 10)
 			renewedLease.Spec.HolderIdentity = &actor
@@ -245,7 +245,7 @@ func UpdateDeltaSnapshotLease(ctx context.Context, logger *logrus.Entry, prevDel
 	renewedTime := time.Now()
 	renewedLease.Spec.RenewTime = &metav1.MicroTime{Time: renewedTime}
 
-	//Update revision number only if revisions in existing lease is lower
+	// Update revisions in deltaSnapLease.Spec.HolderIdentity only when its value is less than latest deltaSnap.LastRevision
 	if len(prevDeltaSnapshots) > 0 {
 		deltaSnap := prevDeltaSnapshots[len(prevDeltaSnapshots)-1]
 		var deltaRev int64
@@ -261,7 +261,7 @@ func UpdateDeltaSnapshotLease(ctx context.Context, logger *logrus.Entry, prevDel
 			logString += " with revision " + actor
 		}
 	} else if len(prevDeltaSnapshots) == 0 && deltaSnapLease.Spec.HolderIdentity == nil {
-		// Special case: Set revision number to 0 if no delta snaps taken at all
+		// Special case: Set revisions in deltaSnapLease.Spec.HolderIdentity to 0 if no delta snaps taken at all
 		actor := strconv.FormatInt(0, 10)
 		renewedLease.Spec.HolderIdentity = &actor
 	}

--- a/pkg/health/heartbeat/heartbeat.go
+++ b/pkg/health/heartbeat/heartbeat.go
@@ -142,7 +142,7 @@ func (hb *Heartbeat) RenewMemberLease(ctx context.Context) error {
 	return nil
 }
 
-// UpdateFullSnapshotLease updates the holderIdentity field of the full snapshot lease with the last revision in the latest full snapshot
+// UpdateFullSnapshotLease renews the full snapshot lease and updates the holderIdentity field with the last revision in the latest full snapshot
 func UpdateFullSnapshotLease(ctx context.Context, logger *logrus.Entry, fullSnapshot *brtypes.Snapshot, k8sClientset client.Client, fullSnapshotLeaseName string) error {
 	if k8sClientset == nil {
 		return &errors.EtcdError{
@@ -214,7 +214,7 @@ func UpdateFullSnapshotLease(ctx context.Context, logger *logrus.Entry, fullSnap
 	return nil
 }
 
-// UpdateDeltaSnapshotLease updates the holderIdentity field of the delta snapshot lease with the total number or revisions stored in delta snapshots since the last full snapshot was taken
+// UpdateDeltaSnapshotLease renews delta snapshot lease and updates the holderIdentity field with the total number or revisions stored in delta snapshots since the last full snapshot was taken
 func UpdateDeltaSnapshotLease(ctx context.Context, logger *logrus.Entry, prevDeltaSnapshots brtypes.SnapList, k8sClientset client.Client, deltaSnapshotLeaseName string) error {
 	if k8sClientset == nil {
 		return &errors.EtcdError{

--- a/pkg/health/heartbeat/heartbeat_test.go
+++ b/pkg/health/heartbeat/heartbeat_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"time"
 
-	//"k8s.io/utils/pointer"
-
 	heartbeat "github.com/gardener/etcd-backup-restore/pkg/health/heartbeat"
 	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently snapshot lease updates are optimised in such a way that if revisions are not updated, the lease will not be renewed.
Going forward, the snapshot leases will be used as a heartbeat and so it would be desirable to renew them even if revisions have not been updated.
This PR does just that. It allows that heartbeat package to renew snapshot leases even if revisions are not updated

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
~~This PR is based on #406, hence lease ignore [`4a9496e`](https://github.com/gardener/etcd-backup-restore/commit/4a9496ee38a066f2714426e0ba17213fb44b03e7) and [`1fe44c5`](https://github.com/gardener/etcd-backup-restore/commit/1fe44c562c0d9d13ac7b3e484b24a82979f59304).~~
Reworked this PR to be standalone and hence can be reviewed and merged 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
