### PR TITLE
Reduce verbosity of leadershipStatus check log

### DIFF
--- a/pkg/leaderelection/leaderelection.go
+++ b/pkg/leaderelection/leaderelection.go
@@ -150,7 +150,7 @@ func (le *LeaderElector) Run(ctx context.Context) error {
 
 // IsLeader checks whether the current instance of backup-restore is leader or not.
 func IsLeader(ctx context.Context, etcdConnectionConfig *brtypes.EtcdConnectionConfig, etcdConnectionTimeout time.Duration, logger *logrus.Entry) (bool, error) {
-	logger.Info("checking the leadershipStatus...")
+	logger.Debug("checking the leadershipStatus...")
 	var endPoint string
 
 	factory := etcdutil.NewFactory(*etcdConnectionConfig)


### PR DESCRIPTION
**What this PR does / why we need it**:
The current verbosity level of this log line is `Info`, which puts it on the same level as logs for snapshots being saved, garbage collection running, etc., however, this particular line is called on every leadership status check, which makes the logs incredibly chatty:

```
time="2022-02-01T16:00:31Z" level=info msg="Setting status to : 200" actor=backup-restore-server
time="2022-02-01T16:00:31Z" level=info msg="Starting snapshotter..." actor=backup-restore-server
time="2022-02-01T16:00:31Z" level=info msg="Will take next full snapshot at time: 2022-02-01 17:00:00 +0000 UTC" actor=snapshotter
time="2022-02-01T16:00:36Z" level=info msg="checking the leadershipStatus..." actor=leader-elector
time="2022-02-01T16:00:41Z" level=info msg="checking the leadershipStatus..." actor=leader-elector
time="2022-02-01T16:00:46Z" level=info msg="checking the leadershipStatus..." actor=leader-elector
time="2022-02-01T16:00:51Z" level=info msg="checking the leadershipStatus..." actor=leader-elector
time="2022-02-01T16:00:56Z" level=info msg="checking the leadershipStatus..." actor=leader-elector
time="2022-02-01T16:01:01Z" level=info msg="checking the leadershipStatus..." actor=leader-elector
time="2022-02-01T16:01:06Z" level=info msg="checking the leadershipStatus..." actor=leader-elector
time="2022-02-01T16:01:11Z" level=info msg="checking the leadershipStatus..." actor=leader-elector
...
```

**Which issue(s) this PR fixes**:
Fixes very verbose logs.