### PR TITLE
Reduce verbosity of leader current state log

### DIFF
--- a/pkg/leaderelection/leaderelection.go
+++ b/pkg/leaderelection/leaderelection.go
@@ -142,7 +142,7 @@ func (le *LeaderElector) Run(ctx context.Context) error {
 				le.CurrentState = StateFollower
 				le.logger.Infof("backup-restore changed the state from %v to %v", StateUnknown, le.CurrentState)
 			} else if !isLeader && le.CurrentState == StateFollower {
-				le.logger.Infof("backup-restore currentState: %v", le.CurrentState)
+				le.logger.Debugf("backup-restore currentState: %v", le.CurrentState)
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduces the amount of logs when running etcd-backup-restore as a Follower in a multi-instance etcd configuration:
```
time="2022-02-21T16:39:47Z" level=info msg="backup-restore currentState: Follower" actor=leader-elector
time="2022-02-21T16:39:52Z" level=info msg="backup-restore currentState: Follower" actor=leader-elector
time="2022-02-21T16:39:57Z" level=info msg="backup-restore currentState: Follower" actor=leader-elector
time="2022-02-21T16:40:02Z" level=info msg="backup-restore currentState: Follower" actor=leader-elector
time="2022-02-21T16:40:07Z" level=info msg="backup-restore currentState: Follower" actor=leader-elector
```

**Which issue(s) this PR fixes**:
Fixes very verbose logs on non-leader etcd-backup-restore.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
