### PR TITLE
Introduced  endpoint in http server for  backup restorer.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 VERSION             := $(shell cat VERSION)
-REGISTRY            := eu.gcr.io/gardener-project/gardener
+REGISTRY            ?= eu.gcr.io/gardener-project/gardener
 IMAGE_REPOSITORY    := $(REGISTRY)/etcdbrctl
 IMAGE_TAG           := $(VERSION)
 BUILD_DIR           := build
 BIN_DIR             := bin
 COVERPROFILE        := test/output/coverprofile.out
+
+IMG ?= ${IMAGE_REPOSITORY}:${IMAGE_TAG}
 
 .DEFAULT_GOAL := build-local
 
@@ -40,15 +42,16 @@ build:
 build-local:
 	@env LOCAL_BUILD=1 .ci/build
 
-.PHONY: docker-image
-docker-image:
+.PHONY: docker-build
+docker-build:
+	@.ci/build
 	@if [[ ! -f $(BIN_DIR)/linux-amd64/etcdbrctl ]]; then echo "No binary found. Please run 'make build'"; false; fi
-	@docker build -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) -f $(BUILD_DIR)/Dockerfile --rm .
+	@docker build -t ${IMG} -f $(BUILD_DIR)/Dockerfile --rm .
 
 .PHONY: docker-push
 docker-push:
 	@if ! docker images $(IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(IMAGE_TAG); then echo "$(IMAGE_REPOSITORY) version $(IMAGE_TAG) is not yet built. Please run 'make docker-image'"; false; fi
-	@docker push $(IMAGE_REPOSITORY):$(IMAGE_TAG)
+	@docker push ${IMG}
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets up an http endpoint with the path `/config` that actually downloads etcd config file from the backup restore sidecar based on the ETCD nodes.
**Which issue(s) this PR fixes**:
Fixes part of #322

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
