### PR TITLE
Fix defragmentation issue for etcd cluster size=1.

### DIFF
--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -203,6 +203,11 @@ func GetAllEtcdEndpoints(ctx context.Context, client etcdClient.ClusterCloser, e
 		etcdEndpoints = append(etcdEndpoints, member.GetClientURLs()...)
 	}
 
+	// For single node etcd: use endpoint which was passed through etcdConnectionConfig
+	if len(etcdEndpoints) == 1 {
+		etcdEndpoints = etcdConnectionConfig.Endpoints
+	}
+
 	return etcdEndpoints, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the defragmentation issue for **etcd cluster size=1** which occurs due to authentication handshake failed as backup-restore used the peer service to connect to etcd.


**Which issue(s) this PR fixes**:
Fixes [494](https://github.com/gardener/etcd-backup-restore/issues/494) (partially)

**Special notes for your reviewer**:
This PR won't fixes the defragmentation issue if `Etcd Cluster Size > 1`

**Release note**:
```bugfix operator
Fix defragmentation issue for `etcd replica=1` which occurs due to authentication handshake failed as backup-restore used the peer service to connect to etcd.
```
