### PR TITLE
Add support for custom endpoints in S3 snapstore

### DIFF
--- a/doc/usage/getting_started.md
+++ b/doc/usage/getting_started.md
@@ -16,7 +16,8 @@ The procedure to provide credentials to access the cloud provider object store v
 * For `AWS S3`: 
    1. The secret file should be provided and it's file path should be made available as environment variables: `AWS_APPLICATION_CREDENTIALS` or `AWS_APPLICATION_CREDENTIALS_JSON`.
    2. `AWS_REGION`, `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` should be made available as environment variables.
-
+   3. For `S3-compatible providers` such as MinIO, `AWS_ENDPOINT` and `AWS_FORCE_PATH_STYLE` can be made available as environment variables to
+   configure the S3 client to communicate to a non-AWS provider.
 
 * For  `Google Cloud Storage`: 
    1. The service account json file should be provided in the `~/.gcp` as a `service-account-file.json` file.

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -45,6 +46,8 @@ const (
 	awsSecretAccessKey          = "AWS_SECRET_ACCESS_KEY"
 	awsAcessKeyID               = "AWS_ACCESS_KEY_ID"
 	awsRegion                   = "AWS_REGION"
+	awsEndpoint                 = "AWS_ENDPOINT"
+	awsForcePathStyle           = "AWS_FORCE_PATH_STYLE"
 	awsCredentialFile           = "AWS_APPLICATION_CREDENTIALS"
 	awsCredentialJSONFile       = "AWS_APPLICATION_CREDENTIALS_JSON"
 )
@@ -88,12 +91,18 @@ func newS3FromSessionOpt(bucket, prefix, tempDir string, maxParallelChunkUploads
 
 func getSessionOptions(prefixString string) (session.Options, error) {
 
+	var s3path *bool
+	if val, err := strconv.ParseBool(os.Getenv(awsForcePathStyle)); err != nil {
+		s3path = &val
+	}
 	// TODO: passing credentials through environment variable will be deprecated by "backup-restore v0.18.0"
 	if _, isSet := os.LookupEnv(prefixString + awsAcessKeyID); isSet {
 		return session.Options{
 			Config: aws.Config{
-				Credentials: credentials.NewStaticCredentials(os.Getenv(prefixString+awsAcessKeyID), os.Getenv(prefixString+awsSecretAccessKey), ""),
-				Region:      pointer.StringPtr(os.Getenv(awsRegion)),
+				Credentials:      credentials.NewStaticCredentials(os.Getenv(prefixString+awsAcessKeyID), os.Getenv(prefixString+awsSecretAccessKey), ""),
+				Region:           pointer.StringPtr(os.Getenv(awsRegion)),
+				Endpoint:         pointer.StringPtr(os.Getenv(awsEndpoint)),
+				S3ForcePathStyle: s3path,
 			},
 		}, nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the capability to specify a different S3 endpoint within the S3 snapstore logic. This allows usage of etcd-backup-restore with non-AWS S3-compliant providers, such as [min.io](https://min.io/) or [Linode Object Storage](https://www.linode.com/products/object-storage/). It also adds a way of setting `S3ForcePathStyle`, which is needed for etcd-backup-restore to be able to save the snapshot in these S3-compatible providers. 

Note that by default when using the AWS SDK client, providing an empty string in the Endpoint field of the `aws.Config{}` struct is functionally similar to what was being done before (which was keeping it nil), and will generate the default endpoint, see: https://pkg.go.dev/github.com/aws/aws-sdk-go@v1.22.0/aws?utm_source=gopls#Config

Last but not least, I understand there's at least [one PR ](https://github.com/gardener/etcd-backup-restore/pull/428)that may modify the logic in this one. I am willing to rebase this PR if necessary if that one gets merged first.

**Which issue(s) this PR fixes**:
Fixes #416

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
* Added support for non-AWS S3-compatible providers by specifying a custom endpoint.
```
