### PR TITLE
Don't fail the Ownercheck when DNS resolve lookup fails.

### DIFF
--- a/pkg/common/checkeractionwatchdog.go
+++ b/pkg/common/checkeractionwatchdog.go
@@ -77,8 +77,10 @@ func (w *checkerActionWatchdog) Start(ctx context.Context) {
 
 		for {
 			result, err := w.checker.Check(ctx)
-			if err != nil || !result {
-				w.logger.Debug("Performing watchdog action")
+			if err != nil {
+				w.logger.Errorf("watchdog check fails: %v", err)
+			} else if !result {
+				w.logger.Info("Performing watchdog action")
 				w.action.Do(ctx)
 				return
 			}

--- a/pkg/common/ownerchecker.go
+++ b/pkg/common/ownerchecker.go
@@ -16,7 +16,6 @@ package common
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -59,7 +58,7 @@ func (c *ownerChecker) Check(ctx context.Context) (bool, error) {
 	owner, err := c.resolver.LookupTXT(ctx, c.ownerName)
 	if err != nil {
 		c.logger.Errorf("Could not resolve owner domain name %s: %v", c.ownerName, err)
-		return false, fmt.Errorf("could not resolve owner domain name %s: %w", c.ownerName, err)
+		return false, err
 	}
 
 	var actualOwnerID string


### PR DESCRIPTION
**What this PR does / why we need it**:
Don't set the [HTTP  handler status to StatusServiceUnavailable](https://github.com/gardener/etcd-backup-restore/blob/03920151cfeeb50d6e8a35c7de2aa1f7c6670625/pkg/server/backuprestoreserver.go#L267) when the ownercheck's [DNS resolve lookup](https://github.com/gardener/etcd-backup-restore/blob/03920151cfeeb50d6e8a35c7de2aa1f7c6670625/pkg/common/ownerchecker.go#L59) fails.
Set the [HTTP  handler status to StatusServiceUnavailable](https://github.com/gardener/etcd-backup-restore/blob/03920151cfeeb50d6e8a35c7de2aa1f7c6670625/pkg/server/backuprestoreserver.go#L267) only when  [OwnerCheck](https://github.com/gardener/etcd-backup-restore/blob/03920151cfeeb50d6e8a35c7de2aa1f7c6670625/pkg/common/ownerchecker.go#L43) confirms that the current ownership has changed.

**Which issue(s) this PR fixes**:
Fixes #437 

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```

cc @plkokanov 