### PR TITLE
Added the new metrics needed to be exposed for multi-node etcd.

### DIFF
--- a/pkg/etcdutil/etcdutil.go
+++ b/pkg/etcdutil/etcdutil.go
@@ -154,12 +154,12 @@ func PerformDefragmentation(defragCtx context.Context, client client.Maintenance
 
 	start := time.Now()
 	if _, err := client.Defragment(defragCtx, endpoint); err != nil {
-		metrics.DefragmentationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
-		logger.Errorf("Failed to defragment etcd member[%s] with error: %v", endpoint, err)
+		metrics.DefragmentationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse, metrics.LabelEndPoint: endpoint}).Observe(time.Since(start).Seconds())
+		logger.Errorf("failed to defragment etcd member[%s] with error: %v", endpoint, err)
 		return err
 	}
 
-	metrics.DefragmentationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Observe(time.Since(start).Seconds())
+	metrics.DefragmentationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededTrue, metrics.LabelEndPoint: endpoint}).Observe(time.Since(start).Seconds())
 	logger.Infof("Finished defragmenting etcd member[%s]", endpoint)
 	// Since below request for status races with other etcd operations. So, size returned in
 	// status might vary from the precise size just after defragmentation.

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -93,10 +93,10 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 		if dataDirStatus == validator.DataDirStatusInvalidInMultiNode || (e.Validator.OriginalClusterSize > 1 && dataDirStatus == validator.DataDirectoryCorrupt) || (e.Validator.OriginalClusterSize > 1 && isEtcdMemberPresent) {
 			start := time.Now()
 			if err := e.restoreInMultiNode(ctx); err != nil {
-				metrics.RestorationDurationSeconds.With(prometheus.Labels{metrics.LabelRestorationKind: metrics.ValueRestoreSingleMemberInMN, metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
+				metrics.RestorationDurationSeconds.With(prometheus.Labels{metrics.LabelRestorationKind: metrics.ValueRestoreSingleMemberInMultiNode, metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
 				return err
 			}
-			metrics.RestorationDurationSeconds.With(prometheus.Labels{metrics.LabelRestorationKind: metrics.ValueRestoreSingleMemberInMN, metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Observe(time.Since(start).Seconds())
+			metrics.RestorationDurationSeconds.With(prometheus.Labels{metrics.LabelRestorationKind: metrics.ValueRestoreSingleMemberInMultiNode, metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Observe(time.Since(start).Seconds())
 		} else {
 			// For case: ClusterSize=1 or when multi-node cluster(ClusterSize>1) is bootstrapped
 			start := time.Now()

--- a/pkg/leaderelection/leaderelection.go
+++ b/pkg/leaderelection/leaderelection.go
@@ -21,7 +21,9 @@ import (
 
 	"github.com/gardener/etcd-backup-restore/pkg/errors"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
+	"github.com/gardener/etcd-backup-restore/pkg/metrics"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
 
@@ -149,6 +151,7 @@ func (le *LeaderElector) Run(ctx context.Context) error {
 				// If learner(non-voting member) is present in a cluster(size>1)
 				// then promote the learner to voting member.
 				if isLearner && le.PromoteCallback != nil {
+					metrics.IsLearner.With(prometheus.Labels{}).Set(1)
 					le.logger.Info("member is a learner(non-voting) member in the cluster...")
 					le.PromoteCallback.Promote(ctx, le.logger)
 				}

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -112,11 +112,13 @@ func (m *memberControl) AddMemberAsLearner(ctx context.Context) error {
 			m.logger.Infof("Member %s already part of etcd cluster", memberURL)
 			return nil
 		}
+		metrics.IsLearnerCountTotal.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Inc()
 		metrics.AddLearnerDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
 		return fmt.Errorf("error while adding member as a learner: %v", err)
 	}
 
-	metrics.HasLearner.With(prometheus.Labels{}).Set(1)
+	metrics.IsLearnerCountTotal.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Inc()
+	metrics.IsLearner.With(prometheus.Labels{}).Set(1)
 	metrics.AddLearnerDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Observe(time.Since(start).Seconds())
 	m.logger.Infof("Added member %v to cluster as a learner", strconv.FormatUint(response.Member.GetID(), 16))
 	return nil

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil/client"
+	"github.com/gardener/etcd-backup-restore/pkg/metrics"
 	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
@@ -103,15 +105,19 @@ func (m *memberControl) AddMemberAsLearner(ctx context.Context) error {
 
 	memAddCtx, cancel := context.WithTimeout(ctx, EtcdTimeout)
 	defer cancel()
+	start := time.Now()
 	response, err := cli.MemberAddAsLearner(memAddCtx, []string{memberURL})
 	if err != nil {
 		if errors.Is(err, rpctypes.Error(rpctypes.ErrGRPCPeerURLExist)) || errors.Is(err, rpctypes.Error(rpctypes.ErrGRPCMemberExist)) {
 			m.logger.Infof("Member %s already part of etcd cluster", memberURL)
 			return nil
 		}
+		metrics.AddLearnerDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
 		return fmt.Errorf("error while adding member as a learner: %v", err)
 	}
 
+	metrics.HasLearner.With(prometheus.Labels{}).Set(1)
+	metrics.AddLearnerDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Observe(time.Since(start).Seconds())
 	m.logger.Infof("Added member %v to cluster as a learner", strconv.FormatUint(response.Member.GetID(), 16))
 	return nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -30,13 +30,22 @@ const (
 	ValueSucceededTrue = "true"
 	// ValueSucceededFalse is value False for metric label failed.
 	ValueSucceededFalse = "false"
+	// ValueRestoreSingleMemberInMN is value for metric of single member restoration in multi-node.
+	ValueRestoreSingleMemberInMN = "single_member"
+	// ValueRestoreSingleNode is value for metric of single node restoration.
+	ValueRestoreSingleNode = "single_node"
 	// LabelKind is a metrics label indicates kind of snapshot associated with metric.
 	LabelKind = "kind"
-	//LabelError is a metric error to indicate error occured
+	// LabelError is a metric error to indicate error occured.
 	LabelError = "error"
+	// LabelRestorationKind metric label indicates kind of restoration associated with metric.
+	LabelRestorationKind = "restore"
+	// LabelEndPoint is metric label for metric of etcd cluster endpoint.
+	LabelEndPoint = "endpoint"
 
 	namespaceEtcdBR      = "etcdbr"
 	subsystemSnapshot    = "snapshot"
+	subsystemRestore     = "restoration"
 	subsystemSnapstore   = "snapstore"
 	subsystemSnapshotter = "snapshotter"
 )
@@ -52,6 +61,11 @@ var (
 			ValueSucceededFalse,
 			ValueSucceededTrue,
 		},
+		LabelRestorationKind: {
+			ValueRestoreSingleMemberInMN,
+			ValueRestoreSingleNode,
+		},
+		LabelEndPoint: {""},
 	}
 
 	// GCSnapshotCounter is metric to count the garbage collected snapshots.
@@ -118,23 +132,26 @@ var (
 		},
 		[]string{LabelSucceeded},
 	)
-	// RestorationDurationSeconds is metric to expose the duration required to restore the data directory from snapshots in seconds.
+
+	// RestorationDurationSeconds is metric to expose the duration required to restore the etcd member.
 	RestorationDurationSeconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: namespaceEtcdBR,
-			Name:      "restoration_duration_seconds",
-			Help:      "Total latency distribution of restoring from snapshot.",
+			Subsystem: subsystemRestore,
+			Name:      "duration_seconds",
+			Help:      "Total latency distribution required to restore the etcd member.",
 		},
-		[]string{LabelSucceeded},
+		[]string{LabelRestorationKind, LabelSucceeded},
 	)
-	// DefragmentationDurationSeconds is metric to expose duration required to defragment snapshot.
+
+	// DefragmentationDurationSeconds is metric to expose duration required to defragment all the members of etcd cluster.
 	DefragmentationDurationSeconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: namespaceEtcdBR,
 			Name:      "defragmentation_duration_seconds",
-			Help:      "Total latency distribution of defragmentation of etcd.",
+			Help:      "Total latency distribution of defragmentation of each etcd cluster member.",
 		},
-		[]string{LabelSucceeded},
+		[]string{LabelSucceeded, LabelEndPoint},
 	)
 
 	// SnapstoreLatestDeltasTotal is metric to expose total number of delta snapshots taken since the latest full snapshot.
@@ -167,6 +184,66 @@ var (
 			Help:      "Total number of snapshotter errors.",
 		},
 		[]string{LabelError},
+	)
+
+	// CurrentClusterSize is metric to expose the current Etcd cluster size.
+	CurrentClusterSize = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespaceEtcdBR,
+			Name:      "cluster_size",
+			Help:      "Current Etcd cluster size.",
+		},
+		[]string{},
+	)
+
+	// IsLearner is metric to expose whether or not this member is a learner.
+	IsLearner = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespaceEtcdBR,
+			Name:      "is_learner",
+			Help:      "Whether or not this member is a learner. 1 if is, 0 otherwise",
+		},
+		[]string{},
+	)
+
+	// HasLearner is metric to expose whether or not this cluster has a learner.
+	HasLearner = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespaceEtcdBR,
+			Name:      "has_learner",
+			Help:      "Whether or not this cluster has a learner. 1 if is, 0 otherwise",
+		},
+		[]string{},
+	)
+
+	// AddLearnerDurationSeconds is metric to expose duration required to add member as a learner.
+	AddLearnerDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespaceEtcdBR,
+			Name:      "add_learner_duration_seconds",
+			Help:      "Total latency to add the etcd member as a learner to the cluster.",
+		},
+		[]string{LabelSucceeded},
+	)
+
+	// MemberRemoveDurationSeconds is metric to expose duration required to remove a member from the cluster.
+	MemberRemoveDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespaceEtcdBR,
+			Name:      "member_remove_duration_seconds",
+			Help:      "Total latency to remove the etcd member from the cluster.",
+		},
+		[]string{LabelSucceeded},
+	)
+
+	// MemberPromoteDurationSeconds is metric to expose duration required to promote the learner to the voting member.
+	MemberPromoteDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespaceEtcdBR,
+			Name:      "member_promote_duration_seconds",
+			Help:      "Total latency to promote the learner to the voting member.",
+		},
+		[]string{LabelSucceeded},
 	)
 )
 
@@ -312,7 +389,8 @@ func init() {
 
 	// RestorationDurationSeconds
 	restorationDurationSecondsLabelValues := map[string][]string{
-		LabelSucceeded: labels[LabelSucceeded],
+		LabelSucceeded:       labels[LabelSucceeded],
+		LabelRestorationKind: labels[LabelRestorationKind],
 	}
 	restorationDurationSecondsCombinations := generateLabelCombinations(restorationDurationSecondsLabelValues)
 	for _, combination := range restorationDurationSecondsCombinations {
@@ -322,10 +400,38 @@ func init() {
 	// DefragmentationDurationSeconds
 	defragmentationDurationSecondsLabelValues := map[string][]string{
 		LabelSucceeded: labels[LabelSucceeded],
+		LabelEndPoint:  labels[LabelEndPoint],
 	}
 	defragmentationDurationSecondsCombinations := generateLabelCombinations(defragmentationDurationSecondsLabelValues)
 	for _, combination := range defragmentationDurationSecondsCombinations {
 		DefragmentationDurationSeconds.With(prometheus.Labels(combination))
+	}
+
+	// MemberRemoveDurationSeconds
+	MemberRemoveDurationSecondsLabelValues := map[string][]string{
+		LabelSucceeded: labels[LabelSucceeded],
+	}
+	MemberRemoveDurationSecondsCombinations := generateLabelCombinations(MemberRemoveDurationSecondsLabelValues)
+	for _, combination := range MemberRemoveDurationSecondsCombinations {
+		MemberRemoveDurationSeconds.With(prometheus.Labels(combination))
+	}
+
+	// AddLearnerDurationSeconds
+	AddLearnerDurationSecondsLabelValues := map[string][]string{
+		LabelSucceeded: labels[LabelSucceeded],
+	}
+	AddLearnerDurationSecondsCombinations := generateLabelCombinations(AddLearnerDurationSecondsLabelValues)
+	for _, combination := range AddLearnerDurationSecondsCombinations {
+		AddLearnerDurationSeconds.With(prometheus.Labels(combination))
+	}
+
+	// MemberPromoteDurationSeconds
+	MemberPromoteDurationSecondsLabelValues := map[string][]string{
+		LabelSucceeded: labels[LabelSucceeded],
+	}
+	MemberPromoteDurationSecondsCombinations := generateLabelCombinations(MemberPromoteDurationSecondsLabelValues)
+	for _, combination := range MemberPromoteDurationSecondsCombinations {
+		MemberPromoteDurationSeconds.With(prometheus.Labels(combination))
 	}
 
 	// SnapstoreLatestDeltasTotal
@@ -336,6 +442,15 @@ func init() {
 
 	//SnapshotterOperationFailure
 	SnapshotterOperationFailure.With(prometheus.Labels(map[string]string{LabelError: ""}))
+
+	//CurrentClusterSize
+	CurrentClusterSize.With(prometheus.Labels(map[string]string{}))
+
+	// IsLearner
+	IsLearner.With(prometheus.Labels(map[string]string{}))
+
+	// HasLearner
+	HasLearner.With(prometheus.Labels(map[string]string{}))
 
 	// Metrics have to be registered to be exposed:
 	prometheus.MustRegister(GCSnapshotCounter)
@@ -353,4 +468,11 @@ func init() {
 	prometheus.MustRegister(SnapstoreLatestDeltasRevisionsTotal)
 
 	prometheus.MustRegister(SnapshotterOperationFailure)
+
+	prometheus.MustRegister(CurrentClusterSize)
+	prometheus.MustRegister(IsLearner)
+	prometheus.MustRegister(HasLearner)
+	prometheus.MustRegister(MemberRemoveDurationSeconds)
+	prometheus.MustRegister(AddLearnerDurationSeconds)
+	prometheus.MustRegister(MemberPromoteDurationSeconds)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -30,8 +30,8 @@ const (
 	ValueSucceededTrue = "true"
 	// ValueSucceededFalse is value False for metric label failed.
 	ValueSucceededFalse = "false"
-	// ValueRestoreSingleMemberInMN is value for metric of single member restoration in multi-node.
-	ValueRestoreSingleMemberInMN = "single_member"
+	// ValueRestoreSingleMemberInMultiNode is value for metric of single member restoration in multi-node.
+	ValueRestoreSingleMemberInMultiNode = "single_member"
 	// ValueRestoreSingleNode is value for metric of single node restoration.
 	ValueRestoreSingleNode = "single_node"
 	// LabelKind is a metrics label indicates kind of snapshot associated with metric.
@@ -62,7 +62,7 @@ var (
 			ValueSucceededTrue,
 		},
 		LabelRestorationKind: {
-			ValueRestoreSingleMemberInMN,
+			ValueRestoreSingleMemberInMultiNode,
 			ValueRestoreSingleNode,
 		},
 		LabelEndPoint: {""},
@@ -206,14 +206,14 @@ var (
 		[]string{},
 	)
 
-	// HasLearner is metric to expose whether or not this cluster has a learner.
-	HasLearner = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
+	// IsLearnerCountTotal is metric to expose the total count when etcd member added as a learner.
+	IsLearnerCountTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
 			Namespace: namespaceEtcdBR,
-			Name:      "has_learner",
-			Help:      "Whether or not this cluster has a learner. 1 if is, 0 otherwise",
+			Name:      "is_learner_count_total",
+			Help:      "Total count when etcd member added as a learner.",
 		},
-		[]string{},
+		[]string{LabelSucceeded},
 	)
 
 	// AddLearnerDurationSeconds is metric to expose duration required to add member as a learner.
@@ -434,6 +434,15 @@ func init() {
 		MemberPromoteDurationSeconds.With(prometheus.Labels(combination))
 	}
 
+	// IsLearnerCountTotal
+	IsLearnerCounterLabelValues := map[string][]string{
+		LabelSucceeded: labels[LabelSucceeded],
+	}
+	IsLearnerCounterCombinations := generateLabelCombinations(IsLearnerCounterLabelValues)
+	for _, combination := range IsLearnerCounterCombinations {
+		IsLearnerCountTotal.With(prometheus.Labels(combination))
+	}
+
 	// SnapstoreLatestDeltasTotal
 	SnapstoreLatestDeltasTotal.With(prometheus.Labels(map[string]string{}))
 
@@ -448,9 +457,6 @@ func init() {
 
 	// IsLearner
 	IsLearner.With(prometheus.Labels(map[string]string{}))
-
-	// HasLearner
-	HasLearner.With(prometheus.Labels(map[string]string{}))
 
 	// Metrics have to be registered to be exposed:
 	prometheus.MustRegister(GCSnapshotCounter)
@@ -471,7 +477,7 @@ func init() {
 
 	prometheus.MustRegister(CurrentClusterSize)
 	prometheus.MustRegister(IsLearner)
-	prometheus.MustRegister(HasLearner)
+	prometheus.MustRegister(IsLearnerCountTotal)
 	prometheus.MustRegister(MemberRemoveDurationSeconds)
 	prometheus.MustRegister(AddLearnerDurationSeconds)
 	prometheus.MustRegister(MemberPromoteDurationSeconds)

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -442,10 +442,13 @@ func DoPromoteMember(ctx context.Context, member *etcdserverpb.Member, cli etcdC
 	memPromoteCtx, cancel := context.WithTimeout(ctx, brtypes.DefaultEtcdConnectionTimeout)
 	defer cancel()
 
+	start := time.Now()
 	//Member promote call will succeed only if member is in sync with leader, and will error out otherwise
 	_, err := cli.MemberPromote(memPromoteCtx, member.ID)
 	if err == nil {
 		//Member successfully promoted
+		metrics.HasLearner.With(prometheus.Labels{}).Set(0)
+		metrics.MemberPromoteDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Observe(time.Since(start).Seconds())
 		logger.Infof("Member %v with [ID: %v] has been promoted", member.GetName(), strconv.FormatUint(member.GetID(), 16))
 		return nil
 	} else if errored.Is(err, rpctypes.Error(rpctypes.ErrGRPCMemberNotLearner)) {
@@ -453,6 +456,8 @@ func DoPromoteMember(ctx context.Context, member *etcdserverpb.Member, cli etcdC
 		logger.Info("Member ", member.Name, " : ", member.ID, " already a voting member of cluster.")
 		return nil
 	}
+
+	metrics.MemberPromoteDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
 	return err
 }
 
@@ -465,6 +470,7 @@ func CheckIfLearnerPresent(ctx context.Context, cli etcdClient.ClusterCloser) (b
 
 	for _, member := range membersInfo.Members {
 		if member.IsLearner {
+			metrics.HasLearner.With(prometheus.Labels{}).Set(1)
 			return true, nil
 		}
 	}
@@ -473,11 +479,14 @@ func CheckIfLearnerPresent(ctx context.Context, cli etcdClient.ClusterCloser) (b
 
 // RemoveMemberFromCluster removes member of given ID from etcd cluster.
 func RemoveMemberFromCluster(ctx context.Context, cli etcdClient.ClusterCloser, memberID uint64, logger *logrus.Entry) error {
+	start := time.Now()
 	_, err := cli.MemberRemove(ctx, memberID)
 	if err != nil {
+		metrics.MemberRemoveDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())
 		return fmt.Errorf("unable to remove member [ID:%v] from the cluster: %v", strconv.FormatUint(memberID, 16), err)
 	}
 
+	metrics.MemberRemoveDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Observe(time.Since(start).Seconds())
 	logger.Infof("successfully removed member [ID: %v] from the cluster", strconv.FormatUint(memberID, 16))
 	return nil
 }

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -447,6 +447,7 @@ func DoPromoteMember(ctx context.Context, member *etcdserverpb.Member, cli etcdC
 	_, err := cli.MemberPromote(memPromoteCtx, member.ID)
 	if err == nil {
 		//Member successfully promoted
+		metrics.IsLearner.With(prometheus.Labels{}).Set(0)
 		metrics.MemberPromoteDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Observe(time.Since(start).Seconds())
 		logger.Infof("Member %v with [ID: %v] has been promoted", member.GetName(), strconv.FormatUint(member.GetID(), 16))
 		return nil

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -447,7 +447,6 @@ func DoPromoteMember(ctx context.Context, member *etcdserverpb.Member, cli etcdC
 	_, err := cli.MemberPromote(memPromoteCtx, member.ID)
 	if err == nil {
 		//Member successfully promoted
-		metrics.HasLearner.With(prometheus.Labels{}).Set(0)
 		metrics.MemberPromoteDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Observe(time.Since(start).Seconds())
 		logger.Infof("Member %v with [ID: %v] has been promoted", member.GetName(), strconv.FormatUint(member.GetID(), 16))
 		return nil
@@ -470,7 +469,6 @@ func CheckIfLearnerPresent(ctx context.Context, cli etcdClient.ClusterCloser) (b
 
 	for _, member := range membersInfo.Members {
 		if member.IsLearner {
-			metrics.HasLearner.With(prometheus.Labels{}).Set(1)
 			return true, nil
 		}
 	}

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -193,6 +193,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 	handler := b.startHTTPServer(etcdInitializer, b.config.SnapstoreConfig.Provider, b.config.EtcdConnectionConfig, b.config.SnapstoreConfig, nil)
 	defer handler.Stop()
 
+	metrics.CurrentClusterSize.With(prometheus.Labels{}).Set(float64(restoreOpts.OriginalClusterSize))
 	// Promotes member if it is a learner
 	if restoreOpts.OriginalClusterSize > 1 {
 		for {
@@ -297,6 +298,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 			if restoreOpts.OriginalClusterSize > 1 {
 				m := member.NewMemberControl(b.config.EtcdConnectionConfig)
 				if err := m.PromoteMember(ctx); err == nil {
+					metrics.IsLearner.With(prometheus.Labels{}).Set(0)
 					logger.Info("Successfully promoted the learner to a voting member...")
 				} else if err != nil {
 					logger.Errorf("unable to promote the learner to a voting member: %v", err)

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -298,7 +298,6 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 			if restoreOpts.OriginalClusterSize > 1 {
 				m := member.NewMemberControl(b.config.EtcdConnectionConfig)
 				if err := m.PromoteMember(ctx); err == nil {
-					metrics.IsLearner.With(prometheus.Labels{}).Set(0)
 					logger.Info("Successfully promoted the learner to a voting member...")
 				} else if err != nil {
 					logger.Errorf("unable to promote the learner to a voting member: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds new metrics which required to be exposed via backup-restore to get more information about multi-node etcd which will be helpful in debugging/fine-tuning the multi-node etcd.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/gardener/etcd-druid/issues/358

**Special notes for your reviewer**:
Please see https://github.com/gardener/etcd-druid/pull/414

**Release note**:
```improvement operator
Added new metrics for multi-node etcd: `etcdbr_defragmentation_duration_seconds`, `etcdbr_restoration_duration_seconds` , `etcdbr_cluster_size` , `etcdbr_is_learner `, `etcdbr_is_learner_count_total `, `etcdbr_add_learner_duration_seconds `, `etcdbr_member_remove_duration_seconds `, `etcdbr_member_promote_duration_seconds `.
```
