### PR TITLE
To dynamically load IaaS credentials during runtime

### DIFF
--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -70,7 +70,7 @@ function setup_test_environment() {
 
 function setup_ginkgo() {
     echo "Installing Ginkgo..."
-    GO111MODULE=off go get -u github.com/onsi/ginkgo/ginkgo
+    go install github.com/onsi/ginkgo/ginkgo@v1.14.1
     ginkgo version
     echo "Successfully installed Ginkgo."
 }

--- a/.ci/unit_test
+++ b/.ci/unit_test
@@ -36,7 +36,7 @@ REPOSITORY=${VCS}/${ORGANIZATION}/${PROJECT}
 cd "${SOURCE_PATH}"
 
 # Install Ginkgo (test framework) to be able to execute the tests.
-GO111MODULE=off go get github.com/onsi/ginkgo/ginkgo
+go install github.com/onsi/ginkgo/ginkgo@v1.14.1
 
 ###############################################################################
 

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -50,7 +50,7 @@ storing snapshots on various cloud storage providers as well as local disk locat
 				logger.Fatalf("Failed to create snapstore from configured storage provider: %v", err)
 			}
 
-			ssr, err := snapshotter.NewSnapshotter(logger, opts.snapshotterConfig, ss, opts.etcdConnectionConfig, opts.compressionConfig, brtypes.NewHealthConfig())
+			ssr, err := snapshotter.NewSnapshotter(logger, opts.snapshotterConfig, ss, opts.etcdConnectionConfig, opts.compressionConfig, brtypes.NewHealthConfig(), opts.snapstoreConfig)
 			if err != nil {
 				logger.Fatalf("Failed to create snapshotter: %v", err)
 			}

--- a/pkg/initializer/validator/validator_suite_test.go
+++ b/pkg/initializer/validator/validator_suite_test.go
@@ -89,7 +89,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 // runSnapshotter creates a snapshotter object and runs it for a duration specified by 'snapshotterDurationSeconds'
 func runSnapshotter(logger *logrus.Entry, deltaSnapshotPeriod time.Duration, endpoints []string, stopCh <-chan struct{}) error {
-	store, err := snapstore.GetSnapstore(&brtypes.SnapstoreConfig{Container: snapstoreDir, Provider: "Local"})
+	snapStoreConfig := &brtypes.SnapstoreConfig{Container: snapstoreDir, Provider: "Local"}
+	store, err := snapstore.GetSnapstore(snapStoreConfig)
 	if err != nil {
 		return err
 	}
@@ -107,7 +108,7 @@ func runSnapshotter(logger *logrus.Entry, deltaSnapshotPeriod time.Duration, end
 
 	healthConfig := brtypes.NewHealthConfig()
 
-	ssr, err := snapshotter.NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig)
+	ssr, err := snapshotter.NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapStoreConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -163,7 +163,7 @@ func (b *BackupRestoreServer) runServerWithSnapshotter(ctx context.Context, rest
 	}
 
 	b.logger.Infof("Creating snapshotter...")
-	ssr, err := snapshotter.NewSnapshotter(b.logger, b.config.SnapshotterConfig, ss, b.config.EtcdConnectionConfig, b.config.CompressionConfig, b.config.HealthConfig)
+	ssr, err := snapshotter.NewSnapshotter(b.logger, b.config.SnapshotterConfig, ss, b.config.EtcdConnectionConfig, b.config.CompressionConfig, b.config.HealthConfig, b.config.SnapstoreConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -52,6 +52,7 @@ var _ = Describe("Snapshotter", func() {
 		etcdConnectionConfig    *etcdutil.EtcdConnectionConfig
 		compressionConfig       *compressor.CompressionConfig
 		healthConfig            *brtypes.HealthConfig
+		snapStoreConfig         *brtypes.SnapstoreConfig
 		err                     error
 	)
 	BeforeEach(func() {
@@ -66,7 +67,8 @@ var _ = Describe("Snapshotter", func() {
 
 	Describe("creating Snapshotter", func() {
 		BeforeEach(func() {
-			store, err = snapstore.GetSnapstore(&brtypes.SnapstoreConfig{Container: path.Join(outputDir, "snapshotter_1.bkp")})
+			snapStoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, "snapshotter_1.bkp")}
+			store, err = snapstore.GetSnapstore(snapStoreConfig)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		Context("With invalid schedule", func() {
@@ -81,7 +83,7 @@ var _ = Describe("Snapshotter", func() {
 					MaxBackups:               1,
 				}
 
-				_, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig)
+				_, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapStoreConfig)
 				Expect(err).Should(HaveOccurred())
 			})
 		})
@@ -98,7 +100,7 @@ var _ = Describe("Snapshotter", func() {
 					MaxBackups:               1,
 				}
 
-				_, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig)
+				_, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapStoreConfig)
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 		})
@@ -119,7 +121,8 @@ var _ = Describe("Snapshotter", func() {
 			It("should timeout & not take any snapshot", func() {
 				maxBackups = 2
 				testTimeout := time.Duration(time.Minute * time.Duration(maxBackups+1))
-				store, err = snapstore.GetSnapstore(&brtypes.SnapstoreConfig{Container: path.Join(outputDir, "snapshotter_2.bkp")})
+				snapStoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, "snapshotter_2.bkp")}
+				store, err = snapstore.GetSnapstore(snapStoreConfig)
 				Expect(err).ShouldNot(HaveOccurred())
 				snapshotterConfig := &brtypes.SnapshotterConfig{
 					FullSnapshotSchedule:     schedule,
@@ -130,7 +133,7 @@ var _ = Describe("Snapshotter", func() {
 					MaxBackups:               maxBackups,
 				}
 
-				ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig)
+				ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapStoreConfig)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				ctx, cancel := context.WithTimeout(testCtx, testTimeout)
@@ -154,7 +157,8 @@ var _ = Describe("Snapshotter", func() {
 					schedule = "* * 31 2 *"
 					maxBackups = 2
 					testTimeout := time.Duration(time.Minute * time.Duration(maxBackups+1))
-					store, err = snapstore.GetSnapstore(&brtypes.SnapstoreConfig{Container: path.Join(outputDir, "snapshotter_3.bkp")})
+					snapStoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, "snapshotter_3.bkp")}
+					store, err = snapstore.GetSnapstore(snapStoreConfig)
 					Expect(err).ShouldNot(HaveOccurred())
 					snapshotterConfig := &brtypes.SnapshotterConfig{
 						FullSnapshotSchedule:     schedule,
@@ -165,7 +169,7 @@ var _ = Describe("Snapshotter", func() {
 						MaxBackups:               maxBackups,
 					}
 
-					ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig)
+					ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapStoreConfig)
 					Expect(err).ShouldNot(HaveOccurred())
 					ctx, cancel := context.WithTimeout(testCtx, testTimeout)
 					defer cancel()
@@ -208,7 +212,8 @@ var _ = Describe("Snapshotter", func() {
 					})
 
 					It("should take periodic backups without delta snapshots", func() {
-						store, err = snapstore.GetSnapstore(&brtypes.SnapstoreConfig{Container: path.Join(outputDir, "snapshotter_4.bkp")})
+						snapStoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, "snapshotter_4.bkp")}
+						store, err = snapstore.GetSnapstore(snapStoreConfig)
 						Expect(err).ShouldNot(HaveOccurred())
 						snapshotterConfig := &brtypes.SnapshotterConfig{
 							FullSnapshotSchedule:     schedule,
@@ -219,7 +224,7 @@ var _ = Describe("Snapshotter", func() {
 							MaxBackups:               maxBackups,
 						}
 
-						ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig)
+						ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapStoreConfig)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						ctx, cancel := context.WithTimeout(testCtx, testTimeout)
@@ -235,7 +240,8 @@ var _ = Describe("Snapshotter", func() {
 					})
 
 					It("should fail on triggering out-of-schedule delta snapshot", func() {
-						store, err = snapstore.GetSnapstore(&brtypes.SnapstoreConfig{Container: path.Join(outputDir, "snapshotter_4.bkp")})
+						snapStoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, "snapshotter_4.bkp")}
+						store, err = snapstore.GetSnapstore(snapStoreConfig)
 						Expect(err).ShouldNot(HaveOccurred())
 						snapshotterConfig := &brtypes.SnapshotterConfig{
 							FullSnapshotSchedule:     schedule,
@@ -246,7 +252,7 @@ var _ = Describe("Snapshotter", func() {
 							MaxBackups:               maxBackups,
 						}
 
-						ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig)
+						ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapStoreConfig)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						_, err = ssr.TriggerDeltaSnapshot()
@@ -263,7 +269,8 @@ var _ = Describe("Snapshotter", func() {
 					Context("with snapshotter starting without first full snapshot", func() {
 						It("first snapshot should be a delta snapshot", func() {
 							currentHour := time.Now().Hour()
-							store, err = snapstore.GetSnapstore(&brtypes.SnapstoreConfig{Container: path.Join(outputDir, "snapshotter_5.bkp")})
+							snapStoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, "snapshotter_5.bkp")}
+							store, err = snapstore.GetSnapstore(snapStoreConfig)
 							Expect(err).ShouldNot(HaveOccurred())
 							snapshotterConfig := &brtypes.SnapshotterConfig{
 								FullSnapshotSchedule:     fmt.Sprintf("59 %d * * *", (currentHour+1)%24), // This make sure that full snapshot timer doesn't trigger full snapshot.
@@ -274,7 +281,7 @@ var _ = Describe("Snapshotter", func() {
 								MaxBackups:               maxBackups,
 							}
 
-							ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig)
+							ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapStoreConfig)
 							Expect(err).ShouldNot(HaveOccurred())
 							populatorCtx, cancelPopulator := context.WithTimeout(testCtx, testTimeout)
 							defer cancelPopulator()
@@ -294,7 +301,8 @@ var _ = Describe("Snapshotter", func() {
 
 					Context("with snapshotter starting with full snapshot", func() {
 						It("should take periodic backups", func() {
-							store, err = snapstore.GetSnapstore(&brtypes.SnapstoreConfig{Container: path.Join(outputDir, "snapshotter_6.bkp")})
+							snapStoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, "snapshotter_6.bkp")}
+							store, err = snapstore.GetSnapstore(snapStoreConfig)
 							Expect(err).ShouldNot(HaveOccurred())
 							snapshotterConfig := &brtypes.SnapshotterConfig{
 								FullSnapshotSchedule:     schedule,
@@ -312,7 +320,7 @@ var _ = Describe("Snapshotter", func() {
 							// populating etcd so that snapshots will be taken
 							go utils.PopulateEtcdWithWaitGroup(populatorCtx, wg, logger, etcdConnectionConfig.Endpoints, nil)
 
-							ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig)
+							ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapStoreConfig)
 							Expect(err).ShouldNot(HaveOccurred())
 							ssrCtx := utils.ContextWithWaitGroup(testCtx, wg)
 							err = ssr.Run(ssrCtx.Done(), true)
@@ -347,9 +355,9 @@ var _ = Describe("Snapshotter", func() {
 
 				// Prepare expected resultant snapshot list
 				var (
-					store            = prepareStoreForGarbageCollection(now, "garbagecollector_exponential.bkp", "v2")
-					snapTime         = time.Date(now.Year(), now.Month(), now.Day()-35, 0, -30, 0, 0, now.Location())
-					expectedSnapList = brtypes.SnapList{}
+					store, snapStoreConfig = prepareStoreForGarbageCollection(now, "garbagecollector_exponential.bkp", "v2")
+					snapTime               = time.Date(now.Year(), now.Month(), now.Day()-35, 0, -30, 0, 0, now.Location())
+					expectedSnapList       = brtypes.SnapList{}
 				)
 
 				expectedSnapList = prepareExpectedSnapshotsList(snapTime, now, expectedSnapList, snapsInV2)
@@ -364,7 +372,7 @@ var _ = Describe("Snapshotter", func() {
 					MaxBackups:               maxBackups,
 				}
 
-				ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig)
+				ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapStoreConfig)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				gcCtx, cancel := context.WithTimeout(testCtx, testTimeout)
@@ -390,9 +398,9 @@ var _ = Describe("Snapshotter", func() {
 
 				// Prepare expected resultant snapshot list
 				var (
-					store            = prepareStoreForBackwardCompatibleGC(now, "gc_exponential_backward_compatible.bkp")
-					snapTime         = time.Date(now.Year(), now.Month(), now.Day()-35, 0, -30, 0, 0, now.Location())
-					expectedSnapList = brtypes.SnapList{}
+					store, snapStoreConfig = prepareStoreForBackwardCompatibleGC(now, "gc_exponential_backward_compatible.bkp")
+					snapTime               = time.Date(now.Year(), now.Month(), now.Day()-35, 0, -30, 0, 0, now.Location())
+					expectedSnapList       = brtypes.SnapList{}
 				)
 
 				expectedSnapList = prepareExpectedSnapshotsList(snapTime, now, expectedSnapList, mixed)
@@ -407,7 +415,7 @@ var _ = Describe("Snapshotter", func() {
 					MaxBackups:               maxBackups,
 				}
 
-				ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig)
+				ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapStoreConfig)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				gcCtx, cancel := context.WithTimeout(testCtx, testTimeout)
@@ -435,9 +443,9 @@ var _ = Describe("Snapshotter", func() {
 
 				// Prepare expected resultant snapshot list
 				var (
-					store            = prepareStoreForGarbageCollection(now, "gc_exponential_backward_compatiblev1.bkp", "v1")
-					snapTime         = time.Date(now.Year(), now.Month(), now.Day()-35, 0, -30, 0, 0, now.Location())
-					expectedSnapList = brtypes.SnapList{}
+					store, snapStoreConfig = prepareStoreForGarbageCollection(now, "gc_exponential_backward_compatiblev1.bkp", "v1")
+					snapTime               = time.Date(now.Year(), now.Month(), now.Day()-35, 0, -30, 0, 0, now.Location())
+					expectedSnapList       = brtypes.SnapList{}
 				)
 
 				expectedSnapList = prepareExpectedSnapshotsList(snapTime, now, expectedSnapList, snapsInV1)
@@ -452,7 +460,7 @@ var _ = Describe("Snapshotter", func() {
 					MaxBackups:               maxBackups,
 				}
 
-				ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig)
+				ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapStoreConfig)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				gcCtx, cancel := context.WithTimeout(testCtx, testTimeout)
@@ -472,7 +480,7 @@ var _ = Describe("Snapshotter", func() {
 
 			It("should garbage collect limitBased", func() {
 				now := time.Now().UTC()
-				store := prepareStoreForGarbageCollection(now, "garbagecollector_limit_based.bkp", "v2")
+				store, snapStoreConfig := prepareStoreForGarbageCollection(now, "garbagecollector_limit_based.bkp", "v2")
 				snapshotterConfig := &brtypes.SnapshotterConfig{
 					FullSnapshotSchedule:     schedule,
 					DeltaSnapshotPeriod:      wrappers.Duration{Duration: 10 * time.Second},
@@ -482,7 +490,7 @@ var _ = Describe("Snapshotter", func() {
 					MaxBackups:               maxBackups,
 				}
 
-				ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig)
+				ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapStoreConfig)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				gcCtx, cancel := context.WithTimeout(testCtx, testTimeout)
@@ -541,7 +549,7 @@ var _ = Describe("Snapshotter", func() {
 			//TODO: Consider removing when backward compatibility no longer needed
 			It("should garbage collect limitBased with only v1 dir structure present (backward compatible test)", func() {
 				now := time.Now().UTC()
-				store := prepareStoreForGarbageCollection(now, "gc_limit_based_backward_compatiblev1.bkp", "v1")
+				store, snapStoreConfig := prepareStoreForGarbageCollection(now, "gc_limit_based_backward_compatiblev1.bkp", "v1")
 				snapshotterConfig := &brtypes.SnapshotterConfig{
 					FullSnapshotSchedule:     schedule,
 					DeltaSnapshotPeriod:      wrappers.Duration{Duration: 10 * time.Second},
@@ -551,7 +559,7 @@ var _ = Describe("Snapshotter", func() {
 					MaxBackups:               maxBackups,
 				}
 
-				ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig)
+				ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapStoreConfig)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				gcCtx, cancel := context.WithTimeout(testCtx, testTimeout)
@@ -803,7 +811,7 @@ func prepareExpectedSnapshotsList(snapTime time.Time, now time.Time, expectedSna
 */
 
 // prepareStoreForGarbageCollection populates the store with dummy snapshots for garbage collection tests
-func prepareStoreForGarbageCollection(forTime time.Time, storeContainer string, storePrefix string) brtypes.SnapStore {
+func prepareStoreForGarbageCollection(forTime time.Time, storeContainer string, storePrefix string) (brtypes.SnapStore, *brtypes.SnapstoreConfig) {
 	var (
 		snapTime           = time.Date(forTime.Year(), forTime.Month(), forTime.Day()-36, 0, 0, 0, 0, forTime.Location())
 		count              = 0
@@ -840,13 +848,13 @@ func prepareStoreForGarbageCollection(forTime time.Time, storeContainer string, 
 		snapTime = snapTime.Add(time.Duration(time.Minute * 10))
 		store.Save(snap, ioutil.NopCloser(strings.NewReader(fmt.Sprintf("dummy-snapshot-content for snap created on %s", snap.CreatedOn))))
 	}
-	return store
+	return store, snapstoreConf
 }
 
 // prepareStoreForBackwardCompatibleGC populates the store with dummy snapshots in both v1 and v2 drectory structures for backward compatible garbage collection tests
 // Tied up with backward compatibility tests
 // TODO: Consider removing when backward compatibility no longer needed
-func prepareStoreForBackwardCompatibleGC(forTime time.Time, storeContainer string) brtypes.SnapStore {
+func prepareStoreForBackwardCompatibleGC(forTime time.Time, storeContainer string) (brtypes.SnapStore, *brtypes.SnapstoreConfig) {
 	var (
 		// Divide the forTime into two period. First period is during when snapshots would be collected in v1 and second period is when snapshots would be collected in v2.
 		snapTimev1         = time.Date(forTime.Year(), forTime.Month(), forTime.Day()-36, 0, 0, 0, 0, forTime.Location())
@@ -856,7 +864,8 @@ func prepareStoreForBackwardCompatibleGC(forTime time.Time, storeContainer strin
 	)
 	fmt.Println("setting up garbage collection test")
 	// Prepare store
-	store, err := snapstore.GetSnapstore(&brtypes.SnapstoreConfig{Container: path.Join(outputDir, storeContainer), Prefix: "v1"})
+	snapStoreConfig := &brtypes.SnapstoreConfig{Container: path.Join(outputDir, storeContainer), Prefix: "v1"}
+	store, err := snapstore.GetSnapstore(snapStoreConfig)
 	Expect(err).ShouldNot(HaveOccurred())
 
 	for snapTimev2.Sub(snapTimev1) >= 0 {
@@ -879,7 +888,8 @@ func prepareStoreForBackwardCompatibleGC(forTime time.Time, storeContainer strin
 
 	count = 0
 	// Prepare store
-	store, err = snapstore.GetSnapstore(&brtypes.SnapstoreConfig{Container: path.Join(outputDir, storeContainer), Prefix: "v2"})
+	snapStoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, storeContainer), Prefix: "v2"}
+	store, err = snapstore.GetSnapstore(snapStoreConfig)
 	Expect(err).ShouldNot(HaveOccurred())
 
 	for forTime.Sub(snapTimev2) >= 0 {
@@ -898,7 +908,7 @@ func prepareStoreForBackwardCompatibleGC(forTime time.Time, storeContainer strin
 		snapTimev2 = snapTimev2.Add(time.Duration(time.Minute * 10))
 		store.Save(snapv2, ioutil.NopCloser(strings.NewReader(fmt.Sprintf("dummy-snapshot-content for snap created on %s", snapv2.CreatedOn))))
 	}
-	return store
+	return store, snapStoreConfig
 }
 
 //validateLimitBasedSnapshots verifies whether the snapshot list after being garbage collected using the limit-based configuration is a valid snapshot list

--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -38,7 +38,7 @@ const (
 	absStorageAccount     = "STORAGE_ACCOUNT"
 	absStorageKey         = "STORAGE_KEY"
 	absCredentialFile     = "AZURE_APPLICATION_CREDENTIALS"
-	absCredentialJSONFile = "AZURE_APPLICATION_CREDENTIALS_Json"
+	absCredentialJSONFile = "AZURE_APPLICATION_CREDENTIALS_JSON"
 )
 
 // ABSSnapStore is an ABS backed snapstore.

--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -17,6 +17,7 @@ package snapstore
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -34,8 +35,10 @@ import (
 )
 
 const (
-	absStorageAccount = "STORAGE_ACCOUNT"
-	absStorageKey     = "STORAGE_KEY"
+	absStorageAccount     = "STORAGE_ACCOUNT"
+	absStorageKey         = "STORAGE_KEY"
+	absCredentialFile     = "AZURE_APPLICATION_CREDENTIALS"
+	absCredentialJSONFile = "AZURE_APPLICATION_CREDENTIALS_Json"
 )
 
 // ABSSnapStore is an ABS backed snapstore.
@@ -45,6 +48,12 @@ type ABSSnapStore struct {
 	// maxParallelChunkUploads hold the maximum number of parallel chunk uploads allowed.
 	maxParallelChunkUploads uint
 	tempDir                 string
+}
+
+type absCredentials struct {
+	BucketName     string `json:"bucketName"`
+	SecretKey      string `json:"storageKey"`
+	StorageAccount string `json:"storageAccount"`
 }
 
 // NewABSSnapStore create new ABSSnapStore from shared configuration with specified bucket
@@ -72,16 +81,88 @@ func NewABSSnapStore(config *brtypes.SnapstoreConfig) (*ABSSnapStore, error) {
 	return GetABSSnapstoreFromClient(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads, &containerURL)
 }
 
-func getCredentials(prefixString string) (storageAccount string, storageKey string, err error) {
-	storageAccount, err = GetEnvVarOrError(prefixString + absStorageAccount)
-	if err != nil {
-		return "", "", err
+func getCredentials(prefixString string) (string, string, error) {
+
+	// TODO: passing credentials through environment variable will be deprecated by "backup-restore v0.18.0"
+	if _, isSet := os.LookupEnv(prefixString + absStorageAccount); isSet {
+		storageAccount, err := GetEnvVarOrError(prefixString + absStorageAccount)
+		if err != nil {
+			return "", "", err
+		}
+		storageKey, err := GetEnvVarOrError(prefixString + absStorageKey)
+		if err != nil {
+			return "", "", err
+		}
+		return storageAccount, storageKey, nil
 	}
-	storageKey, err = GetEnvVarOrError(prefixString + absStorageKey)
-	if err != nil {
-		return "", "", err
+
+	if _, isSet := os.LookupEnv(absCredentialJSONFile); isSet {
+		if filename := os.Getenv(absCredentialJSONFile); filename != "" {
+			credentials, err := readABSCredentialsJSON(filename, prefixString)
+			if err != nil {
+				return "", "", fmt.Errorf("error getting credentials using %v file", filename)
+			}
+			return credentials.StorageAccount, credentials.SecretKey, nil
+		}
 	}
-	return
+
+	if _, isSet := os.LookupEnv(absCredentialFile); isSet {
+		if filename := os.Getenv(absCredentialFile); filename != "" {
+			credentials, err := absReadCredentialsFile(filename, prefixString)
+			if err != nil {
+				return "", "", fmt.Errorf("error getting credentials from %v filepath", filename)
+			}
+			return credentials.StorageAccount, credentials.SecretKey, nil
+		}
+	}
+
+	return "", "", fmt.Errorf("unable to get credentials")
+}
+
+func readABSCredentialsJSON(filename string, prefixString string) (*absCredentials, error) {
+	jsonData, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return absCredentialsFromJSON(jsonData, prefixString)
+}
+
+// absCredentialsFromJSON obtains ABS credentials from a JSON value.
+func absCredentialsFromJSON(jsonData []byte, prefixString string) (*absCredentials, error) {
+	absConfig := &absCredentials{}
+	if err := json.Unmarshal(jsonData, absConfig); err != nil {
+		return nil, err
+	}
+
+	return absConfig, nil
+}
+
+func absReadCredentialsFile(filename string, prefixString string) (*absCredentials, error) {
+	absConfig := &absCredentials{}
+
+	files, err := ioutil.ReadDir(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		if file.Name() == "storageAccount" {
+			data, err := ioutil.ReadFile(filename + "/storageAccount")
+			if err != nil {
+				return nil, err
+			}
+			absConfig.StorageAccount = string(data)
+		} else if file.Name() == "storageKey" {
+			data, err := ioutil.ReadFile(filename + "/storageKey")
+			if err != nil {
+				return nil, err
+			}
+			absConfig.SecretKey = string(data)
+		}
+	}
+
+	return absConfig, nil
 }
 
 // GetABSSnapstoreFromClient returns a new ABS object for a given container using the supplied storageClient

--- a/pkg/snapstore/oss_snapstore.go
+++ b/pkg/snapstore/oss_snapstore.go
@@ -15,6 +15,7 @@
 package snapstore
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -44,16 +45,19 @@ type OSSBucket interface {
 
 const (
 	// Total number of chunks to be uploaded must be one less than maximum limit allowed.
-	ossNoOfChunk    int64 = 9999
-	ossEndPoint           = "ALICLOUD_ENDPOINT"
-	accessKeyID           = "ALICLOUD_ACCESS_KEY_ID"
-	accessKeySecret       = "ALICLOUD_ACCESS_KEY_SECRET"
+	ossNoOfChunk          int64 = 9999
+	ossEndPoint                 = "ALICLOUD_ENDPOINT"
+	accessKeyID                 = "ALICLOUD_ACCESS_KEY_ID"
+	accessKeySecret             = "ALICLOUD_ACCESS_KEY_SECRET"
+	aliCredentialFile           = "ALICLOUD_APPLICATION_CREDENTIALS"
+	aliCredentialJSONFile       = "ALICLOUD_APPLICATION_CREDENTIALS_JSON"
 )
 
 type authOptions struct {
-	endpoint  string
-	accessID  string
-	accessKey string
+	Endpoint   string `json:"storageEndpoint"`
+	AccessID   string `json:"accessKeyID"`
+	AccessKey  string `json:"accessKeySecret"`
+	BucketName string `json:"bucketName"`
 }
 
 // OSSSnapStore is snapstore with Alicloud OSS object store as backend
@@ -67,15 +71,15 @@ type OSSSnapStore struct {
 
 // NewOSSSnapStore create new OSSSnapStore from shared configuration with specified bucket
 func NewOSSSnapStore(config *brtypes.SnapstoreConfig) (*OSSSnapStore, error) {
-	ao, err := authOptionsFromEnv(getEnvPrefixString(config.IsSource))
+	ao, err := getAuthOptions(getEnvPrefixString(config.IsSource))
 	if err != nil {
 		return nil, err
 	}
-	return newOSSFromAuthOpt(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads, ao)
+	return newOSSFromAuthOpt(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads, *ao)
 }
 
 func newOSSFromAuthOpt(bucket, prefix, tempDir string, maxParallelChunkUploads uint, ao authOptions) (*OSSSnapStore, error) {
-	client, err := oss.New(ao.endpoint, ao.accessID, ao.accessKey)
+	client, err := oss.New(ao.Endpoint, ao.AccessID, ao.AccessKey)
 	if err != nil {
 		return nil, err
 	}
@@ -263,25 +267,105 @@ func (s *OSSSnapStore) Delete(snap brtypes.Snapshot) error {
 	return s.bucket.DeleteObject(path.Join(snap.Prefix, snap.SnapDir, snap.SnapName))
 }
 
-func authOptionsFromEnv(prefix string) (authOptions, error) {
+func getAuthOptions(prefix string) (*authOptions, error) {
+
+	// TODO: passing credentials through environment variable will be deprecated by "backup-restore v0.18.0"
+	if _, isSet := os.LookupEnv(prefix + ossEndPoint); isSet {
+		return authOptionsFromEnv(prefix)
+	}
+
+	if _, isSet := os.LookupEnv(aliCredentialJSONFile); isSet {
+		if filename := os.Getenv(aliCredentialJSONFile); filename != "" {
+			ao, err := readALICredentialsJSON(filename, prefix)
+			if err != nil {
+				return nil, fmt.Errorf("error getting credentials using %v file", filename)
+			}
+			return ao, nil
+		}
+	}
+
+	if _, isSet := os.LookupEnv(aliCredentialFile); isSet {
+		if filename := os.Getenv(aliCredentialFile); filename != "" {
+			ao, err := aliReadCredentialsFile(filename, prefix)
+			if err != nil {
+				return nil, fmt.Errorf("error getting credentials from %v filepath", filename)
+			}
+			return ao, nil
+		}
+	}
+
+	return nil, fmt.Errorf("unable to get credentials")
+}
+
+func readALICredentialsJSON(filename string, prefix string) (*authOptions, error) {
+	jsonData, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return aliCredentialsFromJSON(jsonData, prefix)
+}
+
+// aliCredentialsFromJSON obtains AliCloud OSS credentials from a JSON value.
+func aliCredentialsFromJSON(jsonData []byte, prefix string) (*authOptions, error) {
+	aliConfig := &authOptions{}
+	if err := json.Unmarshal(jsonData, aliConfig); err != nil {
+		return nil, err
+	}
+
+	return aliConfig, nil
+}
+
+func aliReadCredentialsFile(filename string, prefix string) (*authOptions, error) {
+	aliConfig := &authOptions{}
+
+	files, err := ioutil.ReadDir(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		if file.Name() == "storageEndpoint" {
+			data, err := ioutil.ReadFile(filename + "/storageEndpoint")
+			if err != nil {
+				return nil, err
+			}
+			aliConfig.Endpoint = string(data)
+		} else if file.Name() == "accessKeySecret" {
+			data, err := ioutil.ReadFile(filename + "/accessKeySecret")
+			if err != nil {
+				return nil, err
+			}
+			aliConfig.AccessKey = string(data)
+		} else if file.Name() == "accessKeyID" {
+			data, err := ioutil.ReadFile(filename + "/accessKeyID")
+			if err != nil {
+				return nil, err
+			}
+			aliConfig.AccessID = string(data)
+		}
+	}
+
+	return aliConfig, nil
+}
+
+func authOptionsFromEnv(prefix string) (*authOptions, error) {
 	endpoint, err := GetEnvVarOrError(prefix + ossEndPoint)
 	if err != nil {
-		return authOptions{}, err
+		return nil, err
 	}
 	accessID, err := GetEnvVarOrError(prefix + accessKeyID)
 	if err != nil {
-		return authOptions{}, err
+		return nil, err
 	}
 	accessKey, err := GetEnvVarOrError(prefix + accessKeySecret)
 	if err != nil {
-		return authOptions{}, err
+		return nil, err
 	}
 
-	ao := authOptions{
-		endpoint:  endpoint,
-		accessID:  accessID,
-		accessKey: accessKey,
-	}
-
-	return ao, nil
+	return &authOptions{
+		Endpoint:  endpoint,
+		AccessID:  accessID,
+		AccessKey: accessKey,
+	}, nil
 }

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -46,7 +46,7 @@ const (
 	awsAcessKeyID               = "AWS_ACCESS_KEY_ID"
 	awsRegion                   = "AWS_REGION"
 	awsCredentialFile           = "AWS_APPLICATION_CREDENTIALS"
-	awsCredentialJSONFile       = "AWS_APPLICATION_CREDENTIALS_Json"
+	awsCredentialJSONFile       = "AWS_APPLICATION_CREDENTIALS_JSON"
 )
 
 // S3SnapStore is snapstore with AWS S3 object store as backend
@@ -60,7 +60,7 @@ type S3SnapStore struct {
 	tempDir                 string
 }
 
-type credentialsFile struct {
+type awsCredentials struct {
 	AccessKeyID     string `json:"accessKeyID"`
 	Region          string `json:"region"`
 	SecretAccessKey string `json:"secretAccessKey"`
@@ -100,7 +100,7 @@ func getSessionOptions(prefixString string) (session.Options, error) {
 
 	if _, isSet := os.LookupEnv(awsCredentialJSONFile); isSet {
 		if filename := os.Getenv(awsCredentialJSONFile); filename != "" {
-			creds, err := readCredentialsJSONFile(filename, prefixString)
+			creds, err := readAWSCredentialsJSONFile(filename, prefixString)
 			if err != nil {
 				return session.Options{}, fmt.Errorf("error getting credentials using %v file", filename)
 			}
@@ -110,9 +110,9 @@ func getSessionOptions(prefixString string) (session.Options, error) {
 
 	if _, isSet := os.LookupEnv(awsCredentialFile); isSet {
 		if filename := os.Getenv(awsCredentialFile); filename != "" {
-			creds, err := readCredentialsFile(filename, prefixString)
+			creds, err := readAWSCredentialsFile(filename, prefixString)
 			if err != nil {
-				return session.Options{}, fmt.Errorf("error getting credentials using %v file", filename)
+				return session.Options{}, fmt.Errorf("error getting credentials from %v filepath", filename)
 			}
 			return creds, nil
 		}
@@ -125,7 +125,7 @@ func getSessionOptions(prefixString string) (session.Options, error) {
 	}, nil
 }
 
-func readCredentialsJSONFile(filename string, prefixString string) (session.Options, error) {
+func readAWSCredentialsJSONFile(filename string, prefixString string) (session.Options, error) {
 	jsonData, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return session.Options{}, err
@@ -137,7 +137,7 @@ func readCredentialsJSONFile(filename string, prefixString string) (session.Opti
 
 // credentialsFromJSON obtains AWS credentials from a JSON value.
 func credentialsFromJSON(jsonData []byte, prefixString string) (session.Options, error) {
-	awsConfig := &credentialsFile{}
+	awsConfig := &awsCredentials{}
 	if err := json.Unmarshal(jsonData, awsConfig); err != nil {
 		return session.Options{}, err
 	}
@@ -150,8 +150,8 @@ func credentialsFromJSON(jsonData []byte, prefixString string) (session.Options,
 	}, nil
 }
 
-func readCredentialsFile(filename string, prefixString string) (session.Options, error) {
-	awsConfig := &credentialsFile{}
+func readAWSCredentialsFile(filename string, prefixString string) (session.Options, error) {
+	awsConfig := &awsCredentials{}
 
 	files, err := ioutil.ReadDir(filename)
 	if err != nil {

--- a/pkg/snapstore/swift_snapstore.go
+++ b/pkg/snapstore/swift_snapstore.go
@@ -16,6 +16,7 @@ package snapstore
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -37,7 +38,9 @@ import (
 )
 
 const (
-	envPrefixSource = "SOURCE_OS_"
+	envPrefixSource         = "SOURCE_OS_"
+	swiftCredentialFile     = "OPENSTACK_APPLICATION_CREDENTIALS"
+	swiftCredentialJSONFile = "OPENSTACK_APPLICATION_CREDENTIALS_JSON"
 )
 
 // SwiftSnapStore is snapstore with Openstack Swift as backend
@@ -50,6 +53,16 @@ type SwiftSnapStore struct {
 	tempDir                 string
 }
 
+type swiftCredentials struct {
+	AuthURL    string `json:"authURL"`
+	BucketName string `json:"bucketName"`
+	DomainName string `json:"domainName"`
+	Password   string `json:"password"`
+	Region     string `json:"region"`
+	TenantName string `json:"tenantName"`
+	Username   string `json:"username"`
+}
+
 const (
 	// Total number of chunks to be uploaded must be one less than maximum limit allowed.
 	swiftNoOfChunk int64 = 999 //Default configuration in swift installation
@@ -57,7 +70,12 @@ const (
 
 // NewSwiftSnapStore create new SwiftSnapStore from shared configuration with specified bucket
 func NewSwiftSnapStore(config *brtypes.SnapstoreConfig) (*SwiftSnapStore, error) {
-	authOpts, err := clientconfig.AuthOptions(getClientOpts(config.IsSource))
+	clientOpts, err := getClientOpts(config.IsSource)
+	if err != nil {
+		return nil, err
+	}
+
+	authOpts, err := clientconfig.AuthOptions(clientOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -82,13 +100,123 @@ func NewSwiftSnapStore(config *brtypes.SnapstoreConfig) (*SwiftSnapStore, error)
 
 }
 
-func getClientOpts(isSource bool) *clientconfig.ClientOpts {
+func getClientOpts(isSource bool) (*clientconfig.ClientOpts, error) {
 	if isSource {
 		return &clientconfig.ClientOpts{
 			EnvPrefix: envPrefixSource,
+		}, nil
+	}
+
+	if _, isSet := os.LookupEnv(swiftCredentialJSONFile); isSet {
+		if filename := os.Getenv(swiftCredentialJSONFile); filename != "" {
+			clientOpts, err := readSwiftCredentialsJSON(filename)
+			if err != nil {
+				return &clientconfig.ClientOpts{}, fmt.Errorf("error getting credentials using %v file", filename)
+			}
+			return clientOpts, nil
 		}
 	}
-	return &clientconfig.ClientOpts{}
+
+	if _, isSet := os.LookupEnv(swiftCredentialFile); isSet {
+		if filename := os.Getenv(swiftCredentialFile); filename != "" {
+			clientOpts, err := swiftReadCredentialsFile(filename)
+			if err != nil {
+				return &clientconfig.ClientOpts{}, fmt.Errorf("error getting credentials from %v filepath", filename)
+			}
+			return clientOpts, nil
+		}
+	}
+
+	return &clientconfig.ClientOpts{}, nil
+}
+
+func readSwiftCredentialsJSON(filename string) (*clientconfig.ClientOpts, error) {
+	jsonData, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return swiftCredentialsFromJSON(jsonData)
+
+}
+
+// swiftCredentialsFromJSON obtains Swift credentials from a JSON value.
+func swiftCredentialsFromJSON(jsonData []byte) (*clientconfig.ClientOpts, error) {
+	cred := &swiftCredentials{}
+	if err := json.Unmarshal(jsonData, cred); err != nil {
+		return nil, err
+	}
+
+	os.Setenv("OS_TENANT_NAME", cred.TenantName)
+	return &clientconfig.ClientOpts{
+		AuthInfo: &clientconfig.AuthInfo{
+			AuthURL:    cred.AuthURL,
+			DomainName: cred.DomainName,
+			Password:   cred.Password,
+			Username:   cred.Username,
+		},
+		RegionName: cred.Region,
+	}, nil
+}
+
+func swiftReadCredentialsFile(filename string) (*clientconfig.ClientOpts, error) {
+	cred := &swiftCredentials{}
+
+	files, err := ioutil.ReadDir(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		if file.Name() == "authURL" {
+			data, err := ioutil.ReadFile(filename + "/authURL")
+			if err != nil {
+				return nil, err
+			}
+			cred.AuthURL = string(data)
+		} else if file.Name() == "domainName" {
+			data, err := ioutil.ReadFile(filename + "/domainName")
+			if err != nil {
+				return nil, err
+			}
+			cred.DomainName = string(data)
+		} else if file.Name() == "password" {
+			data, err := ioutil.ReadFile(filename + "/password")
+			if err != nil {
+				return nil, err
+			}
+			cred.Password = string(data)
+		} else if file.Name() == "region" {
+			data, err := ioutil.ReadFile(filename + "/region")
+			if err != nil {
+				return nil, err
+			}
+			cred.Region = string(data)
+		} else if file.Name() == "tenantName" {
+			data, err := ioutil.ReadFile(filename + "/tenantName")
+			if err != nil {
+				return nil, err
+			}
+			cred.TenantName = string(data)
+		} else if file.Name() == "username" {
+			data, err := ioutil.ReadFile(filename + "/username")
+			if err != nil {
+				return nil, err
+			}
+			cred.Username = string(data)
+		}
+	}
+
+	os.Setenv("OS_TENANT_NAME", cred.TenantName)
+	return &clientconfig.ClientOpts{
+		AuthInfo: &clientconfig.AuthInfo{
+			AuthURL:    cred.AuthURL,
+			DomainName: cred.DomainName,
+			Password:   cred.Password,
+			Username:   cred.Username,
+		},
+		RegionName: cred.Region,
+	}, nil
 }
 
 // NewSwiftSnapstoreFromClient will create the new Swift snapstore object from Swift client

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -207,7 +207,7 @@ func RunSnapshotter(logger *logrus.Entry, snapstoreConfig brtypes.SnapstoreConfi
 
 	healthConfig := brtypes.NewHealthConfig()
 
-	ssr, err := snapshotter.NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig)
+	ssr, err := snapshotter.NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, &snapstoreConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
**To Dynamically load IaaS credentials during runtime:**

- [x] To circumvent a required restart, `etcd-backup-restore` will recreate/update the snapstore object  every time it performs any action on the bucket.
- [x] Mount Kubernetes secrets into the container:
  - [x] AWS s3
  - [x] Azure Blob Storage
  - [x] Alicloud Object storage
  - [x] Swift (Openstack)

**Which issue(s) this PR fixes**:
Fixes #422 

**Special notes for your reviewer**:

**Release note**:
```improvement operator

```
