### PR TITLE
Adds a feature of single member restoration in multi-node etcd.

### DIFF
--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -33,3 +33,8 @@ type SnapstoreError struct {
 func (e *SnapstoreError) Error() string {
 	return e.Message
 }
+
+// AnyError checks whether err is nil or not.
+func AnyError(err error) bool {
+	return err != nil
+}

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -89,11 +89,7 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 	metrics.ValidationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Observe(time.Since(start).Seconds())
 
 	if dataDirStatus != validator.DataDirectoryValid {
-		if dataDirStatus == validator.DataDirStatusInvalidInMultiNode || (e.Validator.OriginalClusterSize > 1 && dataDirStatus == validator.DataDirectoryCorrupt) {
-			if err := e.restoreInMultiNode(ctx); err != nil {
-				return err
-			}
-		} else if e.Validator.OriginalClusterSize > 1 && isEtcdMemberPresent {
+		if dataDirStatus == validator.DataDirStatusInvalidInMultiNode || (e.Validator.OriginalClusterSize > 1 && dataDirStatus == validator.DataDirectoryCorrupt) || (e.Validator.OriginalClusterSize > 1 && isEtcdMemberPresent) {
 			if err := e.restoreInMultiNode(ctx); err != nil {
 				return err
 			}

--- a/pkg/initializer/validator/types.go
+++ b/pkg/initializer/validator/types.go
@@ -38,9 +38,8 @@ const (
 	DataDirectoryCorrupt
 	// DataDirectoryStatusUnknown indicates validator failed to check the data directory status.
 	DataDirectoryStatusUnknown
-	// DataDirStatusUnknownInMultiNode indicates validator failed to check the data directory status in multi-node etcd cluster.
-	// TODO: To be removed when backup-restore supports restoration of single member in multi-node etcd cluster.
-	DataDirStatusUnknownInMultiNode
+	// DataDirStatusInvalidInMultiNode indicates validator failed to check the data directory status in multi-node etcd cluster.
+	DataDirStatusInvalidInMultiNode
 	// RevisionConsistencyError indicates current etcd revision is inconsistent with latest snapshot revision.
 	RevisionConsistencyError
 	// FailBelowRevisionConsistencyError indicates the current etcd revision is inconsistent with failBelowRevision.

--- a/pkg/leaderelection/leaderelection.go
+++ b/pkg/leaderelection/leaderelection.go
@@ -45,25 +45,27 @@ const (
 // LeaderElector holds the all configuration necessary to elect backup-restore Leader.
 type LeaderElector struct {
 	// CurrentState defines currentState of backup-restore for LeaderElection.
-	CurrentState          string
-	Config                *brtypes.Config
-	EtcdConnectionConfig  *brtypes.EtcdConnectionConfig
-	logger                *logrus.Entry
-	Callbacks             *brtypes.LeaderCallbacks
-	LeaseCallbacks        *brtypes.MemberLeaseCallbacks
-	CheckLeadershipStatus brtypes.IsLeaderCallbackFunc
+	CurrentState         string
+	Config               *brtypes.Config
+	EtcdConnectionConfig *brtypes.EtcdConnectionConfig
+	logger               *logrus.Entry
+	Callbacks            *brtypes.LeaderCallbacks
+	LeaseCallbacks       *brtypes.MemberLeaseCallbacks
+	PromoteCallback      *brtypes.PromoteLearnerCallback
+	CheckMemberStatus    brtypes.IsLeaderCallbackFunc
 }
 
 // NewLeaderElector returns LeaderElector configurations.
-func NewLeaderElector(logger *logrus.Entry, etcdConnectionConfig *brtypes.EtcdConnectionConfig, leaderElectionConfig *brtypes.Config, callbacks *brtypes.LeaderCallbacks, memberLeaseCallbacks *brtypes.MemberLeaseCallbacks, checkLeadershipFunc brtypes.IsLeaderCallbackFunc) (*LeaderElector, error) {
+func NewLeaderElector(logger *logrus.Entry, etcdConnectionConfig *brtypes.EtcdConnectionConfig, leaderElectionConfig *brtypes.Config, callbacks *brtypes.LeaderCallbacks, memberLeaseCallbacks *brtypes.MemberLeaseCallbacks, checkLeadershipFunc brtypes.IsLeaderCallbackFunc, promoteCallback *brtypes.PromoteLearnerCallback) (*LeaderElector, error) {
 	return &LeaderElector{
-		logger:                logger.WithField("actor", "leader-elector"),
-		EtcdConnectionConfig:  etcdConnectionConfig,
-		CurrentState:          DefaultCurrentState,
-		Config:                leaderElectionConfig,
-		Callbacks:             callbacks,
-		LeaseCallbacks:        memberLeaseCallbacks,
-		CheckLeadershipStatus: checkLeadershipFunc,
+		logger:               logger.WithField("actor", "leader-elector"),
+		EtcdConnectionConfig: etcdConnectionConfig,
+		CurrentState:         DefaultCurrentState,
+		Config:               leaderElectionConfig,
+		Callbacks:            callbacks,
+		LeaseCallbacks:       memberLeaseCallbacks,
+		CheckMemberStatus:    checkLeadershipFunc,
+		PromoteCallback:      promoteCallback,
 	}, nil
 }
 
@@ -83,7 +85,7 @@ func (le *LeaderElector) Run(ctx context.Context) error {
 			}
 			return nil
 		case <-time.After(le.Config.ReelectionPeriod.Duration):
-			isLeader, err := le.CheckLeadershipStatus(ctx, le.EtcdConnectionConfig, le.Config.EtcdConnectionTimeout.Duration, le.logger)
+			isLeader, isLearner, err := le.CheckMemberStatus(ctx, le.EtcdConnectionConfig, le.Config.EtcdConnectionTimeout.Duration, le.logger)
 			if err != nil {
 				le.logger.Errorf("failed to elect the backup-restore leader: %v", err)
 
@@ -143,20 +145,28 @@ func (le *LeaderElector) Run(ctx context.Context) error {
 				le.logger.Infof("backup-restore changed the state from %v to %v", StateUnknown, le.CurrentState)
 			} else if !isLeader && le.CurrentState == StateFollower {
 				le.logger.Debugf("backup-restore currentState: %v", le.CurrentState)
+
+				// If learner(non-voting member) is present in a cluster(size>1)
+				// then promote the learner to voting member.
+				if isLearner && le.PromoteCallback != nil {
+					le.logger.Info("found a learner(non-voting) member in a cluster...")
+					le.PromoteCallback.Promote(ctx, le.logger)
+				}
 			}
 		}
 	}
 }
 
 // IsLeader checks whether the current instance of backup-restore is leader or not.
-func IsLeader(ctx context.Context, etcdConnectionConfig *brtypes.EtcdConnectionConfig, etcdConnectionTimeout time.Duration, logger *logrus.Entry) (bool, error) {
+// It also returns the boolean indicating the presence of learner(non-voting) member.
+func IsLeader(ctx context.Context, etcdConnectionConfig *brtypes.EtcdConnectionConfig, etcdConnectionTimeout time.Duration, logger *logrus.Entry) (bool, bool, error) {
 	logger.Debug("checking the leadershipStatus...")
 	var endPoint string
 
 	factory := etcdutil.NewFactory(*etcdConnectionConfig)
 	client, err := factory.NewMaintenance()
 	if err != nil {
-		return false, &errors.EtcdError{
+		return false, false, &errors.EtcdError{
 			Message: fmt.Sprintf("failed to create etcd maintenance client: %v", err),
 		}
 	}
@@ -165,7 +175,7 @@ func IsLeader(ctx context.Context, etcdConnectionConfig *brtypes.EtcdConnectionC
 	if len(etcdConnectionConfig.Endpoints) > 0 {
 		endPoint = etcdConnectionConfig.Endpoints[0]
 	} else {
-		return false, fmt.Errorf("etcd endpoints are not passed correctly")
+		return false, false, fmt.Errorf("etcd endpoints are not passed correctly")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, etcdConnectionTimeout)
@@ -174,15 +184,18 @@ func IsLeader(ctx context.Context, etcdConnectionConfig *brtypes.EtcdConnectionC
 	response, err := client.Status(ctx, endPoint)
 	if err != nil {
 		logger.Errorf("failed to get status of etcd endPoint: %v with error: %v", endPoint, err)
-		return false, err
+		return false, false, err
 	}
 
 	if response.Header.MemberId == response.Leader {
-		return true, nil
+		return true, false, nil
 	} else if response.Leader == NoLeaderState {
-		return false, &errors.EtcdError{
+		return false, false, &errors.EtcdError{
 			Message: fmt.Sprintf("currently there is no etcd leader present may be due to etcd quorum loss or election is being held"),
 		}
+	} else if response.IsLearner {
+		return false, true, nil
 	}
-	return false, nil
+
+	return false, false, nil
 }

--- a/pkg/leaderelection/leaderelection_test.go
+++ b/pkg/leaderelection/leaderelection_test.go
@@ -181,7 +181,7 @@ var _ = Describe("Etcd Cluster", func() {
 			})
 		})
 
-		Context("Etcd member is leaner", func() {
+		Context("Etcd member is learner", func() {
 			It("Should promote the learner(non-voting) member to a voting member", func() {
 				minCount := 1
 

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -246,7 +246,7 @@ func (m *memberControl) PromoteMember(ctx context.Context) error {
 		return ErrMissingMember
 	}
 
-	return miscellaneous.DoPromoteMember(ctx, foundMember, cli, m.logger.Logger)
+	return miscellaneous.DoPromoteMember(ctx, foundMember, cli, &m.logger)
 }
 
 func findMember(existingMembers []*etcdserverpb.Member, memberName string) *etcdserverpb.Member {

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -282,10 +282,10 @@ func (m *memberControl) RemoveMember(ctx context.Context) error {
 	}
 	defer cli.Close()
 
-	ctx, cancel := context.WithTimeout(ctx, brtypes.DefaultEtcdConnectionTimeout)
-	defer cancel()
+	memRemoveCtx, memRemoveCtxCancel := context.WithTimeout(ctx, brtypes.DefaultEtcdConnectionTimeout)
+	defer memRemoveCtxCancel()
 
-	memberInfo, err := cli.MemberList(ctx)
+	memberInfo, err := cli.MemberList(memRemoveCtx)
 	if err != nil {
 		return fmt.Errorf("error listing members: %v", err)
 	}
@@ -295,7 +295,7 @@ func (m *memberControl) RemoveMember(ctx context.Context) error {
 		return nil
 	}
 
-	return miscellaneous.RemoveMemberFromCluster(ctx, cli, foundMember.GetID(), &m.logger)
+	return miscellaneous.RemoveMemberFromCluster(memRemoveCtx, cli, foundMember.GetID(), &m.logger)
 }
 
 // IsLearnerPresent checks for the learner(non-voting) member in a cluster.
@@ -308,8 +308,8 @@ func (m *memberControl) IsLearnerPresent(ctx context.Context) (bool, error) {
 	}
 	defer cli.Close()
 
-	ctx, cancel := context.WithTimeout(ctx, brtypes.DefaultEtcdConnectionTimeout)
-	defer cancel()
+	learnerCtx, learnerCtxCancel := context.WithTimeout(ctx, brtypes.DefaultEtcdConnectionTimeout)
+	defer learnerCtxCancel()
 
-	return miscellaneous.CheckIfLearnerPresent(ctx, cli)
+	return miscellaneous.CheckIfLearnerPresent(learnerCtx, cli)
 }

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -274,7 +274,7 @@ func (m *memberControl) UpdateMember(ctx context.Context, cli client.ClusterClos
 
 // RemoveMember removes the member from the etcd cluster.
 func (m *memberControl) RemoveMember(ctx context.Context) error {
-	m.logger.Infof("Removing the %v member from cluster", m.podName)
+	m.logger.Infof("Removing the %s member from cluster", m.podName)
 
 	cli, err := m.clientFactory.NewCluster()
 	if err != nil {

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -300,7 +300,7 @@ func (m *memberControl) RemoveMember(ctx context.Context) error {
 
 // IsLearnerPresent checks for the learner(non-voting) member in a cluster.
 func (m *memberControl) IsLearnerPresent(ctx context.Context) (bool, error) {
-	m.logger.Infof("Removing the %v member from cluster", m.podName)
+	m.logger.Infof("checking the presence of a learner in a cluster...")
 
 	cli, err := m.clientFactory.NewCluster()
 	if err != nil {
@@ -311,7 +311,7 @@ func (m *memberControl) IsLearnerPresent(ctx context.Context) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, brtypes.DefaultEtcdConnectionTimeout)
 	defer cancel()
 
-	return miscellaneous.CheckLearner(ctx, cli)
+	return miscellaneous.CheckIfLearnerPresent(ctx, cli)
 }
 
 // removeMemberFromCluster removes member of given ID from etcd cluster.

--- a/pkg/member/member_control_test.go
+++ b/pkg/member/member_control_test.go
@@ -2,18 +2,26 @@ package member_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
 	"github.com/gardener/etcd-backup-restore/pkg/member"
+	mockfactory "github.com/gardener/etcd-backup-restore/pkg/mock/etcdutil/client"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/etcdserver/etcdserverpb"
 )
 
 var _ = Describe("Membercontrol", func() {
 	var (
 		etcdConnectionConfig *brtypes.EtcdConnectionConfig
+		ctrl                 *gomock.Controller
+		factory              *mockfactory.MockFactory
+		cl                   *mockfactory.MockClusterCloser
 	)
 
 	BeforeEach(func() {
@@ -24,23 +32,13 @@ var _ = Describe("Membercontrol", func() {
 		etcdConnectionConfig.DefragTimeout.Duration = 30 * time.Second
 
 		os.Setenv("POD_NAME", "test-pod")
-	})
 
-	AfterEach(func() {
-		os.Unsetenv("POD_NAME")
-	})
+		ctrl = gomock.NewController(GinkgoT())
+		factory = mockfactory.NewMockFactory(ctrl)
+		cl = mockfactory.NewMockClusterCloser(ctrl)
 
-	Describe("Creating NewMemberControl", func() {
-		It("should not return error with valid configuration", func() {
-			ctrlMember := member.NewMemberControl(etcdConnectionConfig)
-			Expect(ctrlMember).ShouldNot(BeNil())
-		})
-	})
-
-	Describe("While attempting to add a new member as a learner", func() {
-		BeforeEach(func() {
-			outfile := "/tmp/etcd.conf.yaml"
-			etcdConfigYaml := `# Human-readable name for this member.
+		outfile := "/tmp/etcd.conf.yaml"
+		etcdConfigYaml := `# Human-readable name for this member.
     name: etcd1
     data-dir: ` + os.Getenv("ETCD_DATA_DIR") + `
     metrics: extensive
@@ -56,18 +54,35 @@ var _ = Describe("Membercontrol", func() {
     auto-compaction-mode: periodic
     auto-compaction-retention: 30m`
 
-			err := os.WriteFile(outfile, []byte(etcdConfigYaml), 0755)
-			Expect(err).ShouldNot(HaveOccurred())
-			os.Setenv("ETCD_CONF", outfile)
+		err := os.WriteFile(outfile, []byte(etcdConfigYaml), 0755)
+		Expect(err).ShouldNot(HaveOccurred())
+		os.Setenv("ETCD_CONF", outfile)
+
+	})
+
+	AfterEach(func() {
+		os.Unsetenv("POD_NAME")
+		os.Unsetenv("ETCD_CONF")
+	})
+
+	Describe("Creating NewMemberControl", func() {
+		Context("With valid configuration", func() {
+			It("should return memberControl", func() {
+				ctrlMember := member.NewMemberControl(etcdConnectionConfig)
+				Expect(ctrlMember).ShouldNot(BeNil())
+			})
 		})
-		AfterEach(func() {
-			os.Unsetenv("ETCD_CONF")
-		})
+	})
+
+	Describe("While attempting to add a new member as a learner", func() {
 		Context("Member is not already part of the cluster", func() {
 			It("Should add member to the cluster as a learner", func() {
 				mem := member.NewMemberControl(etcdConnectionConfig)
 				err := mem.AddMemberAsLearner(context.TODO())
 				Expect(err).To(BeNil())
+				present, err := mem.IsLearnerPresent(context.TODO())
+				Expect(err).To(BeNil())
+				Expect(present).To(BeTrue())
 			})
 		})
 	})
@@ -79,6 +94,75 @@ var _ = Describe("Membercontrol", func() {
 				bool, err := mem.IsMemberInCluster(context.TODO())
 				Expect(bool).To(BeFalse())
 				Expect(err).To(BeNil())
+			})
+		})
+	})
+
+	Describe("Update Etcd cluster member peer address", func() {
+		var (
+			dummyID = uint64(1111)
+			m       member.Control
+		)
+		BeforeEach(func() {
+			factory.EXPECT().NewCluster().Return(cl, nil)
+			m = member.NewMemberControl(etcdConnectionConfig)
+		})
+
+		Context("Able to connect to etcd member", func() {
+			It("Should not return error", func() {
+				client, err := factory.NewCluster()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				cl.EXPECT().MemberList(gomock.Any()).DoAndReturn(func(_ context.Context) (*clientv3.MemberListResponse, error) {
+					etcdMember1 := &etcdserverpb.Member{
+						ID: dummyID,
+					}
+					etcdMember2 := &etcdserverpb.Member{
+						ID: dummyID + 1,
+					}
+					response := new(clientv3.MemberListResponse)
+
+					response.Members = append(response.Members, etcdMember1, etcdMember2)
+					response.Members = []*etcdserverpb.Member{etcdMember1, etcdMember2}
+					response.Header = &etcdserverpb.ResponseHeader{
+						MemberId: dummyID,
+					}
+					return response, nil
+				})
+
+				cl.EXPECT().MemberUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+
+				err = m.UpdateMember(context.TODO(), client)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+
+		Context("Unable to connect to etcd member for MemberUpdate api call", func() {
+			It("Should return error", func() {
+				client, err := factory.NewCluster()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				cl.EXPECT().MemberList(gomock.Any()).DoAndReturn(func(_ context.Context) (*clientv3.MemberListResponse, error) {
+					etcdMember1 := &etcdserverpb.Member{
+						ID: dummyID,
+					}
+					etcdMember2 := &etcdserverpb.Member{
+						ID: dummyID + 1,
+					}
+					response := new(clientv3.MemberListResponse)
+
+					response.Members = append(response.Members, etcdMember1, etcdMember2)
+					response.Members = []*etcdserverpb.Member{etcdMember1, etcdMember2}
+					response.Header = &etcdserverpb.ResponseHeader{
+						MemberId: dummyID,
+					}
+					return response, nil
+				})
+
+				cl.EXPECT().MemberUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("unable to connect to dummy etcd"))
+
+				err = m.UpdateMember(context.TODO(), client)
+				Expect(err).Should(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -500,3 +500,14 @@ func CheckIfLearnerPresent(ctx context.Context, cli etcdClient.ClusterCloser) (b
 	}
 	return false, nil
 }
+
+// RemoveMemberFromCluster removes member of given ID from etcd cluster.
+func RemoveMemberFromCluster(ctx context.Context, cli etcdClient.ClusterCloser, memberID uint64, logger *logrus.Entry) error {
+	_, err := cli.MemberRemove(ctx, memberID)
+	if err != nil {
+		return fmt.Errorf("unable to remove member [ID:%v] from the cluster: %v", strconv.FormatUint(memberID, 16), err)
+	}
+
+	logger.Infof("successfully removed member [ID: %v] from the cluster", strconv.FormatUint(memberID, 16))
+	return nil
+}

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -446,8 +446,8 @@ func IsBackupBucketEmpty(snapStoreConfig *brtypes.SnapstoreConfig, logger *logru
 	return true
 }
 
-// GetInitialClusterState returns the cluster state, either `new` or `existing`.
-func GetInitialClusterState(ctx context.Context, logger logrus.Entry, clientSet client.Client, podName string, podNS string) string {
+// GetInitialClusterStateIfScaleup checks if it is the Scale-up scenario and returns the cluster state either `new` or `existing`.
+func GetInitialClusterStateIfScaleup(ctx context.Context, logger logrus.Entry, clientSet client.Client, podName string, podNS string) string {
 	//Read sts spec for updated replicas to toggle `initial-cluster-state`
 	curSts := &appsv1.StatefulSet{}
 	errSts := clientSet.Get(ctx, client.ObjectKey{
@@ -486,8 +486,8 @@ func DoPromoteMember(ctx context.Context, member *etcdserverpb.Member, cli etcdC
 	return err
 }
 
-// CheckLearner checks whether a learner(non-voting) member present or not.
-func CheckLearner(ctx context.Context, cli etcdClient.ClusterCloser) (bool, error) {
+// CheckIfLearnerPresent checks whether a learner(non-voting) member present or not.
+func CheckIfLearnerPresent(ctx context.Context, cli etcdClient.ClusterCloser) (bool, error) {
 	membersInfo, err := cli.MemberList(ctx)
 	if err != nil {
 		return false, fmt.Errorf("error listing members: %v", err)

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -468,7 +468,7 @@ func GetInitialClusterStateIfScaleup(ctx context.Context, logger logrus.Entry, c
 }
 
 // DoPromoteMember promotes a given learner to a voting member.
-func DoPromoteMember(ctx context.Context, member *etcdserverpb.Member, cli etcdClient.ClusterCloser, logger *logrus.Logger) error {
+func DoPromoteMember(ctx context.Context, member *etcdserverpb.Member, cli etcdClient.ClusterCloser, logger *logrus.Entry) error {
 	memPromoteCtx, cancel := context.WithTimeout(ctx, brtypes.DefaultEtcdConnectionTimeout)
 	defer cancel()
 

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -464,7 +464,7 @@ func GetInitialClusterState(ctx context.Context, logger logrus.Entry, clientSet 
 		return ClusterStateExisting
 	}
 
-	return ClusterStateNew
+	return ""
 }
 
 // DoPromoteMember promotes a given learner to a voting member.
@@ -484,4 +484,19 @@ func DoPromoteMember(ctx context.Context, member *etcdserverpb.Member, cli etcdC
 		return nil
 	}
 	return err
+}
+
+// CheckLearner checks whether a learner(non-voting) member present or not.
+func CheckLearner(ctx context.Context, cli etcdClient.ClusterCloser) (bool, error) {
+	membersInfo, err := cli.MemberList(ctx)
+	if err != nil {
+		return false, fmt.Errorf("error listing members: %v", err)
+	}
+
+	for _, member := range membersInfo.Members {
+		if member.IsLearner {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -368,7 +368,7 @@ var _ = Describe("Miscellaneous Tests", func() {
 				err := clientSet.Create(testCtx, sts)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				clusterState := GetInitialClusterState(testCtx, *logger, clientSet, podName, namespace)
+				clusterState := GetInitialClusterStateIfScaleup(testCtx, *logger, clientSet, podName, namespace)
 				Expect(clusterState).Should(Equal(emptyString))
 			})
 		})
@@ -395,7 +395,7 @@ var _ = Describe("Miscellaneous Tests", func() {
 				err := clientSet.Create(testCtx, sts)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				clusterState := GetInitialClusterState(testCtx, *logger, clientSet, podName, namespace)
+				clusterState := GetInitialClusterStateIfScaleup(testCtx, *logger, clientSet, podName, namespace)
 				Expect(clusterState).Should(Equal(emptyString))
 			})
 		})
@@ -422,7 +422,7 @@ var _ = Describe("Miscellaneous Tests", func() {
 				err := clientSet.Create(testCtx, sts)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				clusterState := GetInitialClusterState(testCtx, *logger, clientSet, podName, namespace)
+				clusterState := GetInitialClusterStateIfScaleup(testCtx, *logger, clientSet, podName, namespace)
 				Expect(clusterState).Should(Equal(ClusterStateExisting))
 			})
 		})
@@ -452,7 +452,7 @@ var _ = Describe("Miscellaneous Tests", func() {
 				err := clientSet.Create(testCtx, sts)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				clusterState := GetInitialClusterState(testCtx, *logger, clientSet, podName, wrongNamespace)
+				clusterState := GetInitialClusterStateIfScaleup(testCtx, *logger, clientSet, podName, wrongNamespace)
 				Expect(clusterState).Should(Equal(ClusterStateNew))
 			})
 		})

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -430,7 +430,7 @@ var _ = Describe("Miscellaneous Tests", func() {
 		})
 	})
 
-	Describe("Get the Initial ClusterState", func() {
+	Describe("Get the Initial ClusterState for scale-up feature", func() {
 		var (
 			sts             *appsv1.StatefulSet
 			statefulSetName = "etcd-test"
@@ -438,7 +438,7 @@ var _ = Describe("Miscellaneous Tests", func() {
 			namespace       = "test_namespace"
 			emptyString     = ""
 		)
-		Context("In single-node etcd", func() {
+		Context("In single node etcd: no scale-up", func() {
 			It("Should return the cluster state as empty string ", func() {
 				sts = &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
@@ -465,7 +465,7 @@ var _ = Describe("Miscellaneous Tests", func() {
 				Expect(clusterState).Should(Equal(emptyString))
 			})
 		})
-		Context("In multi-node etcd bootstrap", func() {
+		Context("In multi-node etcd bootstrap: no scale-up", func() {
 			It("Should return the cluster state as empty string ", func() {
 				sts = &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -343,9 +343,10 @@ var _ = Describe("Miscellaneous Tests", func() {
 			statefulSetName = "etcd-test"
 			podName         = "etcd-test-0"
 			namespace       = "test_namespace"
+			emptyString     = ""
 		)
 		Context("In single-node etcd", func() {
-			It("Should return the cluster state as `new` ", func() {
+			It("Should return the cluster state as empty string ", func() {
 				sts = &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "StatefulSet",
@@ -368,11 +369,11 @@ var _ = Describe("Miscellaneous Tests", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				clusterState := GetInitialClusterState(testCtx, *logger, clientSet, podName, namespace)
-				Expect(clusterState).Should(Equal(ClusterStateNew))
+				Expect(clusterState).Should(Equal(emptyString))
 			})
 		})
 		Context("In multi-node etcd bootstrap", func() {
-			It("Should return the cluster state as `new` ", func() {
+			It("Should return the cluster state as empty string ", func() {
 				sts = &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "StatefulSet",
@@ -395,7 +396,7 @@ var _ = Describe("Miscellaneous Tests", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				clusterState := GetInitialClusterState(testCtx, *logger, clientSet, podName, namespace)
-				Expect(clusterState).Should(Equal(ClusterStateNew))
+				Expect(clusterState).Should(Equal(emptyString))
 			})
 		})
 		Context("In case of Scaling up from single node to multi-node etcd", func() {

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -367,6 +367,32 @@ var _ = Describe("Miscellaneous Tests", func() {
 			})
 		})
 
+		Context("Remove member from etcd cluster", func() {
+			It("should not return error", func() {
+
+				clientCluster, err := factory.NewCluster()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				cl.EXPECT().MemberRemove(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+				err = RemoveMemberFromCluster(testCtx, clientCluster, dummyID, logger)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+
+		Context("Unable to remove member from etcd cluster", func() {
+			It("should return error", func() {
+
+				clientCluster, err := factory.NewCluster()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				cl.EXPECT().MemberRemove(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("unable to connect dummy etcd"))
+
+				err = RemoveMemberFromCluster(testCtx, clientCluster, dummyID, logger)
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+
 	})
 
 	Describe("BackupLeaderEndpoint", func() {

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -305,7 +305,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 		},
 	}
 
-	checkLeadershipFunc := leaderelection.IsLeader
+	checkLeadershipFunc := leaderelection.EtcdMemberStatus
 
 	b.logger.Infof("Creating leaderElector...")
 	le, err := leaderelection.NewLeaderElector(b.logger, b.config.EtcdConnectionConfig, b.config.LeaderElectionConfig, leaderCallbacks, memberLeaseCallbacks, checkLeadershipFunc, promoteCallback)

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -145,7 +145,7 @@ func (b *BackupRestoreServer) Run(ctx context.Context) error {
 
 // startHTTPServer creates and starts the HTTP handler
 // with status 503 (Service Unavailable)
-func (b *BackupRestoreServer) startHTTPServer(initializer initializer.Initializer, storageProvider string, etcdConfig *brtypes.EtcdConnectionConfig, ssr *snapshotter.Snapshotter) *HTTPHandler {
+func (b *BackupRestoreServer) startHTTPServer(initializer initializer.Initializer, storageProvider string, etcdConfig *brtypes.EtcdConnectionConfig, snapstoreConfig *brtypes.SnapstoreConfig, ssr *snapshotter.Snapshotter) *HTTPHandler {
 	// Start http handler with Error state and wait till snapshotter is up
 	// and running before setting the status to OK.
 	handler := &HTTPHandler{
@@ -163,6 +163,7 @@ func (b *BackupRestoreServer) startHTTPServer(initializer initializer.Initialize
 		HTTPHandlerMutex:     &sync.Mutex{},
 		EtcdConnectionConfig: etcdConfig,
 		StorageProvider:      storageProvider,
+		SnapstoreConfig:      snapstoreConfig,
 	}
 	handler.SetStatus(http.StatusServiceUnavailable)
 	b.logger.Info("Registering the http request handlers...")
@@ -189,7 +190,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 	}
 	etcdInitializer := initializer.NewInitializer(restoreOpts, snapstoreConfig, b.config.EtcdConnectionConfig, b.logger.Logger)
 
-	handler := b.startHTTPServer(etcdInitializer, b.config.SnapstoreConfig.Provider, b.config.EtcdConnectionConfig, nil)
+	handler := b.startHTTPServer(etcdInitializer, b.config.SnapstoreConfig.Provider, b.config.EtcdConnectionConfig, b.config.SnapstoreConfig, nil)
 	defer handler.Stop()
 
 	// Promotes member if it is a learner
@@ -291,10 +292,23 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 		},
 	}
 
+	promoteCallback := &brtypes.PromoteLearnerCallback{
+		Promote: func(ctx context.Context, logger *logrus.Entry) {
+			if restoreOpts.OriginalClusterSize > 1 {
+				m := member.NewMemberControl(b.config.EtcdConnectionConfig)
+				if err := m.PromoteMember(ctx); err == nil {
+					logger.Info("Successfully promoted the learner to a voting member...")
+				} else if err != nil {
+					logger.Errorf("unable to promote the learner to a voting member: %v", err)
+				}
+			}
+		},
+	}
+
 	checkLeadershipFunc := leaderelection.IsLeader
 
 	b.logger.Infof("Creating leaderElector...")
-	le, err := leaderelection.NewLeaderElector(b.logger, b.config.EtcdConnectionConfig, b.config.LeaderElectionConfig, leaderCallbacks, memberLeaseCallbacks, checkLeadershipFunc)
+	le, err := leaderelection.NewLeaderElector(b.logger, b.config.EtcdConnectionConfig, b.config.LeaderElectionConfig, leaderCallbacks, memberLeaseCallbacks, checkLeadershipFunc, promoteCallback)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/httpAPI.go
+++ b/pkg/server/httpAPI.go
@@ -92,6 +92,7 @@ type HTTPHandler struct {
 	ServerTLSCertFile         string
 	ServerTLSKeyFile          string
 	HTTPHandlerMutex          *sync.Mutex
+	SnapstoreConfig           *brtypes.SnapstoreConfig
 }
 
 // healthCheck contains the HealthStatus of backup restore.
@@ -444,9 +445,20 @@ func (h *HTTPHandler) serveConfig(rw http.ResponseWriter, req *http.Request) {
 	domaiName = fmt.Sprintf("%s.%s.%s", svcName, namespace, "svc")
 	config["advertise-client-urls"] = fmt.Sprintf("%s://%s.%s:%s", protocol, podName, domaiName, clientPort)
 
-	config["initial-cluster-state"] = miscellaneous.GetInitialClusterState(req.Context(), *h.Logger, clientSet, podName, podNS)
-
 	config["initial-cluster"] = getInitialCluster(req.Context(), fmt.Sprint(config["initial-cluster"]), *h.EtcdConnectionConfig, protocol, clientPort, *h.Logger, podName)
+
+	clusterSize, err := miscellaneous.GetClusterSize(fmt.Sprint(config["initial-cluster"]))
+	if err != nil {
+		h.Logger.Warnf("Unable to determine the cluster size: %v", err)
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if clusterSize > 1 && h.SnapstoreConfig != nil && !miscellaneous.IsBackupBucketEmpty(h.SnapstoreConfig, h.Logger.Logger) {
+		config["initial-cluster-state"] = "existing"
+	} else {
+		config["initial-cluster-state"] = miscellaneous.GetInitialClusterState(req.Context(), *h.Logger, clientSet, podName, podNS)
+	}
 
 	data, err := yaml.Marshal(&config)
 	if err != nil {

--- a/pkg/server/httpAPI.go
+++ b/pkg/server/httpAPI.go
@@ -483,14 +483,15 @@ func (h *HTTPHandler) GetClusterState(ctx context.Context, clusterSize int, clie
 	}
 
 	// clusterSize > 1
-	state := miscellaneous.GetInitialClusterState(ctx, *h.Logger, clientSet, podName, podNS)
+	state := miscellaneous.GetInitialClusterStateIfScaleup(ctx, *h.Logger, clientSet, podName, podNS)
+
 	if len(state) == 0 {
-		// Not a Scalup scenario.
-		// Either a multi-node bootstarp or a restoration of single member in multi-node.
+		// Not a Scale-up scenario.
+		// Either a multi-node bootstrap or a restoration of single member in multi-node.
 		m := member.NewMemberControl(h.EtcdConnectionConfig)
 
-		// check for a learner presence in a cluster.
-		// if a learner is present then return ClusterStateExisting else ClusterStateNew.
+		// check whether a learner is present in the cluster
+		// if a learner is present then return `ClusterStateExisting` else `ClusterStateNew`.
 		present, _ := m.IsLearnerPresent(ctx)
 		if present {
 			return miscellaneous.ClusterStateExisting

--- a/pkg/server/httpAPI.go
+++ b/pkg/server/httpAPI.go
@@ -492,8 +492,7 @@ func (h *HTTPHandler) GetClusterState(ctx context.Context, clusterSize int, clie
 
 		// check whether a learner is present in the cluster
 		// if a learner is present then return `ClusterStateExisting` else `ClusterStateNew`.
-		present, _ := m.IsLearnerPresent(ctx)
-		if present {
+		if present, err := m.IsLearnerPresent(ctx); present && err == nil {
 			return miscellaneous.ClusterStateExisting
 		}
 		return miscellaneous.ClusterStateNew

--- a/pkg/types/leaderelection.go
+++ b/pkg/types/leaderelection.go
@@ -48,7 +48,12 @@ type MemberLeaseCallbacks struct {
 }
 
 // IsLeaderCallbackFunc is type declaration for callback function to Check LeadershipStatus.
-type IsLeaderCallbackFunc func(context.Context, *EtcdConnectionConfig, time.Duration, *logrus.Entry) (bool, error)
+type IsLeaderCallbackFunc func(context.Context, *EtcdConnectionConfig, time.Duration, *logrus.Entry) (bool, bool, error)
+
+// PromoteLearnerCallback is callback which is triggered when backup-restore wants to promote etcd learner to a voting member.
+type PromoteLearnerCallback struct {
+	Promote func(context.Context, *logrus.Entry)
+}
 
 // Config holds the LeaderElection config.
 type Config struct {

--- a/pkg/types/leaderelection.go
+++ b/pkg/types/leaderelection.go
@@ -47,8 +47,8 @@ type MemberLeaseCallbacks struct {
 	StopLeaseRenewal func()
 }
 
-// IsLeaderCallbackFunc is type declaration for callback function to Check LeadershipStatus.
-type IsLeaderCallbackFunc func(context.Context, *EtcdConnectionConfig, time.Duration, *logrus.Entry) (bool, bool, error)
+// EtcdMemberStatusCallbackFunc is type declaration for callback function to Check Etcd member Status.
+type EtcdMemberStatusCallbackFunc func(context.Context, *EtcdConnectionConfig, time.Duration, *logrus.Entry) (bool, bool, error)
 
 // PromoteLearnerCallback is callback which is triggered when backup-restore wants to promote etcd learner to a voting member.
 type PromoteLearnerCallback struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a feature for restoration of single member in mult-node etcd cluster in case of data/data-dir of etcd member found to be corrupt/invalid.

**Which issue(s) this PR fixes**:
Fixes  https://github.com/gardener/etcd-druid/issues/368

**Special notes for your reviewer**:
Design Doc PR: https://github.com/gardener/etcd-druid/pull/376

**Release note**:
```noteworthy user
For multi-node etcd: Added a feature of single member etcd restoration in case of data/data-dir of etcd member found to be corrupted or invalid.
```
