### PR TITLE
Don't update peer URL when promoting member

### DIFF
--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -195,6 +195,8 @@ func parsePeerURL(peerURL, podName string) (string, error) {
 
 // updateMemberPeerAddress updated the peer address of a specified etcd member
 func (m *memberControl) updateMemberPeerAddress(ctx context.Context, cli client.ClusterCloser, id uint64) error {
+	// Already existing clusters have `http://localhost:2380` as the peer address. This needs to explicitly updated to the new address
+	// TODO: Remove this peer address updation logic on etcd-br v0.20.0
 	m.logger.Infof("Updating member peer URL for %s", m.podName)
 
 	memberURL, err := getMemberURL(m.configFile, m.podName)
@@ -271,13 +273,6 @@ func (m *memberControl) doPromoteMember(ctx context.Context, member *etcdserverp
 		m.logger.Infof("Member %v with ID: %v has been promoted", member.GetName(), member.GetID())
 		return nil
 	} else if errors.Is(err, rpctypes.Error(rpctypes.ErrGRPCMemberNotLearner)) { //Member is not a learner
-		if member.PeerURLs[0] == "http://localhost:2380" { //[]string{"http://localhost:2380"}[0] {
-			// Already existing clusters have `http://localhost:2380` as the peer address. This needs to explicitly updated to the new address
-			// TODO: Remove this peer address updation logic on etcd-br v0.20.0
-			if err := m.updateMemberPeerAddress(ctx, cli, member.ID); err != nil {
-				m.logger.Errorf("Could not update member peer URL : %v", err)
-			}
-		}
 		m.logger.Info("Member ", member.Name, " : ", member.ID, " already part of etcd cluster")
 		return nil
 	}

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -33,8 +33,8 @@ var (
 	ErrMissingMember = errors.New("member missing from member list")
 )
 
-// ControlMember interface defines the functionalities needed to manipulate a member in the etcd cluster
-type ControlMember interface {
+// Control interface defines the functionalities needed to manipulate a member in the etcd cluster
+type Control interface {
 	// AddMemberAsLearner add a new member as a learner to the etcd cluster
 	AddMemberAsLearner(context.Context) error
 
@@ -57,7 +57,7 @@ type memberControl struct {
 }
 
 // NewMemberControl returns new ExponentialBackoff.
-func NewMemberControl(etcdConnConfig *brtypes.EtcdConnectionConfig) ControlMember {
+func NewMemberControl(etcdConnConfig *brtypes.EtcdConnectionConfig) Control {
 	var configFile string
 	logger := logrus.New().WithField("actor", "member-add")
 	etcdConn := *etcdConnConfig

--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -79,7 +79,7 @@ func NewRestorer(store brtypes.SnapStore, logger *logrus.Entry) *Restorer {
 }
 
 // RestoreAndStopEtcd restore the etcd data directory as per specified restore options but doesn't return the ETCD server that it statrted.
-func (r *Restorer) RestoreAndStopEtcd(ro brtypes.RestoreOptions, m member.ControlMember) error {
+func (r *Restorer) RestoreAndStopEtcd(ro brtypes.RestoreOptions, m member.Control) error {
 	embeddedEtcd, err := r.Restore(ro, m)
 	defer func() {
 		if embeddedEtcd != nil {
@@ -91,7 +91,7 @@ func (r *Restorer) RestoreAndStopEtcd(ro brtypes.RestoreOptions, m member.Contro
 }
 
 // Restore restore the etcd data directory as per specified restore options but returns the ETCD server that it statrted.
-func (r *Restorer) Restore(ro brtypes.RestoreOptions, m member.ControlMember) (*embed.Etcd, error) {
+func (r *Restorer) Restore(ro brtypes.RestoreOptions, m member.Control) (*embed.Etcd, error) {
 	if err := r.restoreFromBaseSnapshot(ro); err != nil {
 		return nil, fmt.Errorf("failed to restore from the base snapshot :%v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates member promote logic to not attempt to update peer URL while promoting a member.
Promote member is called only when in multi node case and in that case updated member peer URLs are already used since these are new nodes/pods trying to join the cluster

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
No attempt is made to update member Peer URL when trying to promote a member
```
