### PR TITLE
Add feature parity for s3 compliant providers

### DIFF
--- a/example/storage-provider-secrets/01-aws-s3-storage-secret.yaml
+++ b/example/storage-provider-secrets/01-aws-s3-storage-secret.yaml
@@ -8,6 +8,8 @@ data:
   region: ZXUtd2VzdC0x # eu-west-1
   accessKeyID: YWRtaW4= # admin
   secretAccessKey: YWRtaW4= # admin
+# endpoint: # used for S3 compatible providers
+# s3ForcePathStyle: # set to `true` for S3 compliant providers
 
 #### OR ####
 
@@ -25,3 +27,11 @@ stringData:
     "region": "admin",
     "secretAccessKey": "admin"
     } 
+# secret.json: |-
+#  {
+#  "accessKeyID": "eu-west-1",
+#  "region": "admin",
+#  "secretAccessKey": "admin",
+#  "endpoint": "https://example.com:9000",
+#  "s3ForcePathStyle" true
+#  }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for S3 compatible providers (see #431) when configuration is passed via secrets.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
None
```
