### PR TITLE
Adds and fixes small things

### DIFF
--- a/doc/concepts/leader_election.md
+++ b/doc/concepts/leader_election.md
@@ -1,6 +1,6 @@
 ### Leading ETCD main container’s sidecar is the backup leader 
 
-- The `backup-restore sidecar` poll its corresponding etcd main container to see if it is the leading member in the etcd cluster. This information is used by the backup-restore sidecars to decide that sidecar of the leading etcd main container is the `backup leader`.
+- The `backup-restore sidecar` poll its corresponding etcd container to check if it is the leading member in the etcd cluster. This information is used by the backup-restore sidecars to decide that sidecar of the leading etcd container is the `backup leader`.
 
 - Only `backup leader` sidecar among the members have the responsibility to take/upload the snapshots(full as well as incremental) for a given Etcd cluster as well as to [trigger the defragmentation](https://github.com/gardener/etcd-druid/tree/master/docs/proposals/multi-node#defragmentation) for each Etcd cluster member. 
 

--- a/example/00-etcd-config.yaml
+++ b/example/00-etcd-config.yaml
@@ -1,0 +1,17 @@
+# It can be used to run etcd and etcd-backup-restore locally for testing purpose.
+
+# Human-readable config for single member etcd.
+name: etcd
+data-dir: "default.etcd"
+metrics: extensive
+snapshot-count: 75000
+enable-v2: false
+quota-backend-bytes: 1073741824 # 1Gi
+listen-client-urls: http://0.0.0.0:2379
+advertise-client-urls: http://0.0.0.0:2379
+initial-advertise-peer-urls: http://0.0.0.0:2380
+initial-cluster: etcd=http://0.0.0.0:2380
+initial-cluster-token: new
+initial-cluster-state: new
+auto-compaction-mode: periodic
+auto-compaction-retention: 30m

--- a/pkg/etcdutil/etcdutil.go
+++ b/pkg/etcdutil/etcdutil.go
@@ -276,13 +276,10 @@ func TakeAndSaveFullSnapshot(ctx context.Context, client client.MaintenanceClose
 	logger.Infof("Total time taken by Snapshot API: %f seconds.", timeTaken.Seconds())
 
 	if cc.Enabled {
-		startTimeCompression := time.Now()
 		rc, err = compressor.CompressSnapshot(rc, cc.CompressionPolicy)
 		if err != nil {
 			return nil, fmt.Errorf("unable to obtain reader for compressed file: %v", err)
 		}
-		timeTakenCompression := time.Since(startTimeCompression)
-		logger.Infof("Total time taken in full snapshot compression: %f seconds.", timeTakenCompression.Seconds())
 	}
 	defer rc.Close()
 

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -267,9 +267,6 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 					b.logger.Info("backup-restore stops leading...")
 				}
 				handler.SetSnapshotterToNil()
-
-				// TODO @ishan16696: For Multi-node etcd HTTP status need to be set to `StatusServiceUnavailable` only when backup-restore is in "StateUnknown".
-				handler.SetStatus(http.StatusServiceUnavailable)
 			}
 		},
 	}
@@ -286,6 +283,10 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 			}
 		},
 		StopLeaseRenewal: func() {
+			// when backup-restore is in "StateUnknown"
+			// stop the member lease renewal(if enabled)
+			// and set the HTTP status to `StatusServiceUnavailable`.
+			handler.SetStatus(http.StatusServiceUnavailable)
 			if b.config.HealthConfig.MemberLeaseRenewalEnabled {
 				mmStopCh <- emptyStruct
 			}

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -273,6 +273,10 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 
 	memberLeaseCallbacks := &brtypes.MemberLeaseCallbacks{
 		StartLeaseRenewal: func() {
+			// when backup-restore is in "StateFollower" or "StateLeader"
+			// start the member lease renewal(if enabled)
+			// and set the HTTP status to `StatusOK`.
+			handler.SetStatus(http.StatusOK)
 			mmStopCh = make(chan struct{})
 			if b.config.HealthConfig.MemberLeaseRenewalEnabled {
 				go func() {

--- a/pkg/server/httpAPI.go
+++ b/pkg/server/httpAPI.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/http/pprof"
@@ -208,10 +207,7 @@ func (h *HTTPHandler) serveHealthz(rw http.ResponseWriter, req *http.Request) {
 	rw.WriteHeader(h.GetStatus())
 	healthCheck := &healthCheck{
 		HealthStatus: func() bool {
-			if h.GetStatus() == http.StatusOK {
-				return true
-			}
-			return false
+			return h.GetStatus() == http.StatusOK
 		}(),
 	}
 	json, err := json.Marshal(healthCheck)
@@ -401,7 +397,7 @@ func (h *HTTPHandler) serveLatestSnapshotMetadata(rw http.ResponseWriter, req *h
 func (h *HTTPHandler) serveConfig(rw http.ResponseWriter, req *http.Request) {
 	inputFileName := miscellaneous.EtcdConfigFilePath
 	outputFileName := "/etc/etcd.conf.yaml"
-	configYML, err := ioutil.ReadFile(inputFileName)
+	configYML, err := os.ReadFile(inputFileName)
 	if err != nil {
 		h.Logger.Warnf("Unable to read etcd config file: %v", err)
 		rw.WriteHeader(http.StatusInternalServerError)
@@ -466,7 +462,7 @@ func (h *HTTPHandler) serveConfig(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if err := ioutil.WriteFile(outputFileName, data, 0644); err != nil {
+	if err := os.WriteFile(outputFileName, data, 0644); err != nil {
 		h.Logger.Warnf("Unable to write etcd config file: %v", err)
 		rw.WriteHeader(http.StatusInternalServerError)
 		return


### PR DESCRIPTION
**What this PR does / why we need it**:
1. This [commit](https://github.com/gardener/etcd-backup-restore/pull/491/commits/7143591eb67c97b2e598a119c4bb187ebf79b3b5) adds a **etcd-config.yaml file**. It will be useful in running single member etcd and backup-restore locally for testing purposes. Just have to export  ENV: `ETCD_CONF=example/00-etcd-config.yaml`
2. This [commit](https://github.com/gardener/etcd-backup-restore/pull/491/commits/89afcc595c0b9201092d06837e859029ca14ed74) set the HTTP status to `StatusServiceUnavailable` when backup-restore is in `StateUnknown`.
3. This [commit](https://github.com/gardener/etcd-backup-restore/pull/491/commits/ce3a427f42493c9c652a530d78b836b092af4025) set the HTTP status to `StatusOK` when backup-restore is in `StateFollower` or `StateLeader`.
4. This [commit](https://github.com/gardener/etcd-backup-restore/pull/491/commits/67d6be78acbc5a103007204114d8e951ecde75bd) removes the wrong snapshot compression time calculation as compression is done in this [go routine](https://github.com/gardener/etcd-backup-restore/blob/608b7c470b50a1203071f049dd5c28b31b35e9f5/pkg/compressor/compressor.go#L53-L65). so it was more or less calculating pipe creation time. More info: https://pkg.go.dev/io#Pipe
5. This [commit](https://github.com/gardener/etcd-backup-restore/pull/491/commits/080e6828d847bbb4f19a7a3b4f126299d20e8954) adds small fixes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
set the HTTP status to `StatusServiceUnavailable` when backup-restore is in `StateUnknown`.
```
```improvement operator
set the HTTP status to `StatusOK` when backup-restore is in `StateFollower` or `StateLeader`.
```
