### PR TITLE
Fix the ProbeEtcd timeout.

### DIFF
--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -220,7 +220,7 @@ func (ssr *Snapshotter) TriggerDeltaSnapshot() (*brtypes.Snapshot, error) {
 		return nil, fmt.Errorf("snapshotter is not active")
 	}
 	if ssr.config.DeltaSnapshotPeriod.Duration < brtypes.DeltaSnapshotIntervalThreshold {
-		return nil, fmt.Errorf("Found delta snapshot interval %s less than %v. Delta snapshotting is disabled. ", ssr.config.DeltaSnapshotPeriod.Duration, time.Duration(brtypes.DeltaSnapshotIntervalThreshold))
+		return nil, fmt.Errorf("found delta snapshot interval %s less than %v. Delta snapshotting is disabled. ", ssr.config.DeltaSnapshotPeriod.Duration, time.Duration(brtypes.DeltaSnapshotIntervalThreshold))
 	}
 	ssr.logger.Info("Triggering out of schedule delta snapshot...")
 	ssr.deltaSnapshotReqCh <- emptyStruct
@@ -231,6 +231,7 @@ func (ssr *Snapshotter) TriggerDeltaSnapshot() (*brtypes.Snapshot, error) {
 // stop stops the snapshotter. Once stopped any subsequent calls will
 // not have any effect.
 func (ssr *Snapshotter) stop() {
+	ssr.logger.Info("Closing the Snapshotter...")
 	ssr.SsrStateMutex.Lock()
 	if ssr.fullSnapshotTimer != nil {
 		ssr.fullSnapshotTimer.Stop()

--- a/pkg/types/leaderelection.go
+++ b/pkg/types/leaderelection.go
@@ -27,8 +27,8 @@ import (
 const (
 	// DefaultReelectionPeriod defines default time period for Reelection.
 	DefaultReelectionPeriod = 5 * time.Second
-	// DefaultEtcdConnecTimeout defines default ConnectionTimeout for etcd client.
-	DefaultEtcdConnecTimeout = 5 * time.Second
+	// DefaultEtcdStatusConnecTimeout defines default ConnectionTimeout for etcd client to get Etcd endpoint status.
+	DefaultEtcdStatusConnecTimeout = 5 * time.Second
 )
 
 // LeaderCallbacks are callbacks that are triggered to start/stop the snapshottter when leader's currentState changes.
@@ -67,7 +67,7 @@ type Config struct {
 func NewLeaderElectionConfig() *Config {
 	return &Config{
 		ReelectionPeriod:      wrappers.Duration{Duration: DefaultReelectionPeriod},
-		EtcdConnectionTimeout: wrappers.Duration{Duration: DefaultEtcdConnecTimeout},
+		EtcdConnectionTimeout: wrappers.Duration{Duration: DefaultEtcdStatusConnecTimeout},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We have observed that currently `ProbeEtcd` is using the longer timeout which is set using this flag `--etcd-connection-timeout` and in our landscapes `--etcd-connection-timeout` is set to `5mins`.  (check [here](https://github.com/gardener/etcd-druid/blob/master/pkg/component/etcd/statefulset/values_helper.go#L247))
Due to this longer Timeout `ProbeEtcd` is keep waiting instead of failing the probe and meanwhile when `ProbeEtcd` is waiting if corresponding etcd comes-up then `ProbeEtcd` get succeeds this might leads to some race-conditions between the go-routines as `ProbeEtcd` is suppose to fail.
This PR fixes this issue by using the shorter Timeout of `5sec` in `ProbeEtcd`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @timuthy 

**Release note**:
```bugfix operator
To avoid potential race-condition between go-routines updated `probeEtcd func()` to use shorter timeout.
```
