### PR TITLE
Don't hide error when creating K8s client

### DIFF
--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -172,11 +172,11 @@ func GetKubernetesClientSetOrError() (client.Client, error) {
 	var cl client.Client
 	restConfig, err := config.GetConfig()
 	if err != nil {
-		return nil, fmt.Errorf("could not get InCluster config")
+		return nil, err
 	}
 	cl, err = client.New(restConfig, client.Options{})
 	if err != nil {
-		return nil, fmt.Errorf("could not create kubernetes clientset")
+		return nil, err
 	}
 	return cl, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of returning a new error, we should return the original one to not cover important information that can help to solve the issue.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
