### PR TITLE
Add feature parity for s3 compliant providers.

### DIFF
--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -172,8 +172,10 @@ func readAWSCredentialFiles(dirname string) (session.Options, error) {
 
 	return session.Options{
 		Config: aws.Config{
-			Credentials: credentials.NewStaticCredentials(awsConfig.AccessKeyID, awsConfig.SecretAccessKey, ""),
-			Region:      pointer.StringPtr(awsConfig.Region),
+			Credentials:      credentials.NewStaticCredentials(awsConfig.AccessKeyID, awsConfig.SecretAccessKey, ""),
+			Region:           pointer.StringPtr(awsConfig.Region),
+			Endpoint:         awsConfig.Endpoint,
+			S3ForcePathStyle: awsConfig.S3ForcePathStyle,
 		},
 	}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for S3 compatible providers (see #431) when configuration is passed via secrets mounts which was somehow missed by this PR https://github.com/gardener/etcd-backup-restore/pull/446

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
