### PR TITLE
To capture the Full snapshot time taken and compression time taken

### DIFF
--- a/pkg/types/compactor.go
+++ b/pkg/types/compactor.go
@@ -26,7 +26,7 @@ const (
 	// defaultDefragTimeout defines default timeout duration for ETCD defrag call during compaction of snapshots.
 	defaultDefragTimeout time.Duration = 8 * time.Minute
 	// defaultSnapshotTimeout defines default timeout duration for taking compacted FullSnapshot.
-	defaultSnapshotTimeout time.Duration = 8 * time.Minute
+	defaultSnapshotTimeout time.Duration = 30 * time.Minute
 )
 
 // CompactOptions holds all configurable options of compact.

--- a/pkg/types/etcdconnection.go
+++ b/pkg/types/etcdconnection.go
@@ -30,7 +30,7 @@ const (
 	// DefaultDefragConnectionTimeout defines default timeout duration for ETCD defrag call.
 	DefaultDefragConnectionTimeout time.Duration = 8 * time.Minute
 	// DefaultSnapshotTimeout defines default timeout duration for taking FullSnapshot.
-	DefaultSnapshotTimeout time.Duration = 8 * time.Minute
+	DefaultSnapshotTimeout time.Duration = 15 * time.Minute
 
 	// DefragRetryPeriod is used as the duration after which a defragmentation is retried.
 	DefragRetryPeriod time.Duration = 1 * time.Minute


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Log the time taken by [compression](https://github.com/gardener/etcd-backup-restore/blob/1e3169cd7b7ea8d482f95ecd5fc4e23a6aed92e5/pkg/etcdutil/etcdutil.go#L258) to compress the full snapshot.
2. Log the time taken by [full snapshot api call](https://github.com/gardener/etcd-backup-restore/blob/1e3169cd7b7ea8d482f95ecd5fc4e23a6aed92e5/pkg/etcdutil/etcdutil.go#L251)
3. Increase the default snapshot time taken.

**Which issue(s) this PR fixes**:
Fixes #454 

**Special notes for your reviewer**:

```improvement operator
NONE
```
