### PR TITLE
Temp fix: skip single member restoration in case of data-dir invalid.

### DIFF
--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -77,6 +77,11 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 		return fmt.Errorf("error while initializing: %v", err)
 	}
 
+	if dataDirStatus == validator.DataDirStatusUnknownInMultiNode {
+		metrics.ValidationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
+		return fmt.Errorf("failed to initialize data dir in multi-node cluster")
+	}
+
 	if dataDirStatus == validator.FailBelowRevisionConsistencyError {
 		metrics.ValidationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
 		return fmt.Errorf("failed to initialize since fail below revision check failed")

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -79,7 +79,7 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 
 	if dataDirStatus == validator.DataDirStatusUnknownInMultiNode {
 		metrics.ValidationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
-		return fmt.Errorf("failed to initialize data dir in multi-node cluster")
+		return fmt.Errorf("failed to initialize data dir of cluster member in multi-node cluster")
 	}
 
 	if dataDirStatus == validator.FailBelowRevisionConsistencyError {

--- a/pkg/initializer/validator/datavalidator.go
+++ b/pkg/initializer/validator/datavalidator.go
@@ -68,6 +68,9 @@ func (d *DataValidator) backendPath() string { return filepath.Join(d.snapDir(),
 func (d *DataValidator) Validate(mode Mode, failBelowRevision int64) (DataDirStatus, error) {
 	status, err := d.sanityCheck(failBelowRevision)
 	if status != DataDirectoryValid {
+		if d.OriginalClusterSize > 1 && !miscellaneous.IsBackupBucketEmpty(d.Config.SnapstoreConfig, d.Logger) {
+			return DataDirStatusUnknownInMultiNode, nil
+		}
 		return status, err
 	}
 

--- a/pkg/initializer/validator/datavalidator.go
+++ b/pkg/initializer/validator/datavalidator.go
@@ -68,6 +68,7 @@ func (d *DataValidator) backendPath() string { return filepath.Join(d.snapDir(),
 func (d *DataValidator) Validate(mode Mode, failBelowRevision int64) (DataDirStatus, error) {
 	status, err := d.sanityCheck(failBelowRevision)
 	if status != DataDirectoryValid {
+		// TODO: To be removed when backup-restore supports restoration of single member in multi-node etcd cluster.
 		if d.OriginalClusterSize > 1 && !miscellaneous.IsBackupBucketEmpty(d.Config.SnapstoreConfig, d.Logger) {
 			return DataDirStatusUnknownInMultiNode, nil
 		}

--- a/pkg/initializer/validator/types.go
+++ b/pkg/initializer/validator/types.go
@@ -38,6 +38,9 @@ const (
 	DataDirectoryCorrupt
 	// DataDirectoryStatusUnknown indicates validator failed to check the data directory status.
 	DataDirectoryStatusUnknown
+	// DataDirStatusUnknownInMultiNode indicates validator failed to check the data directory status in multi-node etcd cluster.
+	// TODO: To be removed when backup-restore supports restoration of single member in multi-node etcd cluster.
+	DataDirStatusUnknownInMultiNode
 	// RevisionConsistencyError indicates current etcd revision is inconsistent with latest snapshot revision.
 	RevisionConsistencyError
 	// FailBelowRevisionConsistencyError indicates the current etcd revision is inconsistent with failBelowRevision.

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -146,7 +146,7 @@ func (m *memberControl) IsMemberInCluster(ctx context.Context) (bool, error) {
 		return err
 	})
 	if err != nil {
-		return false, fmt.Errorf("Could not list any etcd members %w", err)
+		return false, fmt.Errorf("could not list any etcd members %w", err)
 	}
 
 	for _, y := range etcdMemberList.Members {
@@ -156,26 +156,26 @@ func (m *memberControl) IsMemberInCluster(ctx context.Context) (bool, error) {
 		}
 	}
 
-	m.logger.Infof("Member %s not part of any running cluster", m.podName)
-	//return false, fmt.Errorf("Could not find member %s in the list", m.podName)
+	m.logger.Infof("Member %v not part of any running cluster", m.podName)
+	m.logger.Infof("Could not find member %v in the list", m.podName)
 	return false, nil
 }
 
 func (m *memberControl) getMemberURL() (string, error) {
 	configYML, err := os.ReadFile(m.configFile)
 	if err != nil {
-		return "", fmt.Errorf("Unable to read etcd config file: %v", err)
+		return "", fmt.Errorf("unable to read etcd config file: %v", err)
 	}
 
 	config := map[string]interface{}{}
 	if err := yaml.Unmarshal([]byte(configYML), &config); err != nil {
-		return "", fmt.Errorf("Unable to unmarshal etcd config yaml file: %v", err)
+		return "", fmt.Errorf("unable to unmarshal etcd config yaml file: %v", err)
 	}
 
 	initAdPeerURL := config["initial-advertise-peer-urls"]
 	peerURL, err := parsePeerURL(initAdPeerURL.(string), m.podName)
 	if err != nil {
-		return "", fmt.Errorf("Could not parse peer URL from the config file : %v", err)
+		return "", fmt.Errorf("could not parse peer URL from the config file : %v", err)
 	}
 	return peerURL, nil
 }
@@ -183,7 +183,7 @@ func (m *memberControl) getMemberURL() (string, error) {
 func parsePeerURL(peerURL, podName string) (string, error) {
 	tokens := strings.Split(peerURL, "@")
 	if len(tokens) < 4 {
-		return "", fmt.Errorf("Invalid peer URL : %s", peerURL)
+		return "", fmt.Errorf("invalid peer URL : %s", peerURL)
 	}
 	domaiName := fmt.Sprintf("%s.%s.%s", tokens[1], tokens[2], "svc")
 
@@ -200,7 +200,7 @@ func (m *memberControl) updateMemberPeerAddress(ctx context.Context, id uint64) 
 
 	memberURL, err := m.getMemberURL()
 	if err != nil {
-		return fmt.Errorf("Could not fetch member URL : %v", err)
+		return fmt.Errorf("could not fetch member URL : %v", err)
 	}
 
 	memberUpdateCtx, cancel := context.WithTimeout(ctx, etcdTimeout)

--- a/pkg/member/member_control_test.go
+++ b/pkg/member/member_control_test.go
@@ -82,5 +82,4 @@ var _ = Describe("Membercontrol", func() {
 			})
 		})
 	})
-
 })

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -431,16 +431,11 @@ func IsBackupBucketEmpty(snapStoreConfig *brtypes.SnapstoreConfig, logger *logru
 	return false
 }
 
-// GetInitialClusterState returns the cluster state
-func GetInitialClusterState(ctx context.Context, logger logrus.Entry, podName string, podNS string) string {
+// GetInitialClusterState returns the cluster state, either `new` or `existing`.
+func GetInitialClusterState(ctx context.Context, logger logrus.Entry, clientSet client.Client, podName string, podNS string) string {
 	clusterState := "new"
 
 	//Read sts spec for updated replicas to toggle `initial-cluster-state`
-	clientSet, err := GetKubernetesClientSetOrError()
-	if err != nil {
-		logger.Errorf("failed to create clientset: %v", err)
-		return clusterState
-	}
 	curSts := &appsv1.StatefulSet{}
 	errSts := clientSet.Get(ctx, client.ObjectKey{
 		Namespace: podNS,

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -308,13 +308,13 @@ func GetEtcdSvcEndpoint() (string, error) {
 
 	configYML, err := os.ReadFile(inputFileName)
 	if err != nil {
-		return "", fmt.Errorf("Unable to read etcd config file: %v", err)
+		return "", fmt.Errorf("unable to read etcd config file: %v", err)
 	}
 
 	config := map[string]interface{}{}
 	err = yaml.Unmarshal([]byte(configYML), &config)
 	if err := yaml.Unmarshal([]byte(configYML), &config); err != nil {
-		return "", fmt.Errorf("Unable to unmarshal etcd config yaml file: %v", err)
+		return "", fmt.Errorf("unable to unmarshal etcd config yaml file: %v", err)
 	}
 
 	advClientURL := config["advertise-client-urls"]
@@ -330,12 +330,12 @@ func GetEtcdSvcEndpoint() (string, error) {
 // ProbeEtcd probes the etcd endpoint to check if an etcd is available
 func ProbeEtcd(ctx context.Context, clientFactory etcdClient.Factory, logger *logrus.Entry) error {
 	clientKV, err := clientFactory.NewKV()
-	defer clientKV.Close()
 	if err != nil {
 		return &errors.EtcdError{
 			Message: fmt.Sprintf("Failed to create etcd KV client: %v", err),
 		}
 	}
+	defer clientKV.Close()
 
 	if _, err := clientKV.Get(ctx, "foo"); err != nil {
 		logger.Errorf("Failed to connect to etcd KV client: %v", err)

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -438,8 +438,6 @@ func IsBackupBucketEmpty(snapStoreConfig *brtypes.SnapstoreConfig, logger *logru
 
 // GetInitialClusterState returns the cluster state, either `new` or `existing`.
 func GetInitialClusterState(ctx context.Context, logger logrus.Entry, clientSet client.Client, podName string, podNS string) string {
-	clusterState := "new"
-
 	//Read sts spec for updated replicas to toggle `initial-cluster-state`
 	curSts := &appsv1.StatefulSet{}
 	errSts := clientSet.Get(ctx, client.ObjectKey{
@@ -448,13 +446,13 @@ func GetInitialClusterState(ctx context.Context, logger logrus.Entry, clientSet 
 	}, curSts)
 	if errSts != nil {
 		logger.Warn("error fetching etcd sts ", errSts)
-		return clusterState
+		return ClusterStateNew
 	}
 
 	//TODO: achieve this without an sts?
 	if *curSts.Spec.Replicas > 1 && *curSts.Spec.Replicas > curSts.Status.UpdatedReplicas {
-		clusterState = "existing"
+		return ClusterStateExisting
 	}
 
-	return clusterState
+	return ClusterStateNew
 }

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -413,6 +413,11 @@ func SleepWithContext(ctx context.Context, sleepFor time.Duration) error {
 // IsBackupBucketEmpty checks whether the backup bucket is empty or not.
 func IsBackupBucketEmpty(snapStoreConfig *brtypes.SnapstoreConfig, logger *logrus.Logger) bool {
 	logger.Info("Checking whether the backup bucket is empty or not...")
+
+	if snapStoreConfig == nil || len(snapStoreConfig.Provider) == 0 {
+		logger.Info("storage provider name not specified")
+		return true
+	}
 	store, err := snapstore.GetSnapstore(snapStoreConfig)
 	if err != nil {
 		logger.Fatalf("failed to create snapstore from configured storage provider: %v", err)

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -309,6 +309,13 @@ var _ = Describe("Miscellaneous Tests", func() {
 				Expect(isBackupBucketEmpty).Should(BeTrue())
 			})
 		})
+		Context("#Storage provider is not specified", func() {
+			It("should return true", func() {
+				snapStoreConfig.Provider = ""
+				isBackupBucketEmpty := IsBackupBucketEmpty(snapStoreConfig, logger.Logger)
+				Expect(isBackupBucketEmpty).Should(BeTrue())
+			})
+		})
 	})
 
 	Describe("Get the Initial ClusterState", func() {

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -413,6 +413,36 @@ var _ = Describe("Miscellaneous Tests", func() {
 				Expect(clusterState).Should(Equal(ClusterStateExisting))
 			})
 		})
+
+		Context("Unable to fetch statefulset", func() {
+			It("Should return clusterState as `new` ", func() {
+				sts = &appsv1.StatefulSet{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: "apps/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      os.Getenv("STS_NAME"),
+						Namespace: os.Getenv("NAMESPACE"),
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: getInt32Pointer(3),
+					},
+					Status: appsv1.StatefulSetStatus{
+						UpdatedReplicas: 1,
+					},
+				}
+
+				wrongNamespace := "wrongNamespace"
+				clientSet := GetFakeKubernetesClientSet()
+
+				err := clientSet.Create(testCtx, sts)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				clusterState := GetInitialClusterState(testCtx, *logger, clientSet, os.Getenv("POD_NAME"), wrongNamespace)
+				Expect(clusterState).Should(Equal(ClusterStateNew))
+			})
+		})
 	})
 
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
By not letting it trigger the the restoration this PR fixes the issues of wrong restoration of single member in a multi-node etcd cluster in case of data-dir found to be invalid. Please refer [here](https://github.com/gardener/etcd-druid/issues/361#issuecomment-1174907483).
This PR also fixes one bug in Scale feature in func: [IsMemberInCluster](https://github.com/gardener/etcd-backup-restore/blob/a6ee3fd56bc0401fe54f048fe8166750f677a777/pkg/member/member_control.go#L164) as it shouldn't return the error, it should return the nil.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/etcd-druid/issues/361 (Temporary fix)

**Special notes for your reviewer**:

**Release note**:
```bugFix operator
Temp fix: skip the single member restoration if data-dir found to be invalid.
```
```bugFix operator
Fixed a bug in Scaleup feature in func: `IsMemberInCluster()` which can cause Scaleup feature to get fail.
```