### PR TITLE
Added insecureSkipVerify and trustedCaCert for AWS S3 implementation …

### DIFF
--- a/doc/usage/getting_started.md
+++ b/doc/usage/getting_started.md
@@ -15,7 +15,7 @@ The procedure to provide credentials to access the cloud provider object store v
 
 * For `AWS S3`: 
    1. The secret file should be provided and it's file path should be made available as environment variables: `AWS_APPLICATION_CREDENTIALS` or `AWS_APPLICATION_CREDENTIALS_JSON`.
-   2. For `S3-compatible providers` such as MinIO, `AWS_ENDPOINT` and `AWS_FORCE_PATH_STYLE` can also be made available in a above file to configure the S3 client to communicate to a non-AWS provider.
+   2. For `S3-compatible providers` such as MinIO, `endpoint`, `s3ForcePathStyle`, `insecureSkipVerify` and `trustedCaCert`, can also be made available in a above file to configure the S3 client to communicate to a non-AWS provider.
 
 * For  `Google Cloud Storage`: 
    1. The service account json file should be provided in the `~/.gcp` as a `service-account-file.json` file.

--- a/example/storage-provider-secrets/01-aws-s3-storage-secret.yaml
+++ b/example/storage-provider-secrets/01-aws-s3-storage-secret.yaml
@@ -10,6 +10,8 @@ data:
   secretAccessKey: YWRtaW4= # admin
 # endpoint: # used for S3 compatible providers
 # s3ForcePathStyle: # set to `true` for S3 compliant providers
+# insecureSkipVerify: # set to `true` for S3 private deployments to skip certificate check
+# trustedCaCert: # set a trusted Certificate authority for private deployments like minio
 
 #### OR ####
 
@@ -33,5 +35,7 @@ stringData:
 #  "region": "admin",
 #  "secretAccessKey": "admin",
 #  "endpoint": "https://example.com:9000",
-#  "s3ForcePathStyle" true
+#  "s3ForcePathStyle": true,
+#  "insecureSkipVerify": true,
+#  "trustedCaCert": "-----BEGIN CERTIFICATE----\nMIIDAzCCAeugAwIBAgIBADANBgkqhkiG9w0BAQsFADAjMSEwHwYDVQQDDBhrM3Mt\nc2VydmVyLWNhQDE2NTc2MzQ0MDQwHhcNMjIwNzEyMTQwMDA0WhcNMzIwNzA5MTQw\n...\n-----END CERTIFICATE-----"
 #  }


### PR DESCRIPTION
…in order to allow connections to private MinIO deployments

**What this PR does / why we need it**:
It allow to set insecureSkipVerify or trustedCaCert in order to be able to connect to private MinIO deployments

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```
Added ability to use insecureSkipVerify or trustedCaCert for private MinIO deployments

```
