### PR TITLE
Drop the feature of passing storage container secrets through Environment Variable.

### DIFF
--- a/doc/usage/getting_started.md
+++ b/doc/usage/getting_started.md
@@ -15,9 +15,7 @@ The procedure to provide credentials to access the cloud provider object store v
 
 * For `AWS S3`: 
    1. The secret file should be provided and it's file path should be made available as environment variables: `AWS_APPLICATION_CREDENTIALS` or `AWS_APPLICATION_CREDENTIALS_JSON`.
-   2. `AWS_REGION`, `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` should be made available as environment variables.
-   3. For `S3-compatible providers` such as MinIO, `AWS_ENDPOINT` and `AWS_FORCE_PATH_STYLE` can be made available as environment variables to
-   configure the S3 client to communicate to a non-AWS provider.
+   2. For `S3-compatible providers` such as MinIO, `AWS_ENDPOINT` and `AWS_FORCE_PATH_STYLE` can also be made available in a above file to configure the S3 client to communicate to a non-AWS provider.
 
 * For  `Google Cloud Storage`: 
    1. The service account json file should be provided in the `~/.gcp` as a `service-account-file.json` file.
@@ -25,22 +23,18 @@ The procedure to provide credentials to access the cloud provider object store v
 
 * For `Azure Blob storage`:
    1. The secret file should be provided and it's file path should be made available as environment variables: `AZURE_APPLICATION_CREDENTIALS` or `AZURE_APPLICATION_CREDENTIALS_JSON`.
-   2. `STORAGE_ACCOUNT` and `STORAGE_KEY` should be made available as environment variables.
 
 * For `Openstack Swift`:
   1. The secret file should be provided and file path should be made available as environment variables: `OPENSTACK_APPLICATION_CREDENTIALS` or `OPENSTACK_APPLICATION_CREDENTIALS_JSON`.
-  2. `OS_USERNAME`, `OS_PASSWORD`, `OS_AUTH_URL`, `OS_TENANT_ID` and `OS_DOMAIN_ID` or `OS_CLOUD` should be made available as environment variables. An optional `OS_REGION_NAME` can be use.
 
 * For `Alicloud OSS`:
   1. The secret file should be provided and file path should be made available as environment variables: `ALICLOUD_APPLICATION_CREDENTIALS` or `ALICLOUD_APPLICATION_CREDENTIALS_JSON`.
-  2. `ALICLOUD_ENDPOINT`, `ALICLOUD_ACCESS_KEY_ID`, `ALICLOUD_ACCESS_KEY_SECRET` should be made available as environment variables.
 
 * For `Dell EMC ECS`:
   1. `ECS_ENDPOINT`, `ECS_ACCESS_KEY_ID`, `ECS_SECRET_ACCESS_KEY` should be made available as environment variables. For development purposes, the environment variables `ECS_DISABLE_SSL` and `ECS_INSECURE_SKIP_VERIFY` can also be set to "true" or "false".
 
 * For `Openshift Container Storage (OCS)`:
   1. The secret file should be provided and file path should be made available as environment variables: `OPENSHIFT_APPLICATION_CREDENTIALS` or `OPENSHIFT_APPLICATION_CREDENTIALS_JSON`.
-  2. `OCS_ENDPOINT`, `OCS_REGION`, `OCS_ACCESS_KEY_ID`, `OCS_SECRET_ACCESS_KEY` should be made available as environment variables.
   For development purposes, the environment variables `OCS_DISABLE_SSL` and `OCS_INSECURE_SKIP_VERIFY` can also be set to "true" or "false".
 
 

--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -34,8 +34,6 @@ import (
 )
 
 const (
-	absStorageAccount     = "STORAGE_ACCOUNT"
-	absStorageKey         = "STORAGE_KEY"
 	absCredentialFile     = "AZURE_APPLICATION_CREDENTIALS"
 	absCredentialJSONFile = "AZURE_APPLICATION_CREDENTIALS_JSON"
 )
@@ -81,19 +79,6 @@ func NewABSSnapStore(config *brtypes.SnapstoreConfig) (*ABSSnapStore, error) {
 }
 
 func getCredentials(prefixString string) (string, string, error) {
-
-	// TODO: passing credentials through environment variable will be deprecated by "backup-restore v0.18.0"
-	if _, isSet := os.LookupEnv(prefixString + absStorageAccount); isSet {
-		storageAccount, err := GetEnvVarOrError(prefixString + absStorageAccount)
-		if err != nil {
-			return "", "", err
-		}
-		storageKey, err := GetEnvVarOrError(prefixString + absStorageKey)
-		if err != nil {
-			return "", "", err
-		}
-		return storageAccount, storageKey, nil
-	}
 
 	if _, isSet := os.LookupEnv(prefixString + absCredentialJSONFile); isSet {
 		if filename := os.Getenv(prefixString + absCredentialJSONFile); filename != "" {

--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -80,24 +80,20 @@ func NewABSSnapStore(config *brtypes.SnapstoreConfig) (*ABSSnapStore, error) {
 
 func getCredentials(prefixString string) (string, string, error) {
 
-	if _, isSet := os.LookupEnv(prefixString + absCredentialJSONFile); isSet {
-		if filename := os.Getenv(prefixString + absCredentialJSONFile); filename != "" {
-			credentials, err := readABSCredentialsJSON(filename)
-			if err != nil {
-				return "", "", fmt.Errorf("error getting credentials using %v file", filename)
-			}
-			return credentials.StorageAccount, credentials.SecretKey, nil
+	if filename, isSet := os.LookupEnv(prefixString + absCredentialJSONFile); isSet {
+		credentials, err := readABSCredentialsJSON(filename)
+		if err != nil {
+			return "", "", fmt.Errorf("error getting credentials using %v file", filename)
 		}
+		return credentials.StorageAccount, credentials.SecretKey, nil
 	}
 
-	if _, isSet := os.LookupEnv(prefixString + absCredentialFile); isSet {
-		if dir := os.Getenv(prefixString + absCredentialFile); dir != "" {
-			credentials, err := readABSCredentialFiles(dir)
-			if err != nil {
-				return "", "", fmt.Errorf("error getting credentials from %v dir", dir)
-			}
-			return credentials.StorageAccount, credentials.SecretKey, nil
+	if dir, isSet := os.LookupEnv(prefixString + absCredentialFile); isSet {
+		credentials, err := readABSCredentialFiles(dir)
+		if err != nil {
+			return "", "", fmt.Errorf("error getting credentials from %v dir", dir)
 		}
+		return credentials.StorageAccount, credentials.SecretKey, nil
 	}
 
 	return "", "", fmt.Errorf("unable to get credentials")

--- a/pkg/snapstore/ocs_s3_snapstore.go
+++ b/pkg/snapstore/ocs_s3_snapstore.go
@@ -26,18 +26,6 @@ import (
 const (
 	ocsCredentialFile         string = "OPENSHIFT_APPLICATION_CREDENTIALS"
 	ocsCredentialFileJSONFile string = "OPENSHIFT_APPLICATION_CREDENTIALS_JSON"
-
-	// TODO: passing credentials through environment variable will be deprecated by "backup-restore v0.18.0"
-	// The constants below will not be needed after the removal of this feature
-	ocsDefaultDisableSSL         bool = false
-	ocsDefaultInsecureSkipVerify bool = false
-
-	ocsEndpoint           string = "OCS_ENDPOINT"
-	ocsRegion             string = "OCS_REGION"
-	ocsDisableSSL         string = "OCS_DISABLE_SSL"
-	ocsInsecureSkipVerify string = "OCS_INSECURE_SKIP_VERIFY"
-	ocsAccessKeyID        string = "OCS_ACCESS_KEY_ID"
-	ocsSecretAccessKey    string = "OCS_SECRET_ACCESS_KEY"
 )
 
 type ocsAuthOptions struct {
@@ -78,15 +66,6 @@ func getOCSAuthOptions(prefix string) (*ocsAuthOptions, error) {
 			}
 			return ao, nil
 		}
-	}
-
-	// TODO: passing credentials through environment variable will be deprecated by "backup-restore v0.18.0"
-	if _, isSet := os.LookupEnv(prefix + ocsEndpoint); isSet {
-		ao, err := readOcsCredentialFromEnv()
-		if err != nil {
-			return nil, fmt.Errorf("error getting credentials from env: %s", err.Error())
-		}
-		return ao, nil
 	}
 
 	return nil, fmt.Errorf("unable to get credentials")
@@ -182,44 +161,6 @@ func ocsCredentialsFromJSON(jsonData []byte) (*ocsAuthOptions, error) {
 	}
 
 	return &ocsConfig, nil
-}
-
-func readOcsCredentialFromEnv() (*ocsAuthOptions, error) {
-	endpoint, err := GetEnvVarOrError(ocsEndpoint)
-	if err != nil {
-		return nil, err
-	}
-	accessKeyID, err := GetEnvVarOrError(ocsAccessKeyID)
-	if err != nil {
-		return nil, err
-	}
-	secretAccessKey, err := GetEnvVarOrError(ocsSecretAccessKey)
-	if err != nil {
-		return nil, err
-	}
-	region, err := GetEnvVarOrError(ocsRegion)
-	if err != nil {
-		return nil, err
-	}
-	disableSSL, err := GetEnvVarToBool(ocsDisableSSL)
-	if err != nil {
-		disableSSL = ocsDefaultDisableSSL
-	}
-	insecureSkipVerify, err := GetEnvVarToBool(ocsInsecureSkipVerify)
-	if err != nil {
-		insecureSkipVerify = ocsDefaultInsecureSkipVerify
-	}
-
-	ao := ocsAuthOptions{
-		Endpoint:           endpoint,
-		Region:             region,
-		DisableSSL:         disableSSL,
-		InsecureSkipVerify: insecureSkipVerify,
-		AccessKeyID:        accessKeyID,
-		SecretAccessKey:    secretAccessKey,
-	}
-
-	return &ao, nil
 }
 
 func ocsAuthOptionsToGenericS3(options ocsAuthOptions) s3AuthOptions {

--- a/pkg/snapstore/ocs_s3_snapstore.go
+++ b/pkg/snapstore/ocs_s3_snapstore.go
@@ -48,24 +48,20 @@ func NewOCSSnapStore(config *brtypes.SnapstoreConfig) (*S3SnapStore, error) {
 }
 
 func getOCSAuthOptions(prefix string) (*ocsAuthOptions, error) {
-	if _, isSet := os.LookupEnv(prefix + ocsCredentialFileJSONFile); isSet {
-		if filename := os.Getenv(prefix + ocsCredentialFileJSONFile); filename != "" {
-			ao, err := readOCSCredentialsJSON(filename)
-			if err != nil {
-				return nil, fmt.Errorf("error getting credentials using %v file", filename)
-			}
-			return ao, nil
+	if filename, isSet := os.LookupEnv(prefix + ocsCredentialFileJSONFile); isSet {
+		ao, err := readOCSCredentialsJSON(filename)
+		if err != nil {
+			return nil, fmt.Errorf("error getting credentials using %v file", filename)
 		}
+		return ao, nil
 	}
 
-	if _, isSet := os.LookupEnv(prefix + ocsCredentialFile); isSet {
-		if dir := os.Getenv(prefix + ocsCredentialFile); dir != "" {
-			ao, err := readOCSCredentialFromDir(dir)
-			if err != nil {
-				return nil, fmt.Errorf("error getting credentials from %v directory", dir)
-			}
-			return ao, nil
+	if dir, isSet := os.LookupEnv(prefix + ocsCredentialFile); isSet {
+		ao, err := readOCSCredentialFromDir(dir)
+		if err != nil {
+			return nil, fmt.Errorf("error getting credentials from %v directory", dir)
 		}
+		return ao, nil
 	}
 
 	return nil, fmt.Errorf("unable to get credentials")

--- a/pkg/snapstore/oss_snapstore.go
+++ b/pkg/snapstore/oss_snapstore.go
@@ -265,24 +265,20 @@ func (s *OSSSnapStore) Delete(snap brtypes.Snapshot) error {
 
 func getAuthOptions(prefix string) (*authOptions, error) {
 
-	if _, isSet := os.LookupEnv(prefix + aliCredentialJSONFile); isSet {
-		if filename := os.Getenv(prefix + aliCredentialJSONFile); filename != "" {
-			ao, err := readALICredentialsJSON(filename)
-			if err != nil {
-				return nil, fmt.Errorf("error getting credentials using %v file", filename)
-			}
-			return ao, nil
+	if filename, isSet := os.LookupEnv(prefix + aliCredentialJSONFile); isSet {
+		ao, err := readALICredentialsJSON(filename)
+		if err != nil {
+			return nil, fmt.Errorf("error getting credentials using %v file", filename)
 		}
+		return ao, nil
 	}
 
-	if _, isSet := os.LookupEnv(prefix + aliCredentialFile); isSet {
-		if dir := os.Getenv(prefix + aliCredentialFile); dir != "" {
-			ao, err := readALICredentialFiles(dir)
-			if err != nil {
-				return nil, fmt.Errorf("error getting credentials from %v directory", dir)
-			}
-			return ao, nil
+	if dir, isSet := os.LookupEnv(prefix + aliCredentialFile); isSet {
+		ao, err := readALICredentialFiles(dir)
+		if err != nil {
+			return nil, fmt.Errorf("error getting credentials from %v directory", dir)
 		}
+		return ao, nil
 	}
 
 	return nil, fmt.Errorf("unable to get credentials")

--- a/pkg/snapstore/oss_snapstore.go
+++ b/pkg/snapstore/oss_snapstore.go
@@ -45,9 +45,6 @@ type OSSBucket interface {
 const (
 	// Total number of chunks to be uploaded must be one less than maximum limit allowed.
 	ossNoOfChunk          int64 = 9999
-	ossEndPoint                 = "ALICLOUD_ENDPOINT"
-	accessKeyID                 = "ALICLOUD_ACCESS_KEY_ID"
-	accessKeySecret             = "ALICLOUD_ACCESS_KEY_SECRET"
 	aliCredentialFile           = "ALICLOUD_APPLICATION_CREDENTIALS"
 	aliCredentialJSONFile       = "ALICLOUD_APPLICATION_CREDENTIALS_JSON"
 )
@@ -268,11 +265,6 @@ func (s *OSSSnapStore) Delete(snap brtypes.Snapshot) error {
 
 func getAuthOptions(prefix string) (*authOptions, error) {
 
-	// TODO: passing credentials through environment variable will be deprecated by "backup-restore v0.18.0"
-	if _, isSet := os.LookupEnv(prefix + ossEndPoint); isSet {
-		return authOptionsFromEnv(prefix)
-	}
-
 	if _, isSet := os.LookupEnv(prefix + aliCredentialJSONFile); isSet {
 		if filename := os.Getenv(prefix + aliCredentialJSONFile); filename != "" {
 			ao, err := readALICredentialsJSON(filename)
@@ -349,27 +341,6 @@ func readALICredentialFiles(dirname string) (*authOptions, error) {
 		return nil, err
 	}
 	return aliConfig, nil
-}
-
-func authOptionsFromEnv(prefix string) (*authOptions, error) {
-	endpoint, err := GetEnvVarOrError(prefix + ossEndPoint)
-	if err != nil {
-		return nil, err
-	}
-	accessID, err := GetEnvVarOrError(prefix + accessKeyID)
-	if err != nil {
-		return nil, err
-	}
-	accessKey, err := GetEnvVarOrError(prefix + accessKeySecret)
-	if err != nil {
-		return nil, err
-	}
-
-	return &authOptions{
-		Endpoint:  endpoint,
-		AccessID:  accessID,
-		AccessKey: accessKey,
-	}, nil
 }
 
 // OSSSnapStoreHash calculates and returns the hash of aliCloud OSS snapstore secret.

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -42,11 +42,6 @@ import (
 const (
 	// Total number of chunks to be uploaded must be one less than maximum limit allowed.
 	s3NoOfChunk           int64 = 9999
-	awsSecretAccessKey          = "AWS_SECRET_ACCESS_KEY"
-	awsAcessKeyID               = "AWS_ACCESS_KEY_ID"
-	awsRegion                   = "AWS_REGION"
-	awsEndpoint                 = "AWS_ENDPOINT"
-	awsForcePathStyle           = "AWS_FORCE_PATH_STYLE"
 	awsCredentialFile           = "AWS_APPLICATION_CREDENTIALS"
 	awsCredentialJSONFile       = "AWS_APPLICATION_CREDENTIALS_JSON"
 )
@@ -91,22 +86,6 @@ func newS3FromSessionOpt(bucket, prefix, tempDir string, maxParallelChunkUploads
 }
 
 func getSessionOptions(prefixString string) (session.Options, error) {
-
-	var s3path *bool
-	if val, err := strconv.ParseBool(os.Getenv(awsForcePathStyle)); err == nil {
-		s3path = &val
-	}
-	// TODO: passing credentials through environment variable will be deprecated by "backup-restore v0.18.0"
-	if _, isSet := os.LookupEnv(prefixString + awsAcessKeyID); isSet {
-		return session.Options{
-			Config: aws.Config{
-				Credentials:      credentials.NewStaticCredentials(os.Getenv(prefixString+awsAcessKeyID), os.Getenv(prefixString+awsSecretAccessKey), ""),
-				Region:           pointer.StringPtr(os.Getenv(awsRegion)),
-				Endpoint:         pointer.StringPtr(os.Getenv(awsEndpoint)),
-				S3ForcePathStyle: s3path,
-			},
-		}, nil
-	}
 
 	if _, isSet := os.LookupEnv(prefixString + awsCredentialJSONFile); isSet {
 		if filename := os.Getenv(prefixString + awsCredentialJSONFile); filename != "" {

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -87,24 +87,20 @@ func newS3FromSessionOpt(bucket, prefix, tempDir string, maxParallelChunkUploads
 
 func getSessionOptions(prefixString string) (session.Options, error) {
 
-	if _, isSet := os.LookupEnv(prefixString + awsCredentialJSONFile); isSet {
-		if filename := os.Getenv(prefixString + awsCredentialJSONFile); filename != "" {
-			creds, err := readAWSCredentialsJSONFile(filename)
-			if err != nil {
-				return session.Options{}, fmt.Errorf("error getting credentials using %v file", filename)
-			}
-			return creds, nil
+	if filename, isSet := os.LookupEnv(prefixString + awsCredentialJSONFile); isSet {
+		creds, err := readAWSCredentialsJSONFile(filename)
+		if err != nil {
+			return session.Options{}, fmt.Errorf("error getting credentials using %v file", filename)
 		}
+		return creds, nil
 	}
 
-	if _, isSet := os.LookupEnv(prefixString + awsCredentialFile); isSet {
-		if dir := os.Getenv(prefixString + awsCredentialFile); dir != "" {
-			creds, err := readAWSCredentialFiles(dir)
-			if err != nil {
-				return session.Options{}, fmt.Errorf("error getting credentials from %v directory", dir)
-			}
-			return creds, nil
+	if dir, isSet := os.LookupEnv(prefixString + awsCredentialFile); isSet {
+		creds, err := readAWSCredentialFiles(dir)
+		if err != nil {
+			return session.Options{}, fmt.Errorf("error getting credentials from %v directory", dir)
 		}
+		return creds, nil
 	}
 
 	return session.Options{

--- a/pkg/snapstore/swift_snapstore.go
+++ b/pkg/snapstore/swift_snapstore.go
@@ -101,24 +101,20 @@ func NewSwiftSnapStore(config *brtypes.SnapstoreConfig) (*SwiftSnapStore, error)
 
 func getClientOpts(isSource bool) (*clientconfig.ClientOpts, error) {
 	prefix := getEnvPrefixString(isSource)
-	if _, isSet := os.LookupEnv(prefix + swiftCredentialJSONFile); isSet {
-		if filename := os.Getenv(prefix + swiftCredentialJSONFile); filename != "" {
-			clientOpts, err := readSwiftCredentialsJSON(filename)
-			if err != nil {
-				return &clientconfig.ClientOpts{}, fmt.Errorf("error getting credentials using %v file", filename)
-			}
-			return clientOpts, nil
+	if filename, isSet := os.LookupEnv(prefix + swiftCredentialJSONFile); isSet {
+		clientOpts, err := readSwiftCredentialsJSON(filename)
+		if err != nil {
+			return &clientconfig.ClientOpts{}, fmt.Errorf("error getting credentials using %v file", filename)
 		}
+		return clientOpts, nil
 	}
 
-	if _, isSet := os.LookupEnv(prefix + swiftCredentialFile); isSet {
-		if dir := os.Getenv(prefix + swiftCredentialFile); dir != "" {
-			clientOpts, err := readSwiftCredentialFiles(dir)
-			if err != nil {
-				return &clientconfig.ClientOpts{}, fmt.Errorf("error getting credentials from %v directory", dir)
-			}
-			return clientOpts, nil
+	if dir, isSet := os.LookupEnv(prefix + swiftCredentialFile); isSet {
+		clientOpts, err := readSwiftCredentialFiles(dir)
+		if err != nil {
+			return &clientconfig.ClientOpts{}, fmt.Errorf("error getting credentials from %v directory", dir)
 		}
+		return clientOpts, nil
 	}
 
 	// If a neither a swiftCredentialFile nor a swiftCredentialJSONFile was found, fall back to


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR drops the feature of passing storage container secrets through ENV for the following storage provider:
1. AWS: S3
2. Openstack: Swift
3. Openshift: OCS
4. Azure: ABS
5. AliCloud: OSS


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```breaking operator
Dropping the feature of passing storage container credentials through ENV for the following storage provider: S3, Swift, OCS, ABS, OSS. Please switch to pass the storage container credentials through volume file mount. 
```
