### PR TITLE
Fix svc endpoint extraction

### DIFF
--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -328,8 +328,9 @@ func GetEtcdSvcEndpoint() (string, error) {
 		return "", fmt.Errorf("total length of tokens is less than four")
 	}
 	protocol := tokens[0]
+	svcName := tokens[1]
 	peerPort := tokens[3]
-	return fmt.Sprintf("%s://%s:%s", protocol, "etcd-main-client", peerPort), nil
+	return fmt.Sprintf("%s://%s:%s", protocol, svcName, peerPort), nil
 }
 
 // ProbeEtcd probes the etcd endpoint to check if an etcd is available


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where the wrong endpoint is used to talk to the etcd cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue has been fixed that caused the `Backup-Restore` component to connect to the wrong etcd cluster for initializing and member-add procedures.
```
