### PR TITLE
Updated ci tests to use ginkgo 1.14.1 when running tests

### DIFF
--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -70,7 +70,7 @@ function setup_test_environment() {
 
 function setup_ginkgo() {
     echo "Installing Ginkgo..."
-    GO111MODULE=off go get -u github.com/onsi/ginkgo/ginkgo
+    go install github.com/onsi/ginkgo/ginkgo@v1.14.1
     ginkgo version
     echo "Successfully installed Ginkgo."
 }

--- a/.ci/unit_test
+++ b/.ci/unit_test
@@ -36,7 +36,7 @@ REPOSITORY=${VCS}/${ORGANIZATION}/${PROJECT}
 cd "${SOURCE_PATH}"
 
 # Install Ginkgo (test framework) to be able to execute the tests.
-GO111MODULE=off go get github.com/onsi/ginkgo/ginkgo
+go install github.com/onsi/ginkgo/ginkgo@v1.14.1
 
 ###############################################################################
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Recently, ginkgo released a new version `v2.0.0`. Our ci tests currently fetch ginkgo's master branch to run our ci tests and this has a few regressions with the new version.
This PR allows for a fixed version `v1.14.1` to be fetched so that our ci tests can run.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR is meant as a temporary measure so that our current work isn't blocked. I will in the meantime also work to migrate all our tests to ginkgo `v2.0.0`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
