### PR TITLE
Fixed bug in compactor pkg where etcd defragmentation was started be…

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/restorer"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+	"go.etcd.io/etcd/clientv3"
 
 	"github.com/sirupsen/logrus"
 
@@ -129,11 +130,11 @@ func (cp *Compactor) Compact(ctx context.Context, opts *brtypes.CompactOptions) 
 	etcdRevision := getResponse.Header.GetRevision()
 
 	// Compact
-	if _, err := clientKV.Compact(ctx, etcdRevision); err != nil {
+	if _, err := clientKV.Compact(ctx, etcdRevision, clientv3.WithCompactPhysical()); err != nil {
 		return nil, fmt.Errorf("failed to compact: %v", err)
 	}
 
-	// Then defrag the ETCD
+	// Then defrag ETCD
 	if opts.NeedDefragmentation {
 		client, err := clientFactory.NewCluster()
 		if err != nil {

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -130,6 +130,8 @@ func (cp *Compactor) Compact(ctx context.Context, opts *brtypes.CompactOptions) 
 	etcdRevision := getResponse.Header.GetRevision()
 
 	// Compact
+	// Please refer below issue for why physical compaction was necessary
+	// https://github.com/gardener/etcd-backup-restore/issues/451
 	if _, err := clientKV.Compact(ctx, etcdRevision, clientv3.WithCompactPhysical()); err != nil {
 		return nil, fmt.Errorf("failed to compact: %v", err)
 	}

--- a/pkg/defragmentor/defrag_test.go
+++ b/pkg/defragmentor/defrag_test.go
@@ -252,7 +252,7 @@ var _ = Describe("Defrag", func() {
 			oldRevision := oldStatus.Header.GetRevision()
 
 			// compact the ETCD DB to let the defragmentor have full effect
-			_, err = clientKV.Compact(testCtx, oldRevision)
+			_, err = clientKV.Compact(testCtx, oldRevision, clientv3.WithCompactPhysical())
 			Expect(err).ShouldNot(HaveOccurred())
 			defragmentorJob := NewDefragmentorJob(testCtx, etcdConnectionConfig, logger, nil)
 			defragmentorJob.Run()


### PR DESCRIPTION
…fore etcd compaction was complete

**What this PR does / why we need it**:
In the etcdbr compaction subcommand, we build an etcd db using full/delta snapshots available in the snapstore, compact the db, defragment it, and finally take a snapshot of the resultant db to obtain a compacted snapshot.

A bug was noticed where the etcd defragmentation was started before the etcd compaction was complete.
This results in performance degradation as defragmentation is no longer effective without a compacted db and leads to large snapshot sizes. 

This PR adds changes to make the etcd compact request wait until compaction is complete before proceeding to defragmentation, thus achieving proper results

**Which issue(s) this PR fixes**:
Fixes #451 

**Special notes for your reviewer**:
Ref: [CompactionRequest Options](https://etcd.io/docs/v3.2/dev-guide/api_reference_v3/#message-compactionrequest-etcdserveretcdserverpbrpcproto)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
