### PR TITLE
Throw Fatal error to avoid potential deadlock condition.

### DIFF
--- a/pkg/health/heartbeat/heartbeat.go
+++ b/pkg/health/heartbeat/heartbeat.go
@@ -310,12 +310,13 @@ func RenewMemberLeasePeriodically(ctx context.Context, stopCh chan struct{}, hco
 
 	clientSet, err := miscellaneous.GetKubernetesClientSetOrError()
 	if err != nil {
-		logger.Errorf("failed to create clientset: %v", err)
+		logger.Fatalf("failed to create clientset: %v", err)
 		return
 	}
+
 	hb, err := NewHeartbeat(logger, etcdConfig, clientSet)
 	if err != nil {
-		logger.Errorf("failed to initialize new heartbeat: %v", err)
+		logger.Fatalf("failed to initialize new heartbeat: %v", err)
 		return
 	}
 	hb.heartbeatTimer = time.NewTimer(hconfig.HeartbeatDuration.Duration)

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -171,7 +171,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 				b.logger.Infof("Creating snapstore from provider: %s", b.config.SnapstoreConfig.Provider)
 				ss, err = snapstore.GetSnapstore(b.config.SnapstoreConfig)
 				if err != nil {
-					b.logger.Errorf("failed to create snapstore from configured storage provider: %v", err)
+					b.logger.Fatalf("failed to create snapstore from configured storage provider: %v", err)
 					return
 				}
 
@@ -179,7 +179,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 				b.logger.Infof("Creating snapshotter...")
 				ssr, err = snapshotter.NewSnapshotter(b.logger, b.config.SnapshotterConfig, ss, b.config.EtcdConnectionConfig, b.config.CompressionConfig, b.config.HealthConfig, b.config.SnapstoreConfig)
 				if err != nil {
-					b.logger.Errorf("failed to create new Snapshotter object: %v", err)
+					b.logger.Fatalf("failed to create new Snapshotter object: %v", err)
 					return
 				}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
It has been observed that etcdbr in etcd-events pod got stuck with this last error log:
```
2022-04-14 21:05:16 | {"log":"failed to create clientset: Get \"https://api.gcp-us1.garden.internal.canary.k8s.ondemand.com:443/api?timeout=32s\": dial tcp: lookup api.gcp-us1.garden.internal.canary.k8s.ondemand.com on 10.243.0.10:53: read udp 10.243.131.151:50810-\u003e10.243.0.10:53: i/o timeout","severity":"ERR"}
```
so, I think it should’ve return throw `Fatal error` to avoid potential deadlock condition.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix operator
Throw Fatal error to avoid edge case potential deadlocks.
```
