### PR TITLE
Added logic for single node restoration after abrupt shutdown.

### DIFF
--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -77,7 +77,7 @@ function setup_ginkgo() {
 
 function setup_etcd(){
   echo "Downloading and installing etcd..."
-  export ETCD_VER=v3.3.8
+  export ETCD_VER=v3.4.13
   if [[ $(uname) == 'Darwin' ]]; then
     curl -L https://storage.googleapis.com/etcd/${ETCD_VER}/etcd-${ETCD_VER}-darwin-amd64.zip -o etcd-${ETCD_VER}-darwin-amd64.zip
     unzip etcd-${ETCD_VER}-darwin-amd64.zip
@@ -196,6 +196,11 @@ function cleanup-aws-infrastructure() {
   echo "AWS infrastructure cleanup completed."
 }
 
+function remove-etcd-data-directory() {
+   echo "Removing ETCD Data Directory"
+   rm -rf ${ETCD_DATA_DIR}
+ }
+
 #############################
 #        Azure Setup        #
 #############################
@@ -229,6 +234,7 @@ function setup_test_cluster() {
 
 function cleanup_test_environment() {
   cleanup-aws-infrastructure
+  remove-etcd-data-directory
 }
 
 ###############################################################################

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -93,8 +93,9 @@ func NewInitializer(options *brtypes.RestoreOptions, snapstoreConfig *brtypes.Sn
 				EmbeddedEtcdQuotaBytes: options.Config.EmbeddedEtcdQuotaBytes,
 				SnapstoreConfig:        snapstoreConfig,
 			},
-			Logger:    logger,
-			ZapLogger: zapLogger,
+			OriginalClusterSize: options.OriginalClusterSize,
+			Logger:              logger,
+			ZapLogger:           zapLogger,
 		},
 		Logger: logger,
 	}

--- a/pkg/initializer/validator/types.go
+++ b/pkg/initializer/validator/types.go
@@ -74,9 +74,10 @@ type Config struct {
 
 // DataValidator contains implements Validator interface to perform data validation.
 type DataValidator struct {
-	Config    *Config
-	Logger    *logrus.Logger
-	ZapLogger *zap.Logger
+	Config              *Config
+	OriginalClusterSize int
+	Logger              *logrus.Logger
+	ZapLogger           *zap.Logger
 }
 
 // Validator is the interface for data validation actions.

--- a/pkg/types/restorer.go
+++ b/pkg/types/restorer.go
@@ -47,7 +47,9 @@ type NewClientFactoryFunc func(cfg EtcdConnectionConfig) client.Factory
 type RestoreOptions struct {
 	Config      *RestorationConfig
 	ClusterURLs types.URLsMap
-	PeerURLs    types.URLs
+	// OriginalClusterSize indicates the actual cluster size from the ETCD config
+	OriginalClusterSize int
+	PeerURLs            types.URLs
 	// Base full snapshot + delta snapshots to restore from
 	BaseSnapshot     *Snapshot
 	DeltaSnapList    SnapList


### PR DESCRIPTION
**What this PR does / why we need it**:
If a node abruptly shutdown in ETCD multi node cluster, it checks revision before coming back up. If the revision number is lesser than the latest snapshot, it fails to restore. Whereas this check is necessary for a single node cluster, it's not necessary for a multinode setup. This PR takes care of both type of clusters.

**Which issue(s) this PR fixes**:
Fixes #481 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
- An initial-cluster field is now expected in the ETCD config
```
