### PR TITLE
Upgrade alpine image used to build backup-restore image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 
 RUN make build
 
-FROM alpine:3.15.4
+FROM alpine:3.15.6 
 
 RUN apk add --update bash curl
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR upgrades the alpine image used to build `backup-restore` images

**Which issue(s) this PR fixes**:
Fixes 
[CVE-2022-2068](https://nvd.nist.gov/vuln/detail/CVE-2022-2068)
[CVE-2022-2097](https://nvd.nist.gov/vuln/detail/CVE-2022-2097)
[CVE-2022-37434](https://nvd.nist.gov/vuln/detail/CVE-2022-37434)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Base alpine image upgraded from `3.15.4` to `3.15.6`
```
