### PR TITLE
Remove redef of ssrStopCh

### DIFF
--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -228,7 +228,6 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 
 	leaderCallbacks := &brtypes.LeaderCallbacks{
 		OnStartedLeading: func(leCtx context.Context) {
-			ssrStopCh = make(chan struct{})
 			var err error
 			var defragCallBack defragmentor.CallbackFunc
 			if runServerWithSnapshotter {


### PR DESCRIPTION
**What this PR does / why we need it**: I have found that in some cases where the connection between etcd and etcdbrctl is disrupted it is possible that the snapshotter is not stopped and when the connection is restored a new one is started and there are now two instances of a snapshotter running. Ensuring that we are sending the stop signal to the same `ssrStopCh` that is passed to the snapshotter when it was created. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/etcd-backup-restore/issues/517

**Special notes for your reviewer**: Looking at the logs you can see that snapshotter is first stopped at `2022-08-03T05:22:45Z` then at `2022-08-03T05:22:51Z` etcdbrctl detects the etcd node is the `Leader`, creates another snapshotter at `2022-08-03T05:22:51Z`. Then at `2022-08-03T05:23:05Z` it fails to get the status of etcd because of a `context deadline exceeded` this updates the backup-restore state to `UnknownState` and then on the next interval for the leaderElection check it changes the state back to `Leader`. However at `2022-08-03T05:23:05Z` only the defragmentor is closed nothing else, and at `2022-08-03T05:23:10Z` we create a new snapshotter. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
