### PR TITLE
OCS S3 Snapstore support access information via mounted secret

### DIFF
--- a/doc/usage/getting_started.md
+++ b/doc/usage/getting_started.md
@@ -38,6 +38,11 @@ The procedure to provide credentials to access the cloud provider object store v
 * For `Dell EMC ECS`:
   1. `ECS_ENDPOINT`, `ECS_ACCESS_KEY_ID`, `ECS_SECRET_ACCESS_KEY` should be made available as environment variables. For development purposes, the environment variables `ECS_DISABLE_SSL` and `ECS_INSECURE_SKIP_VERIFY` can also be set to "true" or "false".
 
+* For `Openshift Container Storage (OCS)`:
+  1. The secret file should be provided and file path should be made available as environment variables: `OPENSHIFT_APPLICATION_CREDENTIALS` or `OPENSHIFT_APPLICATION_CREDENTIALS_JSON`.
+  2. `OCS_ENDPOINT`, `OCS_REGION`, `OCS_ACCESS_KEY_ID`, `OCS_SECRET_ACCESS_KEY` should be made available as environment variables.
+  For development purposes, the environment variables `OCS_DISABLE_SSL` and `OCS_INSECURE_SKIP_VERIFY` can also be set to "true" or "false".
+
 
 Check the [example of storage provider secrets](https://github.com/gardener/etcd-backup-restore/tree/master/example/storage-provider-secrets)
 

--- a/example/storage-provider-secrets/05-openshift-container-storage-secret.yaml
+++ b/example/storage-provider-secrets/05-openshift-container-storage-secret.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-backup
+  namespace: example-ocs
+type: Opaque
+data:
+  accessKeyID: YWRtaW4= # admin
+  secretAccessKey: YWRtaW4= # admin
+  endpoint: aHR0cHM6Ly9vY3Mub3BlbnNoaWZ0Lm9yZw== # https://ocs.openshift.org
+  region: cmVnaW9uMQ== #region1
+
+### OR ###
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-backup
+  namespace: example-json-ocs
+type: Opaque
+stringData:
+  secret.json: |-
+    {
+      "accessKeyID": "admin",
+      "secretAccessKey": "admin",
+      "endpoint": "https://ocs.openshift.org",
+      "region": "region1"
+    }
+

--- a/pkg/snapstore/ocs_s3_snapstore.go
+++ b/pkg/snapstore/ocs_s3_snapstore.go
@@ -17,7 +17,6 @@ package snapstore
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -96,7 +95,7 @@ func getOCSAuthOptions(prefix string) (*ocsAuthOptions, error) {
 func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
 	ao := ocsAuthOptions{}
 
-	files, err := ioutil.ReadDir(dirname)
+	files, err := os.ReadDir(dirname)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +120,7 @@ func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
 			}
 		case "secretAccessKey":
 			{
-				data, err := ioutil.ReadFile(dirname + "/secretAccessKey")
+				data, err := os.ReadFile(dirname + "/secretAccessKey")
 				if err != nil {
 					return nil, err
 				}
@@ -129,7 +128,7 @@ func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
 			}
 		case "region":
 			{
-				data, err := ioutil.ReadFile(dirname + "/region")
+				data, err := os.ReadFile(dirname + "/region")
 				if err != nil {
 					return nil, err
 				}
@@ -137,7 +136,7 @@ func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
 			}
 		case "disableSSL":
 			{
-				data, err := ioutil.ReadFile(dirname + "/disableSSL")
+				data, err := os.ReadFile(dirname + "/disableSSL")
 				if err != nil {
 					return nil, err
 				}
@@ -148,7 +147,7 @@ func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
 			}
 		case "insecureSkipVerify":
 			{
-				data, err := ioutil.ReadFile(dirname + "/insecureSkipVerify")
+				data, err := os.ReadFile(dirname + "/insecureSkipVerify")
 				if err != nil {
 					return nil, err
 				}
@@ -167,7 +166,7 @@ func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
 }
 
 func readOCSCredentialsJSON(filename string) (*ocsAuthOptions, error) {
-	jsonData, err := ioutil.ReadFile(filename)
+	jsonData, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/snapstore/ocs_s3_snapstore.go
+++ b/pkg/snapstore/ocs_s3_snapstore.go
@@ -239,3 +239,17 @@ func isOCSConfigEmpty(config ocsAuthOptions) error {
 	}
 	return fmt.Errorf("ocs s3 credentials: region, secretAccessKey, endpoint or accessKeyID is missing")
 }
+
+func OCSSnapStoreHash(config *brtypes.SnapstoreConfig) (string, error) {
+	ao, err := getOCSAuthOptions("")
+	if err != nil {
+		return "", err
+	}
+
+	return getOCSHash(ao), nil
+}
+
+func getOCSHash(config *ocsAuthOptions) string {
+	data := fmt.Sprintf("%s%s%s%s%v%v", config.AccessKeyID, config.Endpoint, config.Region, config.SecretAccessKey, config.DisableSSL, config.InsecureSkipVerify)
+	return getHash(data)
+}

--- a/pkg/snapstore/ocs_s3_snapstore.go
+++ b/pkg/snapstore/ocs_s3_snapstore.go
@@ -250,6 +250,6 @@ func OCSSnapStoreHash(config *brtypes.SnapstoreConfig) (string, error) {
 }
 
 func getOCSHash(config *ocsAuthOptions) string {
-	data := fmt.Sprintf("%s%s%s%s%v%v", config.AccessKeyID, config.Endpoint, config.Region, config.SecretAccessKey, config.DisableSSL, config.InsecureSkipVerify)
+	data := fmt.Sprintf("%s%s%s%s", config.AccessKeyID, config.Endpoint, config.Region, config.SecretAccessKey)
 	return getHash(data)
 }

--- a/pkg/snapstore/ocs_s3_snapstore.go
+++ b/pkg/snapstore/ocs_s3_snapstore.go
@@ -27,6 +27,18 @@ import (
 const (
 	ocsCredentialFile         string = "OPENSHIFT_APPLICATION_CREDENTIALS"
 	ocsCredentialFileJSONFile string = "OPENSHIFT_APPLICATION_CREDENTIALS_JSON"
+
+	// TODO: passing credentials through environment variable will be deprecated by "backup-restore v0.18.0"
+	// The constants below will not be needed after the removal of this feature
+	ocsDefaultDisableSSL         bool = false
+	ocsDefaultInsecureSkipVerify bool = false
+
+	ocsEndpoint           string = "OCS_ENDPOINT"
+	ocsRegion             string = "OCS_REGION"
+	ocsDisableSSL         string = "OCS_DISABLE_SSL"
+	ocsInsecureSkipVerify string = "OCS_INSECURE_SKIP_VERIFY"
+	ocsAccessKeyID        string = "OCS_ACCESS_KEY_ID"
+	ocsSecretAccessKey    string = "OCS_SECRET_ACCESS_KEY"
 )
 
 type ocsAuthOptions struct {
@@ -67,6 +79,15 @@ func getOCSAuthOptions(prefix string) (*ocsAuthOptions, error) {
 			}
 			return ao, nil
 		}
+	}
+
+	// TODO: passing credentials through environment variable will be deprecated by "backup-restore v0.18.0"
+	if _, isSet := os.LookupEnv(prefix + ocsEndpoint); isSet {
+		ao, err := readOcsCredentialFromEnv()
+		if err != nil {
+			return nil, fmt.Errorf("error getting credentials from env: %s", err.Error())
+		}
+		return ao, nil
 	}
 
 	return nil, fmt.Errorf("unable to get credentials")
@@ -162,6 +183,44 @@ func ocsCredentialsFromJSON(jsonData []byte) (*ocsAuthOptions, error) {
 	}
 
 	return &ocsConfig, nil
+}
+
+func readOcsCredentialFromEnv() (*ocsAuthOptions, error) {
+	endpoint, err := GetEnvVarOrError(ocsEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	accessKeyID, err := GetEnvVarOrError(ocsAccessKeyID)
+	if err != nil {
+		return nil, err
+	}
+	secretAccessKey, err := GetEnvVarOrError(ocsSecretAccessKey)
+	if err != nil {
+		return nil, err
+	}
+	region, err := GetEnvVarOrError(ocsRegion)
+	if err != nil {
+		return nil, err
+	}
+	disableSSL, err := GetEnvVarToBool(ocsDisableSSL)
+	if err != nil {
+		disableSSL = ocsDefaultDisableSSL
+	}
+	insecureSkipVerify, err := GetEnvVarToBool(ocsInsecureSkipVerify)
+	if err != nil {
+		insecureSkipVerify = ocsDefaultInsecureSkipVerify
+	}
+
+	ao := ocsAuthOptions{
+		Endpoint:           endpoint,
+		Region:             region,
+		DisableSSL:         disableSSL,
+		InsecureSkipVerify: insecureSkipVerify,
+		AccessKeyID:        accessKeyID,
+		SecretAccessKey:    secretAccessKey,
+	}
+
+	return &ao, nil
 }
 
 func ocsAuthOptionsToGenericS3(options ocsAuthOptions) s3AuthOptions {

--- a/pkg/snapstore/ocs_s3_snapstore.go
+++ b/pkg/snapstore/ocs_s3_snapstore.go
@@ -240,6 +240,7 @@ func isOCSConfigEmpty(config ocsAuthOptions) error {
 	return fmt.Errorf("ocs s3 credentials: region, secretAccessKey, endpoint or accessKeyID is missing")
 }
 
+//OCSSnapStoreHash calculates and returns the hash of OCS snapstore secret.
 func OCSSnapStoreHash(config *brtypes.SnapstoreConfig) (string, error) {
 	ao, err := getOCSAuthOptions("")
 	if err != nil {

--- a/pkg/snapstore/ocs_s3_snapstore.go
+++ b/pkg/snapstore/ocs_s3_snapstore.go
@@ -113,7 +113,7 @@ func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
 			}
 		case "accessKeyID":
 			{
-				data, err := ioutil.ReadFile(dirname + "/accessKeyID")
+				data, err := os.ReadFile(dirname + "/accessKeyID")
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/snapstore/ocs_s3_snapstore.go
+++ b/pkg/snapstore/ocs_s3_snapstore.go
@@ -105,7 +105,7 @@ func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
 		switch file.Name() {
 		case "endpoint":
 			{
-				data, err := ioutil.ReadFile(dirname + "/endpoint")
+				data, err := os.ReadFile(dirname + "/endpoint")
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/snapstore/ocs_s3_snapstore.go
+++ b/pkg/snapstore/ocs_s3_snapstore.go
@@ -14,64 +14,170 @@
 
 package snapstore
 
-import brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+
+	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+)
 
 const (
-	ocsDefaultDisableSSL         bool = false
-	ocsDefaultInsecureSkipVerify bool = false
-
-	ocsEndpoint           string = "OCS_ENDPOINT"
-	ocsRegion             string = "OCS_REGION"
-	ocsDisableSSL         string = "OCS_DISABLE_SSL"
-	ocsInsecureSkipVerify string = "OCS_INSECURE_SKIP_VERIFY"
-	ocsAccessKeyID        string = "OCS_ACCESS_KEY_ID"
-	ocsSecretAccessKey    string = "OCS_SECRET_ACCESS_KEY"
+	ocsCredentialFile         string = "OPENSHIFT_APPLICATION_CREDENTIALS"
+	ocsCredentialFileJSONFile string = "OPENSHIFT_APPLICATION_CREDENTIALS_JSON"
 )
+
+type ocsAuthOptions struct {
+	Endpoint           string `json:"endpoint"`
+	Region             string `json:"region"`
+	DisableSSL         bool   `json:"disableSSL"`
+	InsecureSkipVerify bool   `json:"insecureSkipVerify"`
+	AccessKeyID        string `json:"accessKeyID"`
+	SecretAccessKey    string `json:"secretAccessKey"`
+}
 
 // NewOCSSnapStore creates a new S3SnapStore from shared configuration with the specified bucket.
 func NewOCSSnapStore(config *brtypes.SnapstoreConfig) (*S3SnapStore, error) {
-	ao, err := ocsAuthOptionsFromEnv()
+	credentials, err := getOCSAuthOptions(getEnvPrefixString(config.IsSource))
 	if err != nil {
 		return nil, err
 	}
-	return newGenericS3FromAuthOpt(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads, ao)
+
+	return newGenericS3FromAuthOpt(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads, ocsAuthOptionsToGenericS3(*credentials))
 }
 
-// ocsAuthOptionsFromEnv gets OCS provider configuration from environment variables.
-func ocsAuthOptionsFromEnv() (s3AuthOptions, error) {
-	endpoint, err := GetEnvVarOrError(ocsEndpoint)
-	if err != nil {
-		return s3AuthOptions{}, err
-	}
-	accessKeyID, err := GetEnvVarOrError(ocsAccessKeyID)
-	if err != nil {
-		return s3AuthOptions{}, err
-	}
-	secretAccessKey, err := GetEnvVarOrError(ocsSecretAccessKey)
-	if err != nil {
-		return s3AuthOptions{}, err
-	}
-	region, err := GetEnvVarOrError(ocsRegion)
-	if err != nil {
-		return s3AuthOptions{}, err
-	}
-	disableSSL, err := GetEnvVarToBool(ocsDisableSSL)
-	if err != nil {
-		disableSSL = ocsDefaultDisableSSL
-	}
-	insecureSkipVerify, err := GetEnvVarToBool(ocsInsecureSkipVerify)
-	if err != nil {
-		insecureSkipVerify = ocsDefaultInsecureSkipVerify
+func getOCSAuthOptions(prefix string) (*ocsAuthOptions, error) {
+	if _, isSet := os.LookupEnv(prefix + ocsCredentialFileJSONFile); isSet {
+		if filename := os.Getenv(prefix + ocsCredentialFileJSONFile); filename != "" {
+			ao, err := readOCSCredentialsJSON(filename)
+			if err != nil {
+				return nil, fmt.Errorf("error getting credentials using %v file", filename)
+			}
+			return ao, nil
+		}
 	}
 
-	ao := s3AuthOptions{
-		endpoint:           endpoint,
-		region:             region,
-		disableSSL:         disableSSL,
-		insecureSkipVerify: insecureSkipVerify,
-		accessKeyID:        accessKeyID,
-		secretAccessKey:    secretAccessKey,
+	if _, isSet := os.LookupEnv(prefix + ocsCredentialFile); isSet {
+		if dir := os.Getenv(prefix + ocsCredentialFile); dir != "" {
+			ao, err := readOCSCredentialFromDir(dir)
+			if err != nil {
+				return nil, fmt.Errorf("error getting credentials from %v directory", dir)
+			}
+			return ao, nil
+		}
 	}
 
-	return ao, nil
+	return nil, fmt.Errorf("unable to get credentials")
+}
+
+func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
+	ao := ocsAuthOptions{}
+
+	files, err := ioutil.ReadDir(dirname)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		switch file.Name() {
+		case "endpoint":
+			{
+				data, err := ioutil.ReadFile(dirname + "/endpoint")
+				if err != nil {
+					return nil, err
+				}
+				ao.Endpoint = string(data)
+			}
+		case "accessKeyID":
+			{
+				data, err := ioutil.ReadFile(dirname + "/accessKeyID")
+				if err != nil {
+					return nil, err
+				}
+				ao.AccessKeyID = string(data)
+			}
+		case "secretAccessKey":
+			{
+				data, err := ioutil.ReadFile(dirname + "/secretAccessKey")
+				if err != nil {
+					return nil, err
+				}
+				ao.SecretAccessKey = string(data)
+			}
+		case "region":
+			{
+				data, err := ioutil.ReadFile(dirname + "/region")
+				if err != nil {
+					return nil, err
+				}
+				ao.Region = string(data)
+			}
+		case "disableSSL":
+			{
+				data, err := ioutil.ReadFile(dirname + "/disableSSL")
+				if err != nil {
+					return nil, err
+				}
+				ao.DisableSSL, err = strconv.ParseBool(string(data))
+				if err != nil {
+					return nil, err
+				}
+			}
+		case "insecureSkipVerify":
+			{
+				data, err := ioutil.ReadFile(dirname + "/insecureSkipVerify")
+				if err != nil {
+					return nil, err
+				}
+				ao.InsecureSkipVerify, err = strconv.ParseBool(string(data))
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	if err := isOCSConfigEmpty(ao); err != nil {
+		return nil, err
+	}
+	return &ao, nil
+}
+
+func readOCSCredentialsJSON(filename string) (*ocsAuthOptions, error) {
+	jsonData, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return ocsCredentialsFromJSON(jsonData)
+}
+
+// ocsCredentialsFromJSON obtains OCS credentials from a JSON value.
+func ocsCredentialsFromJSON(jsonData []byte) (*ocsAuthOptions, error) {
+	ocsConfig := ocsAuthOptions{}
+	if err := json.Unmarshal(jsonData, &ocsConfig); err != nil {
+		return nil, err
+	}
+
+	return &ocsConfig, nil
+}
+
+func ocsAuthOptionsToGenericS3(options ocsAuthOptions) s3AuthOptions {
+	return s3AuthOptions{
+		endpoint:           options.Endpoint,
+		region:             options.Region,
+		accessKeyID:        options.AccessKeyID,
+		secretAccessKey:    options.SecretAccessKey,
+		disableSSL:         options.DisableSSL,
+		insecureSkipVerify: options.InsecureSkipVerify,
+	}
+}
+
+func isOCSConfigEmpty(config ocsAuthOptions) error {
+	if len(config.AccessKeyID) != 0 && len(config.Region) != 0 && len(config.SecretAccessKey) != 0 && len(config.Endpoint) != 0 {
+		return nil
+	}
+	return fmt.Errorf("ocs s3 credentials: region, secretAccessKey, endpoint or accessKeyID is missing")
 }

--- a/pkg/snapstore/utils.go
+++ b/pkg/snapstore/utils.go
@@ -186,6 +186,8 @@ func GetSnapstoreSecretHash(config *brtypes.SnapstoreConfig) (string, error) {
 		return SwiftSnapStoreHash(config)
 	case brtypes.SnapstoreProviderOSS:
 		return OSSSnapStoreHash(config)
+	case brtypes.SnapstoreProviderOCS:
+		return OCSSnapStoreHash(config)
 	default:
 		return "", nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**
OCS S3 snapstore now supports the new way of supplying access information via a secret mounted to a specific directory.
This allows for copying ETCd backups between OCS buckets with etcd-druid.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
OCS S3 Snapstore now supports supplying access information via a mounted secret.
```
