### PR TITLE
Handle SIGTERM in main signal handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"syscall"
 
 	"github.com/gardener/etcd-backup-restore/cmd"
 )
@@ -45,10 +46,9 @@ func main() {
 func setupSignalHandler() context.Context {
 	close(onlyOneSignalHandler) // panics when called twice
 
-	var shutdownSignals = []os.Signal{os.Interrupt}
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 2)
-	signal.Notify(c, shutdownSignals...)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c
 		cancel()


### PR DESCRIPTION
**What this PR does / why we need it**:
The changes in here allow etcd-backup-restore to exit cleanly (cancel all contexts, stop leaderelection) when it's running inside a Kubernetes cluster, and the container receives a SIGTERM when the Pod is terminating.

I kept the SIGINT signal, since previously it caught it as well (via `os.Interrupt`). More information: https://pkg.go.dev/os/signal

**Special notes for your reviewer**:
I tested this by running etcd-backup-restore standalone and sending it SIGINT and SIGTERM signals:
```
pkill --signal SIGTERM <PROCESS NAME>
```

**Release note**:
```improvement operator
Fixed etcd-backup-restore exiting immediately on SIGTERM without proper context cancellation
```
