### PR TITLE
Fix defragmentation fail issue which occurs due certificate IP SANs for single node etcd.

### DIFF
--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -203,6 +203,11 @@ func GetAllEtcdEndpoints(ctx context.Context, client etcdClient.ClusterCloser, e
 		etcdEndpoints = append(etcdEndpoints, member.GetClientURLs()...)
 	}
 
+	// For single node etcd: use endpoint which was passed through etcdConnectionConfig
+	// refer: https://github.com/gardener/etcd-druid/issues/325
+	if len(etcdEndpoints) == 1 {
+		etcdEndpoints = etcdConnectionConfig.Endpoints
+	}
 	return etcdEndpoints, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix defragmentation fail issue which occurs due certificate IP SANs for single node etcd.

**Which issue(s) this PR fixes**:
Fixes [#325](https://github.com/gardener/etcd-druid/issues/325) of etcd-druid.

**Special notes for your reviewer**:

**Release note**:
```bugfix operator
Fix defragmentation fail issue which occurs due to x509: failed to validate certificate for 0.0.0.0 because it doesn't contain any IP SANs.
```
