### PR TITLE
Assigned the correct Peer Address to Etcd after it restores from the backup-bucket.

### DIFF
--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -43,7 +43,7 @@ func NewRestoreCommand(ctx context.Context) *cobra.Command {
 			}
 
 			rs := restorer.NewRestorer(store, logrus.NewEntry(logger))
-			if err := rs.RestoreAndStopEtcd(*options); err != nil {
+			if err := rs.RestoreAndStopEtcd(*options, nil); err != nil {
 				logger.Fatalf("Failed to restore snapshot: %v", err)
 				return
 			}

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -80,7 +80,7 @@ func (cp *Compactor) Compact(ctx context.Context, opts *brtypes.CompactOptions) 
 
 	// Then restore from the snapshots
 	r := restorer.NewRestorer(cp.store, cp.logger)
-	embeddedEtcd, err := r.Restore(*cmpctOptions)
+	embeddedEtcd, err := r.Restore(*cmpctOptions, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to restore snapshots during compaction: %v", err)
 	}

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Running Compactor", func() {
 
 				rstr := restorer.NewRestorer(store, logger)
 
-				err = rstr.RestoreAndStopEtcd(*restoreOpts)
+				err = rstr.RestoreAndStopEtcd(*restoreOpts, nil)
 
 				Expect(err).ShouldNot(HaveOccurred())
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
@@ -237,7 +237,7 @@ var _ = Describe("Running Compactor", func() {
 
 				rstr := restorer.NewRestorer(store, logger)
 
-				err = rstr.RestoreAndStopEtcd(*restoreOpts)
+				err = rstr.RestoreAndStopEtcd(*restoreOpts, nil)
 
 				Expect(err).ShouldNot(HaveOccurred())
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -167,7 +167,8 @@ func (e *EtcdInitializer) restoreCorruptData() (bool, error) {
 	}
 
 	rs := restorer.NewRestorer(store, logrus.NewEntry(logger))
-	if err := rs.RestoreAndStopEtcd(tempRestoreOptions); err != nil {
+	m := member.NewMemberControl(e.Config.EtcdConnectionConfig)
+	if err := rs.RestoreAndStopEtcd(tempRestoreOptions, m); err != nil {
 		err = fmt.Errorf("failed to restore snapshot: %v", err)
 		return false, err
 	}

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -21,11 +21,11 @@ import (
 )
 
 const (
-	// retryPeriod is the peroid after which an operation is retried
-	retryPeriod = 5 * time.Second
+	// RetryPeriod is the peroid after which an operation is retried
+	RetryPeriod = 2 * time.Second
 
-	// etcdTimeout is timeout for etcd operations
-	etcdTimeout = 5 * time.Second
+	// EtcdTimeout is timeout for etcd operations
+	EtcdTimeout = 5 * time.Second
 )
 
 var (
@@ -43,6 +43,9 @@ type ControlMember interface {
 
 	// PromoteMember promotes an etcd member from a learner to a voting member of the cluster. This will succeed if and only if learner is in a healthy state and the learner is in sync with leader
 	PromoteMember(context.Context) error
+
+	// UpdateMember updates the peer address of a specified etcd cluster member.
+	UpdateMember(context.Context, client.ClusterCloser) error
 }
 
 // memberControl holds the configuration for the mechanism of adding a new member to the cluster.
@@ -84,7 +87,7 @@ func NewMemberControl(etcdConnConfig *brtypes.EtcdConnectionConfig) ControlMembe
 // AddMemberAsLearner add a member as a learner to the etcd cluster
 func (m *memberControl) AddMemberAsLearner(ctx context.Context) error {
 	//Add member as learner to cluster
-	memberURL, err := m.getMemberURL()
+	memberURL, err := getMemberURL(m.configFile, m.podName)
 	if err != nil {
 		m.logger.Fatalf("Error fetching etcd member URL : %v", err)
 	}
@@ -95,7 +98,7 @@ func (m *memberControl) AddMemberAsLearner(ctx context.Context) error {
 	}
 	defer cli.Close()
 
-	memAddCtx, cancel := context.WithTimeout(ctx, etcdTimeout)
+	memAddCtx, cancel := context.WithTimeout(ctx, EtcdTimeout)
 	defer cancel()
 	_, err = cli.MemberAddAsLearner(memAddCtx, []string{memberURL})
 
@@ -120,7 +123,7 @@ func (m *memberControl) IsMemberInCluster(ctx context.Context) (bool, error) {
 	err := retry.OnError(backoff, func(err error) bool {
 		return err != nil
 	}, func() error {
-		etcdProbeCtx, cancel := context.WithTimeout(context.TODO(), etcdTimeout)
+		etcdProbeCtx, cancel := context.WithTimeout(context.TODO(), EtcdTimeout)
 		defer cancel()
 		return miscellaneous.ProbeEtcd(etcdProbeCtx, m.clientFactory, &m.logger)
 	})
@@ -140,7 +143,7 @@ func (m *memberControl) IsMemberInCluster(ctx context.Context) (bool, error) {
 	err = retry.OnError(retry.DefaultBackoff, func(err error) bool {
 		return err != nil
 	}, func() error {
-		memListCtx, cancel := context.WithTimeout(context.TODO(), etcdTimeout)
+		memListCtx, cancel := context.WithTimeout(context.TODO(), EtcdTimeout)
 		defer cancel()
 		etcdMemberList, err = cli.MemberList(memListCtx)
 		return err
@@ -161,8 +164,8 @@ func (m *memberControl) IsMemberInCluster(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-func (m *memberControl) getMemberURL() (string, error) {
-	configYML, err := os.ReadFile(m.configFile)
+func getMemberURL(configFile string, podName string) (string, error) {
+	configYML, err := os.ReadFile(configFile)
 	if err != nil {
 		return "", fmt.Errorf("unable to read etcd config file: %v", err)
 	}
@@ -173,7 +176,7 @@ func (m *memberControl) getMemberURL() (string, error) {
 	}
 
 	initAdPeerURL := config["initial-advertise-peer-urls"]
-	peerURL, err := parsePeerURL(initAdPeerURL.(string), m.podName)
+	peerURL, err := parsePeerURL(initAdPeerURL.(string), podName)
 	if err != nil {
 		return "", fmt.Errorf("could not parse peer URL from the config file : %v", err)
 	}
@@ -190,20 +193,16 @@ func parsePeerURL(peerURL, podName string) (string, error) {
 	return fmt.Sprintf("%s://%s.%s:%s", tokens[0], podName, domaiName, tokens[3]), nil
 }
 
-// UpdateMemberPeerAddress updated the peer address of a specified etcd member
-func (m *memberControl) updateMemberPeerAddress(ctx context.Context, id uint64) error {
+// updateMemberPeerAddress updated the peer address of a specified etcd member
+func (m *memberControl) updateMemberPeerAddress(ctx context.Context, cli client.ClusterCloser, id uint64) error {
 	m.logger.Infof("Updating member peer URL for %s", m.podName)
-	cli, err := m.clientFactory.NewCluster()
-	if err != nil {
-		return fmt.Errorf("failed to build etcd cluster client : %v", err)
-	}
 
-	memberURL, err := m.getMemberURL()
+	memberURL, err := getMemberURL(m.configFile, m.podName)
 	if err != nil {
 		return fmt.Errorf("could not fetch member URL : %v", err)
 	}
 
-	memberUpdateCtx, cancel := context.WithTimeout(ctx, etcdTimeout)
+	memberUpdateCtx, cancel := context.WithTimeout(ctx, EtcdTimeout)
 	defer cancel()
 
 	_, err = cli.MemberUpdate(memberUpdateCtx, id, []string{memberURL})
@@ -240,11 +239,25 @@ func (m *memberControl) PromoteMember(ctx context.Context) error {
 
 func findMember(existingMembers []*etcdserverpb.Member, memberName string) *etcdserverpb.Member {
 	for _, member := range existingMembers {
-		if member.Name == memberName {
+		if member.GetName() == memberName {
 			return member
 		}
 	}
 	return nil
+}
+
+// UpdateMember updates the peer address of a specified etcd cluster member.
+func (m *memberControl) UpdateMember(ctx context.Context, cli client.ClusterCloser) error {
+	m.logger.Infof("Attempting to update the member Info %v", m.podName)
+	ctx, cancel := context.WithTimeout(ctx, brtypes.DefaultEtcdConnectionTimeout)
+	defer cancel()
+
+	membersInfo, err := cli.MemberList(ctx)
+	if err != nil {
+		return fmt.Errorf("error listing members: %v", err)
+	}
+
+	return m.updateMemberPeerAddress(ctx, cli, membersInfo.Header.GetMemberId())
 }
 
 func (m *memberControl) doPromoteMember(ctx context.Context, member *etcdserverpb.Member, cli client.ClusterCloser) error {
@@ -252,13 +265,13 @@ func (m *memberControl) doPromoteMember(ctx context.Context, member *etcdserverp
 	defer cancel()
 	_, err := cli.MemberPromote(memPromoteCtx, member.ID) //Member promote call will succeed only if member is in sync with leader, and will error out otherwise
 	if err == nil {                                       //Member successfully promoted
-		m.logger.Info("Member promoted ", member.Name, " : ", member.ID)
+		m.logger.Infof("Member %v with ID: %v have been promoted", member.GetName(), member.GetID())
 		return nil
 	} else if errors.Is(err, rpctypes.Error(rpctypes.ErrGRPCMemberNotLearner)) { //Member is not a learner
 		if member.PeerURLs[0] == "http://localhost:2380" { //[]string{"http://localhost:2380"}[0] {
 			// Already existing clusters have `http://localhost:2380` as the peer address. This needs to explicitly updated to the new address
 			// TODO: Remove this peer address updation logic on etcd-br v0.20.0
-			err = m.updateMemberPeerAddress(ctx, member.ID)
+			err = m.updateMemberPeerAddress(ctx, cli, member.ID)
 			m.logger.Errorf("Could not update member peer URL : %v", err)
 		}
 		m.logger.Info("Member ", member.Name, " : ", member.ID, " already part of etcd cluster")

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -268,7 +268,7 @@ func (m *memberControl) doPromoteMember(ctx context.Context, member *etcdserverp
 	defer cancel()
 	_, err := cli.MemberPromote(memPromoteCtx, member.ID) //Member promote call will succeed only if member is in sync with leader, and will error out otherwise
 	if err == nil {                                       //Member successfully promoted
-		m.logger.Infof("Member %v with ID: %v have been promoted", member.GetName(), member.GetID())
+		m.logger.Infof("Member %v with ID: %v has been promoted", member.GetName(), member.GetID())
 		return nil
 	} else if errors.Is(err, rpctypes.Error(rpctypes.ErrGRPCMemberNotLearner)) { //Member is not a learner
 		if member.PeerURLs[0] == "http://localhost:2380" { //[]string{"http://localhost:2380"}[0] {

--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gardener/etcd-backup-restore/pkg/compressor"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil/client"
+	"github.com/gardener/etcd-backup-restore/pkg/member"
 	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 	"github.com/sirupsen/logrus"
@@ -78,8 +79,8 @@ func NewRestorer(store brtypes.SnapStore, logger *logrus.Entry) *Restorer {
 }
 
 // RestoreAndStopEtcd restore the etcd data directory as per specified restore options but doesn't return the ETCD server that it statrted.
-func (r *Restorer) RestoreAndStopEtcd(ro brtypes.RestoreOptions) error {
-	embeddedEtcd, err := r.Restore(ro)
+func (r *Restorer) RestoreAndStopEtcd(ro brtypes.RestoreOptions, m member.ControlMember) error {
+	embeddedEtcd, err := r.Restore(ro, m)
 	defer func() {
 		if embeddedEtcd != nil {
 			embeddedEtcd.Server.Stop()
@@ -90,7 +91,7 @@ func (r *Restorer) RestoreAndStopEtcd(ro brtypes.RestoreOptions) error {
 }
 
 // Restore restore the etcd data directory as per specified restore options but returns the ETCD server that it statrted.
-func (r *Restorer) Restore(ro brtypes.RestoreOptions) (*embed.Etcd, error) {
+func (r *Restorer) Restore(ro brtypes.RestoreOptions, m member.ControlMember) (*embed.Etcd, error) {
 	if err := r.restoreFromBaseSnapshot(ro); err != nil {
 		return nil, fmt.Errorf("failed to restore from the base snapshot :%v", err)
 	}
@@ -120,6 +121,14 @@ func (r *Restorer) Restore(ro brtypes.RestoreOptions) (*embed.Etcd, error) {
 		return e, err
 	}
 
+	if m != nil {
+		clientCluster, err := clientFactory.NewCluster()
+		if err != nil {
+			return e, err
+		}
+		defer clientCluster.Close()
+		m.UpdateMember(context.TODO(), clientCluster)
+	}
 	return e, nil
 }
 

--- a/pkg/snapshot/restorer/restorer_test.go
+++ b/pkg/snapshot/restorer/restorer_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Running Restorer", func() {
 				restoreOpts.Config.InitialAdvertisePeerURLs = []string{"http://localhost:2390"}
 				restoreOpts.ClusterURLs, err = types.NewURLsMap(restoreOpts.Config.InitialCluster)
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).Should(HaveOccurred())
 			})
 		})
@@ -146,7 +146,7 @@ var _ = Describe("Running Restorer", func() {
 			It("should fail to restore", func() {
 				restoreOpts.Config.RestoreDataDir = ""
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).Should(HaveOccurred())
 			})
 		})
@@ -156,7 +156,7 @@ var _ = Describe("Running Restorer", func() {
 				restoreOpts.BaseSnapshot.SnapDir = "test"
 				restoreOpts.BaseSnapshot.SnapName = "test"
 
-				err := rstr.RestoreAndStopEtcd(restoreOpts)
+				err := rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).Should(HaveOccurred())
 			})
 		})
@@ -182,7 +182,7 @@ var _ = Describe("Running Restorer", func() {
 		Context("with maximum of one fetcher allowed", func() {
 			It("should restore etcd data directory", func() {
 				restoreOpts.Config.MaxFetchers = 1
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
@@ -194,7 +194,7 @@ var _ = Describe("Running Restorer", func() {
 			It("should restore etcd data directory", func() {
 				restoreOpts.Config.MaxFetchers = 4
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
@@ -206,7 +206,7 @@ var _ = Describe("Running Restorer", func() {
 			It("should restore etcd data directory", func() {
 				restoreOpts.Config.MaxFetchers = 100
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
@@ -323,7 +323,7 @@ var _ = Describe("Running Restorer", func() {
 					restoreOpts.BaseSnapshot.SnapName = ""
 				}
 
-				err := rstr.RestoreAndStopEtcd(restoreOpts)
+				err := rstr.RestoreAndStopEtcd(restoreOpts, nil)
 
 				Expect(err).ShouldNot(HaveOccurred())
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
@@ -364,7 +364,7 @@ var _ = Describe("Running Restorer", func() {
 					PeerURLs:      peerUrls,
 				}
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -408,7 +408,7 @@ var _ = Describe("Running Restorer", func() {
 					PeerURLs:      peerUrls,
 				}
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).Should(HaveOccurred())
 				// the below consistency fails with index out of range error hence commented,
 				// but the etcd directory is filled partially as part of the restore which should be relooked.
@@ -446,7 +446,7 @@ var _ = Describe("Running Restorer", func() {
 				}
 
 				logger.Infoln("starting restore, restore directory exists already")
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				logger.Infof("Failed to restore because :: %s", err)
 
 				Expect(err).Should(HaveOccurred())
@@ -494,7 +494,7 @@ var _ = Describe("Running Restorer", func() {
 				}
 
 				logger.Infoln("starting restore while snapshotter is running")
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -582,7 +582,7 @@ var _ = Describe("Running Restorer", func() {
 					PeerURLs:      peerUrls,
 				}
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -667,7 +667,7 @@ var _ = Describe("Running Restorer", func() {
 					PeerURLs:      peerUrls,
 				}
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -782,7 +782,7 @@ var _ = Describe("Running Restorer when both v1 and v2 directory structures are 
 			err = os.RemoveAll(path.Join(emDir, "member"))
 			Expect(err).ShouldNot(HaveOccurred())
 
-			err = rstr.RestoreAndStopEtcd(restoreOpts)
+			err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, resp.KeyTo, logger)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -814,7 +814,7 @@ var _ = Describe("Running Restorer when both v1 and v2 directory structures are 
 			err = os.RemoveAll(path.Join(emDir, "member"))
 			Expect(err).ShouldNot(HaveOccurred())
 
-			err = rstr.RestoreAndStopEtcd(restoreOpts)
+			err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, resp.KeyTo, logger)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -846,7 +846,7 @@ var _ = Describe("Running Restorer when both v1 and v2 directory structures are 
 			err = os.RemoveAll(path.Join(emDir, "member"))
 			Expect(err).ShouldNot(HaveOccurred())
 
-			err = rstr.RestoreAndStopEtcd(restoreOpts)
+			err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, resp.KeyTo, logger)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -880,7 +880,7 @@ var _ = Describe("Running Restorer when both v1 and v2 directory structures are 
 			err = os.RemoveAll(path.Join(emDir, "member"))
 			Expect(err).ShouldNot(HaveOccurred())
 
-			err = rstr.RestoreAndStopEtcd(restoreOpts)
+			err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, resp.KeyTo, logger)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -913,7 +913,7 @@ var _ = Describe("Running Restorer when both v1 and v2 directory structures are 
 				err = os.RemoveAll(path.Join(emDir, "member"))
 				Expect(err).ShouldNot(HaveOccurred())
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).Should(HaveOccurred())
 			})
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
When we create a new etcd cluster(size=1) then Peer address is correct, but after restoration of Etcd by backup-restore the Peer Address is not seems to be correct. This PR fixes this bug.

**Which issue(s) this PR fixes**:
Fixes #500 

**Special notes for your reviewer**:
Please test Scale up feature only after this [PR](https://github.com/gardener/etcd-backup-restore/pull/501) get merge as it contains one fix of Scale up feature.

**Release note**:
```improvement operator
Assigned the correct Peer address to the Etcd after it restores from backup-bucket.
```
