### PR TITLE
Add serviceEndpoint to connect to etcd

### DIFF
--- a/pkg/etcdutil/client/option.go
+++ b/pkg/etcdutil/client/option.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+// Options contains options used by the client.
+type Options struct {
+	UseServiceEndpoints bool
+}
+
+// Option is an interface for changing configuration in client options.
+type Option interface {
+	ApplyTo(*Options)
+}
+
+var _ Option = (*UseServiceEndpoints)(nil)
+
+// UseServiceEndpoints instructs the client to use the service endpoints instead of endpoints.
+type UseServiceEndpoints bool
+
+// ApplyTo applies this configuration to the given options.
+func (u UseServiceEndpoints) ApplyTo(opt *Options) {
+	opt.UseServiceEndpoints = bool(u)
+}

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -69,14 +69,9 @@ func NewMemberControl(etcdConnConfig *brtypes.EtcdConnectionConfig) Control {
 	var configFile string
 	logger := logrus.New().WithField("actor", "member-add")
 	etcdConn := *etcdConnConfig
-	svcEndpoint, err := miscellaneous.GetEtcdSvcEndpoint()
-	if err != nil {
-		logger.Errorf("Error getting etcd service endpoint %v", err)
-	}
-	if svcEndpoint != "" {
-		etcdConn.Endpoints = []string{svcEndpoint}
-	}
-	clientFactory := etcdutil.NewFactory(etcdConn)
+
+	// We want to use the service endpoint since we're only supposed to connect to ready etcd members.
+	clientFactory := etcdutil.NewFactory(etcdConn, client.UseServiceEndpoints(true))
 	podName, err := miscellaneous.GetEnvVarOrError("POD_NAME")
 	if err != nil {
 		logger.Fatalf("Error reading POD_NAME env var : %v", err)

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -304,37 +304,6 @@ func GetEnvVarOrError(varName string) (string, error) {
 	return value, nil
 }
 
-// GetEtcdSvcEndpoint returns the endpoint to the etcd client service
-func GetEtcdSvcEndpoint() (string, error) {
-	inputFileName := GetConfigFilePath()
-	if inputFileName != EtcdConfigFilePath {
-		// Return "" here to indicate to the caller to use the default svc endpoint.
-		// This is used for testing purposes where localhost is to be used as the endpoint
-		return "", nil
-	}
-
-	configYML, err := os.ReadFile(inputFileName)
-	if err != nil {
-		return "", fmt.Errorf("unable to read etcd config file: %v", err)
-	}
-
-	config := map[string]interface{}{}
-	err = yaml.Unmarshal([]byte(configYML), &config)
-	if err := yaml.Unmarshal([]byte(configYML), &config); err != nil {
-		return "", fmt.Errorf("unable to unmarshal etcd config yaml file: %v", err)
-	}
-
-	advClientURL := config["advertise-client-urls"]
-	tokens := strings.Split(fmt.Sprint(advClientURL), "@")
-	if len(tokens) < 4 {
-		return "", fmt.Errorf("total length of tokens is less than four")
-	}
-	protocol := tokens[0]
-	svcName := tokens[1]
-	peerPort := tokens[3]
-	return fmt.Sprintf("%s://%s:%s", protocol, svcName, peerPort), nil
-}
-
 // ProbeEtcd probes the etcd endpoint to check if an etcd is available
 func ProbeEtcd(ctx context.Context, clientFactory etcdClient.Factory, logger *logrus.Entry) error {
 	clientKV, err := clientFactory.NewKV()

--- a/pkg/types/etcdconnection.go
+++ b/pkg/types/etcdconnection.go
@@ -41,6 +41,7 @@ type EtcdConnectionConfig struct {
 	// Endpoints are the endpoints from which the backup will be take or defragmentation will be called.
 	// This need not be necessary match the entire etcd cluster.
 	Endpoints          []string          `json:"endpoints"`
+	ServiceEndpoints   []string          `json:"serviceEndpoints,omitempty"`
 	Username           string            `json:"username,omitempty"`
 	Password           string            `json:"password,omitempty"`
 	ConnectionTimeout  wrappers.Duration `json:"connectionTimeout,omitempty"`
@@ -69,6 +70,7 @@ func NewEtcdConnectionConfig() *EtcdConnectionConfig {
 // AddFlags adds the flags to flagset.
 func (c *EtcdConnectionConfig) AddFlags(fs *flag.FlagSet) {
 	fs.StringSliceVarP(&c.Endpoints, "endpoints", "e", c.Endpoints, "comma separated list of etcd endpoints")
+	fs.StringSliceVar(&c.ServiceEndpoints, "service-endpoints", c.ServiceEndpoints, "comma separated list of etcd endpoints that are used for etcd-backup-restore to connect to etcd through a (Kubernetes) service")
 	fs.StringVar(&c.Username, "etcd-username", c.Username, "etcd server username, if one is required")
 	fs.StringVar(&c.Password, "etcd-password", c.Password, "etcd server password, if one is required")
 	fs.DurationVar(&c.ConnectionTimeout.Duration, "etcd-connection-timeout", c.ConnectionTimeout.Duration, "etcd client connection timeout")

--- a/pkg/types/restorer.go
+++ b/pkg/types/restorer.go
@@ -40,7 +40,7 @@ const (
 )
 
 // NewClientFactoryFunc allows to define how to create a client.Factory
-type NewClientFactoryFunc func(cfg EtcdConnectionConfig) client.Factory
+type NewClientFactoryFunc func(cfg EtcdConnectionConfig, opts ...client.Option) client.Factory
 
 // RestoreOptions hold all snapshot restore related fields
 // Note: Please ensure DeepCopy and DeepCopyInto are properly implemented.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new flag `--service-endpoints` to the `etcdbrctl server` command. These (Kubernetes) service URLs ensure that `etcd-backup-restore` only connects to etcd member which are ready to server traffic. Especially the `MemberAdd` and `Init` steps require this.

**Special notes for your reviewer**:
/cc @aaronfern 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A new flag `--service-endpoints` has been added to the `etcdbrctl server` command. These (Kubernetes) service URLs ensure that `etcd-backup-restore` only connects to etcd member which are ready to server traffic. Especially the `MemberAdd` and `Init` steps require this.
```