### PR TITLE
Added a timer while opening a boltDB and improve error handling for verifying database.

### DIFF
--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -48,6 +48,11 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 		return fmt.Errorf("won't initialize ETCD because wrong ETCD volume is mounted: %v", err)
 	}
 
+	if dataDirStatus == validator.FailToOpenBoltDBError {
+		metrics.ValidationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
+		return fmt.Errorf("failed to initialize since another process still holds the file lock")
+	}
+
 	if dataDirStatus == validator.DataDirectoryStatusUnknown {
 		metrics.ValidationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
 		return fmt.Errorf("error while initializing: %v", err)

--- a/pkg/initializer/validator/types.go
+++ b/pkg/initializer/validator/types.go
@@ -42,12 +42,15 @@ const (
 	RevisionConsistencyError
 	// FailBelowRevisionConsistencyError indicates the current etcd revision is inconsistent with failBelowRevision.
 	FailBelowRevisionConsistencyError
+	// FailToOpenBoltDBError indicates that backup-restore is unable to open boltDB as it is failed to acquire lock over database.
+	FailToOpenBoltDBError
 )
 
 const (
 	snapSuffix                    = ".snap"
 	connectionTimeout             = time.Duration(10 * time.Second)
 	embeddedEtcdPingLimitDuration = 60 * time.Second
+	timeoutToOpenBoltDB           = 120 * time.Second
 	podNamespace                  = "POD_NAMESPACE"
 	safeGuard                     = "safe_guard"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Till now to verify `boltDB`, backup-restore used to open it and while opening `boltDB` when it was unable to acquire the lock over database file then backup-restore used to ends up waiting indefinitely for other process to release the lock over database file.
This PR mitigate this issue by introducing a timeout setting to open boltDB, so backup-restore won't have to wait indefinitely, if it fails to acquire lock it can throw error after timeout occurs.


**Note**: Till now we haven’t decided what action needs to be taken when backup-restore throws error in this case but I think `etcd-druid` can take care of this case as it seems to be just like restoration of single member in `multi-node etcd`.

**Which issue(s) this PR fixes**:
Fixes  # [469](https://github.com/gardener/etcd-backup-restore/issues/469) partially  

**Special notes for your reviewer**:
I have set `timeoutToOpenBoltDB` to `120 * time.Second`. I choose randomly but I'm open for change. 

**Release note**:
```improvement operator
Introducing a timeout `timeoutToOpenBoltDB` to open boltDB within a given time, so backup-restore won't have to wait for ever.
```
