### PR TITLE
Cherry pick changes for rel v0.18.1

### DIFF
--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -43,7 +43,7 @@ func NewRestoreCommand(ctx context.Context) *cobra.Command {
 			}
 
 			rs := restorer.NewRestorer(store, logrus.NewEntry(logger))
-			if err := rs.RestoreAndStopEtcd(*options); err != nil {
+			if err := rs.RestoreAndStopEtcd(*options, nil); err != nil {
 				logger.Fatalf("Failed to restore snapshot: %v", err)
 				return
 			}

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -80,7 +80,7 @@ func (cp *Compactor) Compact(ctx context.Context, opts *brtypes.CompactOptions) 
 
 	// Then restore from the snapshots
 	r := restorer.NewRestorer(cp.store, cp.logger)
-	embeddedEtcd, err := r.Restore(*cmpctOptions)
+	embeddedEtcd, err := r.Restore(*cmpctOptions, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to restore snapshots during compaction: %v", err)
 	}

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Running Compactor", func() {
 
 				rstr := restorer.NewRestorer(store, logger)
 
-				err = rstr.RestoreAndStopEtcd(*restoreOpts)
+				err = rstr.RestoreAndStopEtcd(*restoreOpts, nil)
 
 				Expect(err).ShouldNot(HaveOccurred())
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
@@ -237,7 +237,7 @@ var _ = Describe("Running Compactor", func() {
 
 				rstr := restorer.NewRestorer(store, logger)
 
-				err = rstr.RestoreAndStopEtcd(*restoreOpts)
+				err = rstr.RestoreAndStopEtcd(*restoreOpts, nil)
 
 				Expect(err).ShouldNot(HaveOccurred())
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -167,7 +167,8 @@ func (e *EtcdInitializer) restoreCorruptData() (bool, error) {
 	}
 
 	rs := restorer.NewRestorer(store, logrus.NewEntry(logger))
-	if err := rs.RestoreAndStopEtcd(tempRestoreOptions); err != nil {
+	m := member.NewMemberControl(e.Config.EtcdConnectionConfig)
+	if err := rs.RestoreAndStopEtcd(tempRestoreOptions, m); err != nil {
 		err = fmt.Errorf("failed to restore snapshot: %v", err)
 		return false, err
 	}

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -77,6 +77,11 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 		return fmt.Errorf("error while initializing: %v", err)
 	}
 
+	if dataDirStatus == validator.DataDirStatusUnknownInMultiNode {
+		metrics.ValidationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
+		return fmt.Errorf("failed to initialize data dir of cluster member in multi-node cluster")
+	}
+
 	if dataDirStatus == validator.FailBelowRevisionConsistencyError {
 		metrics.ValidationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
 		return fmt.Errorf("failed to initialize since fail below revision check failed")

--- a/pkg/initializer/validator/datavalidator.go
+++ b/pkg/initializer/validator/datavalidator.go
@@ -68,6 +68,10 @@ func (d *DataValidator) backendPath() string { return filepath.Join(d.snapDir(),
 func (d *DataValidator) Validate(mode Mode, failBelowRevision int64) (DataDirStatus, error) {
 	status, err := d.sanityCheck(failBelowRevision)
 	if status != DataDirectoryValid {
+		// TODO: To be removed when backup-restore supports restoration of single member in multi-node etcd cluster.
+		if d.OriginalClusterSize > 1 && !miscellaneous.IsBackupBucketEmpty(d.Config.SnapstoreConfig, d.Logger) {
+			return DataDirStatusUnknownInMultiNode, nil
+		}
 		return status, err
 	}
 

--- a/pkg/initializer/validator/types.go
+++ b/pkg/initializer/validator/types.go
@@ -38,6 +38,9 @@ const (
 	DataDirectoryCorrupt
 	// DataDirectoryStatusUnknown indicates validator failed to check the data directory status.
 	DataDirectoryStatusUnknown
+	// DataDirStatusUnknownInMultiNode indicates validator failed to check the data directory status in multi-node etcd cluster.
+	// TODO: To be removed when backup-restore supports restoration of single member in multi-node etcd cluster.
+	DataDirStatusUnknownInMultiNode
 	// RevisionConsistencyError indicates current etcd revision is inconsistent with latest snapshot revision.
 	RevisionConsistencyError
 	// FailBelowRevisionConsistencyError indicates the current etcd revision is inconsistent with failBelowRevision.

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -71,12 +71,8 @@ func NewMemberControl(etcdConnConfig *brtypes.EtcdConnectionConfig) ControlMembe
 		logger.Fatalf("Error reading POD_NAME env var : %v", err)
 	}
 	//TODO: Refactor needed
-	etcdConfigForTest := os.Getenv("ETCD_CONF")
-	if etcdConfigForTest != "" {
-		configFile = etcdConfigForTest
-	} else {
-		configFile = "/var/etcd/config/etcd.conf.yaml"
-	}
+	configFile = miscellaneous.GetConfigFilePath()
+
 	return &memberControl{
 		clientFactory: clientFactory,
 		logger:        *logger,
@@ -161,7 +157,8 @@ func (m *memberControl) IsMemberInCluster(ctx context.Context) (bool, error) {
 	}
 
 	m.logger.Infof("Member %s not part of any running cluster", m.podName)
-	return false, fmt.Errorf("Could not find member %s in the list", m.podName)
+	//return false, fmt.Errorf("Could not find member %s in the list", m.podName)
+	return false, nil
 }
 
 func (m *memberControl) getMemberURL() (string, error) {

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -146,7 +146,7 @@ func (m *memberControl) IsMemberInCluster(ctx context.Context) (bool, error) {
 		return err
 	})
 	if err != nil {
-		return false, fmt.Errorf("Could not list any etcd members %w", err)
+		return false, fmt.Errorf("could not list any etcd members %w", err)
 	}
 
 	for _, y := range etcdMemberList.Members {
@@ -156,26 +156,26 @@ func (m *memberControl) IsMemberInCluster(ctx context.Context) (bool, error) {
 		}
 	}
 
-	m.logger.Infof("Member %s not part of any running cluster", m.podName)
-	//return false, fmt.Errorf("Could not find member %s in the list", m.podName)
+	m.logger.Infof("Member %v not part of any running cluster", m.podName)
+	m.logger.Infof("Could not find member %v in the list", m.podName)
 	return false, nil
 }
 
 func (m *memberControl) getMemberURL() (string, error) {
 	configYML, err := os.ReadFile(m.configFile)
 	if err != nil {
-		return "", fmt.Errorf("Unable to read etcd config file: %v", err)
+		return "", fmt.Errorf("unable to read etcd config file: %v", err)
 	}
 
 	config := map[string]interface{}{}
 	if err := yaml.Unmarshal([]byte(configYML), &config); err != nil {
-		return "", fmt.Errorf("Unable to unmarshal etcd config yaml file: %v", err)
+		return "", fmt.Errorf("unable to unmarshal etcd config yaml file: %v", err)
 	}
 
 	initAdPeerURL := config["initial-advertise-peer-urls"]
 	peerURL, err := parsePeerURL(initAdPeerURL.(string), m.podName)
 	if err != nil {
-		return "", fmt.Errorf("Could not parse peer URL from the config file : %v", err)
+		return "", fmt.Errorf("could not parse peer URL from the config file : %v", err)
 	}
 	return peerURL, nil
 }
@@ -183,7 +183,7 @@ func (m *memberControl) getMemberURL() (string, error) {
 func parsePeerURL(peerURL, podName string) (string, error) {
 	tokens := strings.Split(peerURL, "@")
 	if len(tokens) < 4 {
-		return "", fmt.Errorf("Invalid peer URL : %s", peerURL)
+		return "", fmt.Errorf("invalid peer URL : %s", peerURL)
 	}
 	domaiName := fmt.Sprintf("%s.%s.%s", tokens[1], tokens[2], "svc")
 
@@ -200,7 +200,7 @@ func (m *memberControl) updateMemberPeerAddress(ctx context.Context, id uint64) 
 
 	memberURL, err := m.getMemberURL()
 	if err != nil {
-		return fmt.Errorf("Could not fetch member URL : %v", err)
+		return fmt.Errorf("could not fetch member URL : %v", err)
 	}
 
 	memberUpdateCtx, cancel := context.WithTimeout(ctx, etcdTimeout)

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -21,11 +21,11 @@ import (
 )
 
 const (
-	// retryPeriod is the peroid after which an operation is retried
-	retryPeriod = 5 * time.Second
+	// RetryPeriod is the peroid after which an operation is retried
+	RetryPeriod = 2 * time.Second
 
-	// etcdTimeout is timeout for etcd operations
-	etcdTimeout = 5 * time.Second
+	// EtcdTimeout is timeout for etcd operations
+	EtcdTimeout = 5 * time.Second
 )
 
 var (
@@ -43,6 +43,9 @@ type ControlMember interface {
 
 	// PromoteMember promotes an etcd member from a learner to a voting member of the cluster. This will succeed if and only if learner is in a healthy state and the learner is in sync with leader
 	PromoteMember(context.Context) error
+
+	// UpdateMember updates the peer address of a specified etcd cluster member.
+	UpdateMember(context.Context, client.ClusterCloser) error
 }
 
 // memberControl holds the configuration for the mechanism of adding a new member to the cluster.
@@ -84,7 +87,7 @@ func NewMemberControl(etcdConnConfig *brtypes.EtcdConnectionConfig) ControlMembe
 // AddMemberAsLearner add a member as a learner to the etcd cluster
 func (m *memberControl) AddMemberAsLearner(ctx context.Context) error {
 	//Add member as learner to cluster
-	memberURL, err := m.getMemberURL()
+	memberURL, err := getMemberURL(m.configFile, m.podName)
 	if err != nil {
 		m.logger.Fatalf("Error fetching etcd member URL : %v", err)
 	}
@@ -95,7 +98,7 @@ func (m *memberControl) AddMemberAsLearner(ctx context.Context) error {
 	}
 	defer cli.Close()
 
-	memAddCtx, cancel := context.WithTimeout(ctx, etcdTimeout)
+	memAddCtx, cancel := context.WithTimeout(ctx, EtcdTimeout)
 	defer cancel()
 	_, err = cli.MemberAddAsLearner(memAddCtx, []string{memberURL})
 
@@ -120,7 +123,7 @@ func (m *memberControl) IsMemberInCluster(ctx context.Context) (bool, error) {
 	err := retry.OnError(backoff, func(err error) bool {
 		return err != nil
 	}, func() error {
-		etcdProbeCtx, cancel := context.WithTimeout(context.TODO(), etcdTimeout)
+		etcdProbeCtx, cancel := context.WithTimeout(context.TODO(), EtcdTimeout)
 		defer cancel()
 		return miscellaneous.ProbeEtcd(etcdProbeCtx, m.clientFactory, &m.logger)
 	})
@@ -140,7 +143,7 @@ func (m *memberControl) IsMemberInCluster(ctx context.Context) (bool, error) {
 	err = retry.OnError(retry.DefaultBackoff, func(err error) bool {
 		return err != nil
 	}, func() error {
-		memListCtx, cancel := context.WithTimeout(context.TODO(), etcdTimeout)
+		memListCtx, cancel := context.WithTimeout(context.TODO(), EtcdTimeout)
 		defer cancel()
 		etcdMemberList, err = cli.MemberList(memListCtx)
 		return err
@@ -161,8 +164,8 @@ func (m *memberControl) IsMemberInCluster(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-func (m *memberControl) getMemberURL() (string, error) {
-	configYML, err := os.ReadFile(m.configFile)
+func getMemberURL(configFile string, podName string) (string, error) {
+	configYML, err := os.ReadFile(configFile)
 	if err != nil {
 		return "", fmt.Errorf("unable to read etcd config file: %v", err)
 	}
@@ -173,7 +176,7 @@ func (m *memberControl) getMemberURL() (string, error) {
 	}
 
 	initAdPeerURL := config["initial-advertise-peer-urls"]
-	peerURL, err := parsePeerURL(initAdPeerURL.(string), m.podName)
+	peerURL, err := parsePeerURL(initAdPeerURL.(string), podName)
 	if err != nil {
 		return "", fmt.Errorf("could not parse peer URL from the config file : %v", err)
 	}
@@ -190,23 +193,22 @@ func parsePeerURL(peerURL, podName string) (string, error) {
 	return fmt.Sprintf("%s://%s.%s:%s", tokens[0], podName, domaiName, tokens[3]), nil
 }
 
-// UpdateMemberPeerAddress updated the peer address of a specified etcd member
-func (m *memberControl) updateMemberPeerAddress(ctx context.Context, id uint64) error {
+// updateMemberPeerAddress updated the peer address of a specified etcd member
+func (m *memberControl) updateMemberPeerAddress(ctx context.Context, cli client.ClusterCloser, id uint64) error {
 	m.logger.Infof("Updating member peer URL for %s", m.podName)
-	cli, err := m.clientFactory.NewCluster()
-	if err != nil {
-		return fmt.Errorf("failed to build etcd cluster client : %v", err)
-	}
 
-	memberURL, err := m.getMemberURL()
+	memberURL, err := getMemberURL(m.configFile, m.podName)
 	if err != nil {
 		return fmt.Errorf("could not fetch member URL : %v", err)
 	}
 
-	memberUpdateCtx, cancel := context.WithTimeout(ctx, etcdTimeout)
+	memberUpdateCtx, cancel := context.WithTimeout(ctx, EtcdTimeout)
 	defer cancel()
 
-	_, err = cli.MemberUpdate(memberUpdateCtx, id, []string{memberURL})
+	if _, err := cli.MemberUpdate(memberUpdateCtx, id, []string{memberURL}); err == nil {
+		m.logger.Info("Successfully updated the member peer URL")
+		return nil
+	}
 	return err
 }
 
@@ -240,11 +242,25 @@ func (m *memberControl) PromoteMember(ctx context.Context) error {
 
 func findMember(existingMembers []*etcdserverpb.Member, memberName string) *etcdserverpb.Member {
 	for _, member := range existingMembers {
-		if member.Name == memberName {
+		if member.GetName() == memberName {
 			return member
 		}
 	}
 	return nil
+}
+
+// UpdateMember updates the peer address of a specified etcd cluster member.
+func (m *memberControl) UpdateMember(ctx context.Context, cli client.ClusterCloser) error {
+	m.logger.Infof("Attempting to update the member Info: %v", m.podName)
+	ctx, cancel := context.WithTimeout(ctx, brtypes.DefaultEtcdConnectionTimeout)
+	defer cancel()
+
+	membersInfo, err := cli.MemberList(ctx)
+	if err != nil {
+		return fmt.Errorf("error listing members: %v", err)
+	}
+
+	return m.updateMemberPeerAddress(ctx, cli, membersInfo.Header.GetMemberId())
 }
 
 func (m *memberControl) doPromoteMember(ctx context.Context, member *etcdserverpb.Member, cli client.ClusterCloser) error {
@@ -252,14 +268,15 @@ func (m *memberControl) doPromoteMember(ctx context.Context, member *etcdserverp
 	defer cancel()
 	_, err := cli.MemberPromote(memPromoteCtx, member.ID) //Member promote call will succeed only if member is in sync with leader, and will error out otherwise
 	if err == nil {                                       //Member successfully promoted
-		m.logger.Info("Member promoted ", member.Name, " : ", member.ID)
+		m.logger.Infof("Member %v with ID: %v has been promoted", member.GetName(), member.GetID())
 		return nil
 	} else if errors.Is(err, rpctypes.Error(rpctypes.ErrGRPCMemberNotLearner)) { //Member is not a learner
 		if member.PeerURLs[0] == "http://localhost:2380" { //[]string{"http://localhost:2380"}[0] {
 			// Already existing clusters have `http://localhost:2380` as the peer address. This needs to explicitly updated to the new address
 			// TODO: Remove this peer address updation logic on etcd-br v0.20.0
-			err = m.updateMemberPeerAddress(ctx, member.ID)
-			m.logger.Errorf("Could not update member peer URL : %v", err)
+			if err := m.updateMemberPeerAddress(ctx, cli, member.ID); err != nil {
+				m.logger.Errorf("Could not update member peer URL : %v", err)
+			}
 		}
 		m.logger.Info("Member ", member.Name, " : ", member.ID, " already part of etcd cluster")
 		return nil

--- a/pkg/member/member_control_test.go
+++ b/pkg/member/member_control_test.go
@@ -82,5 +82,4 @@ var _ = Describe("Membercontrol", func() {
 			})
 		})
 	})
-
 })

--- a/pkg/member/member_control_test.go
+++ b/pkg/member/member_control_test.go
@@ -74,10 +74,11 @@ var _ = Describe("Membercontrol", func() {
 
 	Describe("While attempting to check if etcd is part of a cluster", func() {
 		Context("When cluster is up and member is not part of the list", func() {
-			It("Should return an error", func() {
+			It("Should return false and no error", func() {
 				mem := member.NewMemberControl(etcdConnectionConfig)
-				_, err := mem.IsMemberInCluster(context.TODO())
-				Expect(err).ToNot(BeNil())
+				bool, err := mem.IsMemberInCluster(context.TODO())
+				Expect(bool).To(BeFalse())
+				Expect(err).To(BeNil())
 			})
 		})
 	})

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -61,9 +61,8 @@ type BackupRestoreServer struct {
 
 var (
 	// runServerWithSnapshotter indicates whether to start server with or without snapshotter.
-	runServerWithSnapshotter bool   = true
-	etcdConfig               string = "/var/etcd/config/etcd.conf.yaml"
-	retryTimeout                    = 5 * time.Second
+	runServerWithSnapshotter bool = true
+	retryTimeout                  = 5 * time.Second
 )
 
 // NewBackupRestoreServer return new backup restore server.
@@ -98,14 +97,7 @@ func (b *BackupRestoreServer) Run(ctx context.Context) error {
 	var inputFileName string
 	var err error
 
-	// (For testing purpose) If no ETCD_CONF variable set as environment variable, then consider backup-restore server is not used for tests.
-	// For tests or to run backup-restore server as standalone, user needs to set ETCD_CONF variable with proper location of ETCD config yaml
-	etcdConfigForTest := os.Getenv("ETCD_CONF")
-	if etcdConfigForTest != "" {
-		inputFileName = etcdConfigForTest
-	} else {
-		inputFileName = etcdConfig
-	}
+	inputFileName = miscellaneous.GetConfigFilePath()
 
 	configYML, err := os.ReadFile(inputFileName)
 	if err != nil {
@@ -119,7 +111,7 @@ func (b *BackupRestoreServer) Run(ctx context.Context) error {
 		return err
 	}
 
-	initialClusterMap, err := types.NewURLsMap(fmt.Sprint(config["initial-cluster"]))
+	initialClusterSize, err := miscellaneous.GetClusterSize(fmt.Sprint(config["initial-cluster"]))
 	if err != nil {
 		b.logger.Fatal("Please provide initial cluster value for embedded ETCD")
 	}
@@ -139,7 +131,7 @@ func (b *BackupRestoreServer) Run(ctx context.Context) error {
 	options := &brtypes.RestoreOptions{
 		Config:              b.config.RestorationConfig,
 		ClusterURLs:         clusterURLsMap,
-		OriginalClusterSize: len(initialClusterMap),
+		OriginalClusterSize: initialClusterSize,
 		PeerURLs:            peerURLs,
 	}
 
@@ -200,19 +192,21 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 	defer handler.Stop()
 
 	// Promotes member if it is a learner
-	for {
-		select {
-		case <-ctx.Done():
-			b.logger.Info("Context cancelled. Stopping retry promoting member")
-			return ctx.Err()
-		default:
+	if restoreOpts.OriginalClusterSize > 1 {
+		for {
+			select {
+			case <-ctx.Done():
+				b.logger.Info("Context cancelled. Stopping retry promoting member")
+				return ctx.Err()
+			default:
+			}
+			m := member.NewMemberControl(b.config.EtcdConnectionConfig)
+			err := m.PromoteMember(ctx)
+			if err == nil {
+				break
+			}
+			miscellaneous.SleepWithContext(ctx, retryTimeout)
 		}
-		m := member.NewMemberControl(b.config.EtcdConnectionConfig)
-		err := m.PromoteMember(ctx)
-		if err == nil {
-			break
-		}
-		miscellaneous.SleepWithContext(ctx, retryTimeout)
 	}
 
 	leaderCallbacks := &brtypes.LeaderCallbacks{

--- a/pkg/server/httpAPI.go
+++ b/pkg/server/httpAPI.go
@@ -396,7 +396,7 @@ func (h *HTTPHandler) serveLatestSnapshotMetadata(rw http.ResponseWriter, req *h
 }
 
 func (h *HTTPHandler) serveConfig(rw http.ResponseWriter, req *http.Request) {
-	inputFileName := "/var/etcd/config/etcd.conf.yaml"
+	inputFileName := miscellaneous.EtcdConfigFilePath
 	outputFileName := "/etc/etcd.conf.yaml"
 	configYML, err := ioutil.ReadFile(inputFileName)
 	if err != nil {
@@ -489,7 +489,7 @@ func getInitialCluster(ctx context.Context, initialCluster string, etcdConn brty
 	})
 	noOfMembers := 0
 	if err != nil {
-		logger.Warnf("Error with MemberList() : %v", err)
+		logger.Warnf("Could not list members : %v", err)
 	} else {
 		noOfMembers = len(memList.Members)
 	}

--- a/pkg/server/httpAPI.go
+++ b/pkg/server/httpAPI.go
@@ -40,9 +40,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/clientv3"
-	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/util/retry"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -415,6 +413,14 @@ func (h *HTTPHandler) serveConfig(rw http.ResponseWriter, req *http.Request) {
 	// fetch pod name from env
 	podNS := os.Getenv("POD_NAMESPACE")
 	podName := os.Getenv("POD_NAME")
+
+	clientSet, err := miscellaneous.GetKubernetesClientSetOrError()
+	if err != nil {
+		h.Logger.Warnf("Failed to create clientset: %v", err)
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
 	config["name"] = podName
 
 	initAdPeerURL := config["initial-advertise-peer-urls"]
@@ -437,7 +443,7 @@ func (h *HTTPHandler) serveConfig(rw http.ResponseWriter, req *http.Request) {
 	domaiName = fmt.Sprintf("%s.%s.%s", svcName, namespace, "svc")
 	config["advertise-client-urls"] = fmt.Sprintf("%s://%s.%s:%s", protocol, podName, domaiName, clientPort)
 
-	config["initial-cluster-state"] = getInitialClusterState(req.Context(), *h.Logger, podName, podNS)
+	config["initial-cluster-state"] = miscellaneous.GetInitialClusterState(req.Context(), *h.Logger, clientSet, podName, podNS)
 
 	config["initial-cluster"] = getInitialCluster(req.Context(), fmt.Sprint(config["initial-cluster"]), *h.EtcdConnectionConfig, protocol, clientPort, *h.Logger, podName)
 
@@ -515,33 +521,6 @@ func getInitialCluster(ctx context.Context, initialCluster string, etcdConn brty
 	}
 
 	return initialCluster
-}
-
-func getInitialClusterState(ctx context.Context, logger logrus.Entry, podName string, podNS string) string {
-	clusterState := "new"
-
-	//Read sts spec for updated replicas to toggle `initial-cluster-state`
-	clientSet, err := miscellaneous.GetKubernetesClientSetOrError()
-	if err != nil {
-		logger.Errorf("failed to create clientset: %v", err)
-		return clusterState
-	}
-	curSts := &appsv1.StatefulSet{}
-	errSts := clientSet.Get(ctx, client.ObjectKey{
-		Namespace: podNS,
-		Name:      podName[:strings.LastIndex(podName, "-")],
-	}, curSts)
-	if errSts != nil {
-		logger.Warn("error fetching etcd sts ", errSts)
-		return clusterState
-	}
-
-	//TODO: achieve this without an sts?
-	if *curSts.Spec.Replicas > 1 && *curSts.Spec.Replicas > curSts.Status.UpdatedReplicas {
-		clusterState = "existing"
-	}
-
-	return clusterState
 }
 
 func parsePeerURL(peerURL string) (string, string, string, string, error) {

--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -79,7 +79,7 @@ func NewRestorer(store brtypes.SnapStore, logger *logrus.Entry) *Restorer {
 }
 
 // RestoreAndStopEtcd restore the etcd data directory as per specified restore options but doesn't return the ETCD server that it statrted.
-func (r *Restorer) RestoreAndStopEtcd(ro brtypes.RestoreOptions, m member.ControlMember) error {
+func (r *Restorer) RestoreAndStopEtcd(ro brtypes.RestoreOptions, m member.Control) error {
 	embeddedEtcd, err := r.Restore(ro, m)
 	defer func() {
 		if embeddedEtcd != nil {
@@ -91,7 +91,7 @@ func (r *Restorer) RestoreAndStopEtcd(ro brtypes.RestoreOptions, m member.Contro
 }
 
 // Restore restore the etcd data directory as per specified restore options but returns the ETCD server that it statrted.
-func (r *Restorer) Restore(ro brtypes.RestoreOptions, m member.ControlMember) (*embed.Etcd, error) {
+func (r *Restorer) Restore(ro brtypes.RestoreOptions, m member.Control) (*embed.Etcd, error) {
 	if err := r.restoreFromBaseSnapshot(ro); err != nil {
 		return nil, fmt.Errorf("failed to restore from the base snapshot :%v", err)
 	}

--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gardener/etcd-backup-restore/pkg/compressor"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil/client"
+	"github.com/gardener/etcd-backup-restore/pkg/member"
 	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 	"github.com/sirupsen/logrus"
@@ -78,8 +79,8 @@ func NewRestorer(store brtypes.SnapStore, logger *logrus.Entry) *Restorer {
 }
 
 // RestoreAndStopEtcd restore the etcd data directory as per specified restore options but doesn't return the ETCD server that it statrted.
-func (r *Restorer) RestoreAndStopEtcd(ro brtypes.RestoreOptions) error {
-	embeddedEtcd, err := r.Restore(ro)
+func (r *Restorer) RestoreAndStopEtcd(ro brtypes.RestoreOptions, m member.ControlMember) error {
+	embeddedEtcd, err := r.Restore(ro, m)
 	defer func() {
 		if embeddedEtcd != nil {
 			embeddedEtcd.Server.Stop()
@@ -90,7 +91,7 @@ func (r *Restorer) RestoreAndStopEtcd(ro brtypes.RestoreOptions) error {
 }
 
 // Restore restore the etcd data directory as per specified restore options but returns the ETCD server that it statrted.
-func (r *Restorer) Restore(ro brtypes.RestoreOptions) (*embed.Etcd, error) {
+func (r *Restorer) Restore(ro brtypes.RestoreOptions, m member.ControlMember) (*embed.Etcd, error) {
 	if err := r.restoreFromBaseSnapshot(ro); err != nil {
 		return nil, fmt.Errorf("failed to restore from the base snapshot :%v", err)
 	}
@@ -120,6 +121,14 @@ func (r *Restorer) Restore(ro brtypes.RestoreOptions) (*embed.Etcd, error) {
 		return e, err
 	}
 
+	if m != nil {
+		clientCluster, err := clientFactory.NewCluster()
+		if err != nil {
+			return e, err
+		}
+		defer clientCluster.Close()
+		m.UpdateMember(context.TODO(), clientCluster)
+	}
 	return e, nil
 }
 

--- a/pkg/snapshot/restorer/restorer_test.go
+++ b/pkg/snapshot/restorer/restorer_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Running Restorer", func() {
 				restoreOpts.Config.InitialAdvertisePeerURLs = []string{"http://localhost:2390"}
 				restoreOpts.ClusterURLs, err = types.NewURLsMap(restoreOpts.Config.InitialCluster)
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).Should(HaveOccurred())
 			})
 		})
@@ -146,7 +146,7 @@ var _ = Describe("Running Restorer", func() {
 			It("should fail to restore", func() {
 				restoreOpts.Config.RestoreDataDir = ""
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).Should(HaveOccurred())
 			})
 		})
@@ -156,7 +156,7 @@ var _ = Describe("Running Restorer", func() {
 				restoreOpts.BaseSnapshot.SnapDir = "test"
 				restoreOpts.BaseSnapshot.SnapName = "test"
 
-				err := rstr.RestoreAndStopEtcd(restoreOpts)
+				err := rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).Should(HaveOccurred())
 			})
 		})
@@ -182,7 +182,7 @@ var _ = Describe("Running Restorer", func() {
 		Context("with maximum of one fetcher allowed", func() {
 			It("should restore etcd data directory", func() {
 				restoreOpts.Config.MaxFetchers = 1
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
@@ -194,7 +194,7 @@ var _ = Describe("Running Restorer", func() {
 			It("should restore etcd data directory", func() {
 				restoreOpts.Config.MaxFetchers = 4
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
@@ -206,7 +206,7 @@ var _ = Describe("Running Restorer", func() {
 			It("should restore etcd data directory", func() {
 				restoreOpts.Config.MaxFetchers = 100
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
@@ -323,7 +323,7 @@ var _ = Describe("Running Restorer", func() {
 					restoreOpts.BaseSnapshot.SnapName = ""
 				}
 
-				err := rstr.RestoreAndStopEtcd(restoreOpts)
+				err := rstr.RestoreAndStopEtcd(restoreOpts, nil)
 
 				Expect(err).ShouldNot(HaveOccurred())
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
@@ -364,7 +364,7 @@ var _ = Describe("Running Restorer", func() {
 					PeerURLs:      peerUrls,
 				}
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -408,7 +408,7 @@ var _ = Describe("Running Restorer", func() {
 					PeerURLs:      peerUrls,
 				}
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).Should(HaveOccurred())
 				// the below consistency fails with index out of range error hence commented,
 				// but the etcd directory is filled partially as part of the restore which should be relooked.
@@ -446,7 +446,7 @@ var _ = Describe("Running Restorer", func() {
 				}
 
 				logger.Infoln("starting restore, restore directory exists already")
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				logger.Infof("Failed to restore because :: %s", err)
 
 				Expect(err).Should(HaveOccurred())
@@ -494,7 +494,7 @@ var _ = Describe("Running Restorer", func() {
 				}
 
 				logger.Infoln("starting restore while snapshotter is running")
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -582,7 +582,7 @@ var _ = Describe("Running Restorer", func() {
 					PeerURLs:      peerUrls,
 				}
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -667,7 +667,7 @@ var _ = Describe("Running Restorer", func() {
 					PeerURLs:      peerUrls,
 				}
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, keyTo, logger)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -782,7 +782,7 @@ var _ = Describe("Running Restorer when both v1 and v2 directory structures are 
 			err = os.RemoveAll(path.Join(emDir, "member"))
 			Expect(err).ShouldNot(HaveOccurred())
 
-			err = rstr.RestoreAndStopEtcd(restoreOpts)
+			err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, resp.KeyTo, logger)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -814,7 +814,7 @@ var _ = Describe("Running Restorer when both v1 and v2 directory structures are 
 			err = os.RemoveAll(path.Join(emDir, "member"))
 			Expect(err).ShouldNot(HaveOccurred())
 
-			err = rstr.RestoreAndStopEtcd(restoreOpts)
+			err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, resp.KeyTo, logger)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -846,7 +846,7 @@ var _ = Describe("Running Restorer when both v1 and v2 directory structures are 
 			err = os.RemoveAll(path.Join(emDir, "member"))
 			Expect(err).ShouldNot(HaveOccurred())
 
-			err = rstr.RestoreAndStopEtcd(restoreOpts)
+			err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, resp.KeyTo, logger)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -880,7 +880,7 @@ var _ = Describe("Running Restorer when both v1 and v2 directory structures are 
 			err = os.RemoveAll(path.Join(emDir, "member"))
 			Expect(err).ShouldNot(HaveOccurred())
 
-			err = rstr.RestoreAndStopEtcd(restoreOpts)
+			err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = utils.CheckDataConsistency(testCtx, restoreOpts.Config.RestoreDataDir, resp.KeyTo, logger)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -913,7 +913,7 @@ var _ = Describe("Running Restorer when both v1 and v2 directory structures are 
 				err = os.RemoveAll(path.Join(emDir, "member"))
 				Expect(err).ShouldNot(HaveOccurred())
 
-				err = rstr.RestoreAndStopEtcd(restoreOpts)
+				err = rstr.RestoreAndStopEtcd(restoreOpts, nil)
 				Expect(err).Should(HaveOccurred())
 			})
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry pick [`40e936`](https://github.com/gardener/etcd-backup-restore/commit/40e9368d4df0785ff5713d0a9eb94d16343610e3), [`7d27a4`](https://github.com/gardener/etcd-backup-restore/commit/7d27a47f5793b0949492d225ada5fd8344b6b6a2), [`41f9c5`](https://github.com/gardener/etcd-backup-restore/commit/41f9c5215aa1c99cd8ed5ccecc281d755882d45b), and [`008a47`](https://github.com/gardener/etcd-backup-restore/commit/008a478e4a43c3d47f2dac721623861059fca78f) onto `rel-v0.18` branch

**Which issue(s) this PR fixes**:
Fixes gardener/etcd-druid #361 (temporary fix), and #500 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator https://github.com/gardener/etcd-backup-restore #504 @aaronfern 
Fixed a bug where etcd calls related to multi node operation were used in single node operation
```
```bugFix operator https://github.com/gardener/etcd-backup-restore #501 @ishan16696 
Temp fix: skip the single member restoration if data-dir found to be invalid.
```
```bugFix operator https://github.com/gardener/etcd-backup-restore #501 @ishan16696 
Fixed a bug in Scaleup feature in func: `IsMemberInCluster()` which can cause Scaleup feature to get fail.
```
```improvement operator https://github.com/gardener/etcd-backup-restore #505 @ishan16696 
Assigned the correct Peer address to the Etcd after it restores from backup-bucket.
```
```improvement operator https://github.com/gardener/etcd-backup-restore #506 @aaronfern 
No attempt is made to update member Peer URL when trying to promote a member
```