### PR TITLE
Added a file containing shoot identifier to safe guard against wrong volume mount.

### DIFF
--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -43,6 +43,11 @@ import (
 func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int64) error {
 	start := time.Now()
 	dataDirStatus, err := e.Validator.Validate(mode, failBelowRevision)
+	if dataDirStatus == validator.WrongVolumeMounted {
+		metrics.ValidationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
+		return fmt.Errorf("won't initialize ETCD because wrong ETCD volume is mounted: %v", err)
+	}
+
 	if dataDirStatus == validator.DataDirectoryStatusUnknown {
 		metrics.ValidationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
 		return fmt.Errorf("error while initializing: %v", err)

--- a/pkg/initializer/validator/types.go
+++ b/pkg/initializer/validator/types.go
@@ -28,6 +28,8 @@ type DataDirStatus int
 const (
 	// DataDirectoryValid indicates data directory is valid.
 	DataDirectoryValid = iota
+	// WrongVolumeMounted indicates wrong volume is attached to the ETCD container
+	WrongVolumeMounted
 	// DataDirectoryNotExist indicates data directory is non-existent.
 	DataDirectoryNotExist
 	// DataDirectoryInvStruct indicates data directory has invalid structure.
@@ -46,6 +48,8 @@ const (
 	snapSuffix                    = ".snap"
 	connectionTimeout             = time.Duration(10 * time.Second)
 	embeddedEtcdPingLimitDuration = 60 * time.Second
+	podNamespace                  = "POD_NAMESPACE"
+	safeGuard                     = "safe_guard"
 )
 
 // Mode is the Validation mode passed on to the DataValidator


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR checks whether wrong volume is mounted to ETCD container and if so, it doesn't start the ETCD. It writes shoot identifier to a file in the mounted volume. Then it checks if the mounted volume contains file with the same shoot identifier that is passed to it as POD Namespace.

**Which issue(s) this PR fixes**:
Fixes #
https://github.com/gardener/etcd-backup-restore/issues/466

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
- ETCD won't restart from the PVC if it is wrongly mounted to the pod
```
