### PR TITLE
Reduce verbosity of Renew member lease logs.

### DIFF
--- a/pkg/health/heartbeat/heartbeat.go
+++ b/pkg/health/heartbeat/heartbeat.go
@@ -137,7 +137,7 @@ func (hb *Heartbeat) RenewMemberLease(ctx context.Context) error {
 		}
 	}
 
-	hb.logger.Info("Renewed member lease for etcd at ", renewedTime)
+	hb.logger.Debugf("Renewed member lease for etcd memberID: %v", memberID)
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduces the amount of logs when running `etcd-backup-restore`. Also removed the time from the log as time is already there.
```
time="2022-03-31T14:24:52Z" level=info msg="Renewed member lease for etcd at 2022-03-31 14:24:52.244446329 +0000 UTC m=+494.963656744" actor=heartbeat
time="2022-03-31T14:25:02Z" level=info msg="Renewed member lease for etcd at 2022-03-31 14:25:02.299752615 +0000 UTC m=+505.018963027" actor=heartbeat
time="2022-03-31T14:25:12Z" level=info msg="Renewed member lease for etcd at 2022-03-31 14:25:12.353494461 +0000 UTC m=+515.072704874" actor=heartbeat
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @aaronfern 

**Release note**:
```improvement operator
NONE
```
