### PR TITLE
Handling the boltDB panic in case of database found to be corrupt.

### DIFF
--- a/pkg/initializer/validator/types.go
+++ b/pkg/initializer/validator/types.go
@@ -36,6 +36,8 @@ const (
 	DataDirectoryInvStruct
 	// DataDirectoryCorrupt indicates data directory is corrupt.
 	DataDirectoryCorrupt
+	// BoltDBCorrupt indicates Bolt database is corrupt.
+	BoltDBCorrupt
 	// DataDirectoryStatusUnknown indicates validator failed to check the data directory status.
 	DataDirectoryStatusUnknown
 	// DataDirStatusInvalidInMultiNode indicates validator failed to check the data directory status in multi-node etcd cluster.

--- a/pkg/initializer/validator/validator_suite_test.go
+++ b/pkg/initializer/validator/validator_suite_test.go
@@ -38,12 +38,6 @@ var (
 	etcdRevision int64
 )
 
-// fileInfo holds file information such as file name and file path
-type fileInfo struct {
-	name string
-	path string
-}
-
 func TestValidator(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Validator Suite")


### PR DESCRIPTION
**What this PR does / why we need it**:
BoltDB is not expected a corrupt DB file as it contains the information of pages and other metadata information.
This PR handles the `boltDB panic` in case of database found to be corrupt while opening the database file during the data-dir verification by backup-restore.

**Which issue(s) this PR fixes**:
Fixes #519 

**Special notes for your reviewer**:
/cc @shreyas-s-rao 

**Release note**:
```improvement operator
Handles the bolt database panic in case of database found to be corrupt.
```
