### PR TITLE
Build Multi-Arch Images 📦 

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -50,23 +50,9 @@ VERSION_FILE="$(${READLINK_BIN}  -f "${SOURCE_PATH}/VERSION")"
 VERSION="$(cat "${VERSION_FILE}")"
 GIT_SHA=$(git rev-parse --short HEAD || echo "GitNotFound")
 
-# If no LOCAL_BUILD environment variable is set, we configure the `go build` command
-# to build for linux OS, amd64 architectures and without CGO enablement.
-if [[ -z "$LOCAL_BUILD" ]]; then
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-    -a \
-    -mod vendor \
-    -v \
-    -o "${BINARY_PATH}/linux-amd64/etcdbrctl" \
-    -ldflags "-w -X ${REPOSITORY}/pkg/version.Version=${VERSION} -X ${REPOSITORY}/pkg/version.GitSHA=${GIT_SHA}" \
-    main.go
-
-# If the LOCAL_BUILD environment variable is set, we simply run `go build`.
-else
-  go build \
-    -v \
-    -mod vendor \
-    -o "${BINARY_PATH}/etcdbrctl" \
-    -ldflags "-w -X ${REPOSITORY}/pkg/version.Version=${VERSION} -X ${REPOSITORY}/pkg/version.GitSHA=${GIT_SHA}" \
-    main.go
-fi
+CGO_ENABLED=0  go build \
+  -v \
+  -mod vendor \
+  -o "${BINARY_PATH}/etcdbrctl" \
+  -ldflags "-w -X ${REPOSITORY}/pkg/version.Version=${VERSION} -X ${REPOSITORY}/pkg/version.GitSHA=${GIT_SHA}" \
+  main.go

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -26,6 +26,10 @@ etcd-backup-restore:
           'inject-commit-hash'
         inject_effective_version: true
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           etcdbrctl:
             registry: 'gcr-readwrite'

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,6 @@ build-local:
 
 .PHONY: docker-build
 docker-build:
-	@.ci/build
-	@if [[ ! -f $(BIN_DIR)/linux-amd64/etcdbrctl ]]; then echo "No binary found. Please run 'make build'"; false; fi
 	@docker build -t ${IMG} -f $(BUILD_DIR)/Dockerfile --rm .
 
 .PHONY: docker-push

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM eu.gcr.io/gardener-project/3rd/alpine:3.10.1
+FROM golang:1.18.3 as builder
+
+WORKDIR /go/src/github.com/gardener/backup-restore
+COPY . .
+
+RUN make build
+
+FROM alpine:3.15.4
 
 RUN apk add --update bash curl
 
-COPY ./bin/linux-amd64/etcdbrctl /usr/local/bin/etcdbrctl
+COPY --from=builder /go/src/github.com/gardener/backup-restore/bin/etcdbrctl /usr/local/bin/etcdbrctl
 WORKDIR /
 ENTRYPOINT ["/usr/local/bin/etcdbrctl"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR lets the CI pipeline build multi-arch images including `linux/amd64` and `linux/arm64` images.

**Which issue(s) this PR fixes**:
Fixes partly #https://github.com/gardener/gardener/issues/6258

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Published docker images for Etcd-Backup-Restore are now multi-arch ready. They support `linux/amd64` and `linux/arm64`.
```
```noteworthy operator
The Etcd-Backup-Restore image has been updated to `Alpine 3.15.4`.
```
