### PR TITLE
Throw Fatal error to avoid potential deadlock.

### DIFF
--- a/pkg/health/heartbeat/heartbeat_suite_test.go
+++ b/pkg/health/heartbeat/heartbeat_suite_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	logger  = logrus.New().WithField("suite", "snapshotter")
+	logger  = logrus.New().WithField("suite", "heartbeat")
 	etcd    *embed.Etcd
 	err     error
 	testCtx = context.Background()

--- a/pkg/health/heartbeat/heartbeat_test.go
+++ b/pkg/health/heartbeat/heartbeat_test.go
@@ -8,6 +8,7 @@ import (
 	heartbeat "github.com/gardener/etcd-backup-restore/pkg/health/heartbeat"
 	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+	"github.com/gardener/etcd-backup-restore/pkg/wrappers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -322,4 +323,26 @@ var _ = Describe("Heartbeat", func() {
 			})
 		})
 	})
+
+	Describe("Renewing member lease periodically", func() {
+		var (
+			mmStopCh          chan struct{}
+			hConfig           = &brtypes.HealthConfig{}
+			leaseUpdatePeriod = 2 * time.Second
+		)
+		BeforeEach(func() {
+			mmStopCh = make(chan struct{})
+			hConfig = &brtypes.HealthConfig{
+				MemberLeaseRenewalEnabled: true,
+				HeartbeatDuration:         wrappers.Duration{Duration: leaseUpdatePeriod},
+			}
+		})
+		Context("With fail to create clientset", func() {
+			It("Should return an error", func() {
+				err := heartbeat.RenewMemberLeasePeriodically(testCtx, mmStopCh, hConfig, logger, etcdConnectionConfig)
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+	})
+
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
It has been observed that etcdbr in etcd-events pod got stuck with this last error log:
```
2022-04-14 21:05:16 | {"log":"failed to create clientset: Get \"https://api.gcp-us1.garden.internal.canary.k8s.ondemand.com:443/api?timeout=32s\": dial tcp: lookup api.gcp-us1.garden.internal.canary.k8s.ondemand.com on 10.243.0.10:53: read udp 10.243.131.151:50810-\u003e10.243.0.10:53: i/o timeout","severity":"ERR"}
```
so, I think it should’ve return throw `Fatal error` to avoid potential deadlock condition.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix operator
Throw Fatal error to avoid edge case potential deadlocks.
```
