### PR TITLE
Cherry pick commits for branch rel-v0.20

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -42,13 +42,13 @@ etcd-backup-restore:
                 build: ~
     steps:
       check:
-        image: 'golang:1.17'
+        image: 'golang:1.18.6'
       unit_test:
-        image: 'golang:1.17'
+        image: 'golang:1.18.6'
       integration_test:
         image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'
       build:
-        image: 'golang:1.17'
+        image: 'golang:1.18.6'
         output_dir: 'binary'
 
   jobs:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18.3 as builder
+FROM golang:1.18.6 as builder
 
 WORKDIR /go/src/github.com/gardener/backup-restore
 COPY . .

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -418,6 +418,8 @@ func IsBackupBucketEmpty(snapStoreConfig *brtypes.SnapstoreConfig, logger *logru
 	return true
 }
 
+const scaledToMultiNodeAnnotationKey = "gardener.cloud/scaled-to-multi-node"
+
 // GetInitialClusterStateIfScaleup checks if it is the Scale-up scenario and returns the cluster state either `new` or `existing`.
 func GetInitialClusterStateIfScaleup(ctx context.Context, logger logrus.Entry, clientSet client.Client, podName string, podNS string) (*string, error) {
 	//Read sts spec for updated replicas to toggle `initial-cluster-state`
@@ -431,7 +433,7 @@ func GetInitialClusterStateIfScaleup(ctx context.Context, logger logrus.Entry, c
 		return nil, err
 	}
 
-	if metav1.HasAnnotation(curSts.ObjectMeta, "gardener.cloud/scaled-to-multi-node") {
+	if metav1.HasAnnotation(curSts.ObjectMeta, scaledToMultiNodeAnnotationKey) {
 		return pointer.StringPtr(ClusterStateExisting), nil
 	}
 

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -39,6 +39,8 @@ import (
 	"go.etcd.io/etcd/etcdserver/etcdserverpb"
 	"go.etcd.io/etcd/pkg/types"
 	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -417,24 +419,27 @@ func IsBackupBucketEmpty(snapStoreConfig *brtypes.SnapstoreConfig, logger *logru
 }
 
 // GetInitialClusterStateIfScaleup checks if it is the Scale-up scenario and returns the cluster state either `new` or `existing`.
-func GetInitialClusterStateIfScaleup(ctx context.Context, logger logrus.Entry, clientSet client.Client, podName string, podNS string) string {
+func GetInitialClusterStateIfScaleup(ctx context.Context, logger logrus.Entry, clientSet client.Client, podName string, podNS string) (*string, error) {
 	//Read sts spec for updated replicas to toggle `initial-cluster-state`
 	curSts := &appsv1.StatefulSet{}
-	errSts := clientSet.Get(ctx, client.ObjectKey{
+	err := clientSet.Get(ctx, client.ObjectKey{
 		Namespace: podNS,
 		Name:      podName[:strings.LastIndex(podName, "-")],
 	}, curSts)
-	if errSts != nil {
-		logger.Warn("error fetching etcd sts ", errSts)
-		return ClusterStateNew
+	if err != nil {
+		logger.Warn("error fetching etcd sts ", err)
+		return nil, err
 	}
 
-	//TODO: achieve this without an sts?
+	if metav1.HasAnnotation(curSts.ObjectMeta, "gardener.cloud/scaled-to-multi-node") {
+		return pointer.StringPtr(ClusterStateExisting), nil
+	}
+
+	// fallback - preserves backward compatibility
 	if *curSts.Spec.Replicas > 1 && *curSts.Spec.Replicas > curSts.Status.UpdatedReplicas {
-		return ClusterStateExisting
+		return pointer.StringPtr(ClusterStateExisting), nil
 	}
-
-	return ""
+	return nil, nil
 }
 
 // DoPromoteMember promotes a given learner to a voting member.

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -547,7 +547,7 @@ var _ = Describe("Miscellaneous Tests", func() {
 					UpdatedReplicas: 3,
 				}
 				sts.Annotations = map[string]string{
-					"gardener.cloud/scaled-to-multi-node": "",
+					scaledToMultiNodeAnnotationKey: "",
 				}
 			})
 

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -463,10 +463,9 @@ var _ = Describe("Miscellaneous Tests", func() {
 			statefulSetName = "etcd-test"
 			podName         = "etcd-test-0"
 			namespace       = "test_namespace"
-			emptyString     = ""
 		)
 		Context("In single node etcd: no scale-up", func() {
-			It("Should return the cluster state as empty string ", func() {
+			It("Should return the cluster state as nil", func() {
 				sts = &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "StatefulSet",
@@ -488,12 +487,13 @@ var _ = Describe("Miscellaneous Tests", func() {
 				err := clientSet.Create(testCtx, sts)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				clusterState := GetInitialClusterStateIfScaleup(testCtx, *logger, clientSet, podName, namespace)
-				Expect(clusterState).Should(Equal(emptyString))
+				clusterState, err := GetInitialClusterStateIfScaleup(testCtx, *logger, clientSet, podName, namespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(clusterState).To(BeNil())
 			})
 		})
 		Context("In multi-node etcd bootstrap: no scale-up", func() {
-			It("Should return the cluster state as empty string ", func() {
+			It("Should return the cluster state as nil", func() {
 				sts = &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "StatefulSet",
@@ -515,8 +515,9 @@ var _ = Describe("Miscellaneous Tests", func() {
 				err := clientSet.Create(testCtx, sts)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				clusterState := GetInitialClusterStateIfScaleup(testCtx, *logger, clientSet, podName, namespace)
-				Expect(clusterState).Should(Equal(emptyString))
+				clusterState, err := GetInitialClusterStateIfScaleup(testCtx, *logger, clientSet, podName, namespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(clusterState).Should(BeNil())
 			})
 		})
 		Context("In case of Scaling up from single node to multi-node etcd", func() {
@@ -542,13 +543,14 @@ var _ = Describe("Miscellaneous Tests", func() {
 				err := clientSet.Create(testCtx, sts)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				clusterState := GetInitialClusterStateIfScaleup(testCtx, *logger, clientSet, podName, namespace)
+				clusterState, err := GetInitialClusterStateIfScaleup(testCtx, *logger, clientSet, podName, namespace)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(clusterState).Should(Equal(ClusterStateExisting))
 			})
 		})
 
 		Context("Unable to fetch statefulset", func() {
-			It("Should return clusterState as `new` ", func() {
+			It("Should return error", func() {
 				sts = &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "StatefulSet",
@@ -572,8 +574,8 @@ var _ = Describe("Miscellaneous Tests", func() {
 				err := clientSet.Create(testCtx, sts)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				clusterState := GetInitialClusterStateIfScaleup(testCtx, *logger, clientSet, podName, wrongNamespace)
-				Expect(clusterState).Should(Equal(ClusterStateNew))
+				_, err = GetInitialClusterStateIfScaleup(testCtx, *logger, clientSet, podName, wrongNamespace)
+				Expect(err).To(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -26,8 +26,11 @@ import (
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 	"github.com/golang/mock/gomock"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/etcdserver/etcdserverpb"
 	appsv1 "k8s.io/api/apps/v1"
@@ -464,24 +467,22 @@ var _ = Describe("Miscellaneous Tests", func() {
 			podName         = "etcd-test-0"
 			namespace       = "test_namespace"
 		)
+
+		BeforeEach(func() {
+			sts = emptyStatefulSet(statefulSetName, namespace)
+		})
+
 		Context("In single node etcd: no scale-up", func() {
-			It("Should return the cluster state as nil", func() {
-				sts = &appsv1.StatefulSet{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "StatefulSet",
-						APIVersion: "apps/v1",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      statefulSetName,
-						Namespace: namespace,
-					},
-					Spec: appsv1.StatefulSetSpec{
-						Replicas: pointer.Int32Ptr(1),
-					},
-					Status: appsv1.StatefulSetStatus{
-						UpdatedReplicas: 1,
-					},
+			BeforeEach(func() {
+				sts.Spec = appsv1.StatefulSetSpec{
+					Replicas: pointer.Int32Ptr(1),
 				}
+				sts.Status = appsv1.StatefulSetStatus{
+					UpdatedReplicas: 1,
+				}
+			})
+
+			It("Should return the cluster state as nil", func() {
 				clientSet := GetFakeKubernetesClientSet()
 
 				err := clientSet.Create(testCtx, sts)
@@ -492,24 +493,18 @@ var _ = Describe("Miscellaneous Tests", func() {
 				Expect(clusterState).To(BeNil())
 			})
 		})
+
 		Context("In multi-node etcd bootstrap: no scale-up", func() {
-			It("Should return the cluster state as nil", func() {
-				sts = &appsv1.StatefulSet{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "StatefulSet",
-						APIVersion: "apps/v1",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      statefulSetName,
-						Namespace: namespace,
-					},
-					Spec: appsv1.StatefulSetSpec{
-						Replicas: pointer.Int32Ptr(3),
-					},
-					Status: appsv1.StatefulSetStatus{
-						UpdatedReplicas: 3,
-					},
+			BeforeEach(func() {
+				sts.Spec = appsv1.StatefulSetSpec{
+					Replicas: pointer.Int32Ptr(3),
 				}
+				sts.Status = appsv1.StatefulSetStatus{
+					UpdatedReplicas: 3,
+				}
+			})
+
+			It("Should return the cluster state as nil", func() {
 				clientSet := GetFakeKubernetesClientSet()
 
 				err := clientSet.Create(testCtx, sts)
@@ -520,24 +515,18 @@ var _ = Describe("Miscellaneous Tests", func() {
 				Expect(clusterState).Should(BeNil())
 			})
 		})
-		Context("In case of Scaling up from single node to multi-node etcd", func() {
-			It("Should return clusterState as `existing` ", func() {
-				sts = &appsv1.StatefulSet{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "StatefulSet",
-						APIVersion: "apps/v1",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      statefulSetName,
-						Namespace: namespace,
-					},
-					Spec: appsv1.StatefulSetSpec{
-						Replicas: pointer.Int32Ptr(3),
-					},
-					Status: appsv1.StatefulSetStatus{
-						UpdatedReplicas: 1,
-					},
+
+		Context("In case of Scaling up from single node to multi-node etcd with no scale-up annotation set", func() {
+			BeforeEach(func() {
+				sts.Spec = appsv1.StatefulSetSpec{
+					Replicas: pointer.Int32Ptr(3),
 				}
+				sts.Status = appsv1.StatefulSetStatus{
+					UpdatedReplicas: 1,
+				}
+			})
+
+			It("Should return clusterState as `existing` ", func() {
 				clientSet := GetFakeKubernetesClientSet()
 
 				err := clientSet.Create(testCtx, sts)
@@ -545,7 +534,33 @@ var _ = Describe("Miscellaneous Tests", func() {
 
 				clusterState, err := GetInitialClusterStateIfScaleup(testCtx, *logger, clientSet, podName, namespace)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(clusterState).Should(Equal(ClusterStateExisting))
+				Expect(clusterState).Should(PointTo(Equal(ClusterStateExisting)))
+			})
+		})
+
+		Context("scaling of single node to multi-node etcd with scale-up annotation set", func() {
+			BeforeEach(func() {
+				sts.Spec = appsv1.StatefulSetSpec{
+					Replicas: pointer.Int32Ptr(3),
+				}
+				sts.Status = appsv1.StatefulSetStatus{
+					UpdatedReplicas: 3,
+				}
+				sts.Annotations = map[string]string{
+					"gardener.cloud/scaled-to-multi-node": "",
+				}
+			})
+
+			It("should return existing cluster", func() {
+				clientSet := GetFakeKubernetesClientSet()
+
+				err := clientSet.Create(testCtx, sts)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				clusterState, err := GetInitialClusterStateIfScaleup(testCtx, *logger, clientSet, podName, namespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(clusterState).Should(PointTo(Equal(ClusterStateExisting)))
+
 			})
 		})
 
@@ -579,14 +594,17 @@ var _ = Describe("Miscellaneous Tests", func() {
 			})
 		})
 	})
+
 	Describe("parse peer urls config", func() {
 		var (
 			initialAdPeerURL string
 			podName          string
 		)
+
 		BeforeEach(func() {
 			podName = "etcd-test-pod-0"
 		})
+
 		Context("parse peer url", func() {
 			It("parsing well-defined initial-advertise-peer-urls", func() {
 				initialAdPeerURL = "https@etcd-events-peer@shoot--dev--test@2380"
@@ -594,6 +612,7 @@ var _ = Describe("Miscellaneous Tests", func() {
 				Expect(err).To(BeNil())
 				Expect(peerURL).To(Equal("https://etcd-test-pod-0.etcd-events-peer.shoot--dev--test.svc:2380"))
 			})
+
 			It("parsing malformed initial-advertise-peer-urls", func() {
 				initialAdPeerURL = "https@etcd-events-peer@shoot--dev--test"
 				_, err := ParsePeerURL(initialAdPeerURL, podName)
@@ -601,15 +620,19 @@ var _ = Describe("Miscellaneous Tests", func() {
 			})
 		})
 	})
+
 	Describe("read config file into a map", func() {
 		const testdataPath = "testdata"
 		var (
 			configPath string
 		)
+
 		Context("valid config file", func() {
+
 			BeforeEach(func() {
 				configPath = filepath.Join(testdataPath, "valid_config.yaml")
 			})
+
 			It("test read and parse yaml", func() {
 				configAsMap, err := ReadConfigFileAsMap(configPath)
 				Expect(err).To(BeNil())
@@ -617,6 +640,7 @@ var _ = Describe("Miscellaneous Tests", func() {
 				Expect(configAsMap["name"]).To(Equal("etcd-57c38d")) //just testing one property
 			})
 		})
+
 		Context("invalid file path", func() {
 			It("test read and parse for a non-existent path", func() {
 				configPath = "file-does-not-exist.yaml"
@@ -624,10 +648,12 @@ var _ = Describe("Miscellaneous Tests", func() {
 				Expect(err).ToNot(BeNil())
 			})
 		})
+
 		Context("invalid yaml file", func() {
 			BeforeEach(func() {
 				configPath = filepath.Join(testdataPath, "invalid_config.yaml")
 			})
+
 			It("test read and parse an invalid config yaml", func() {
 				_, err := ReadConfigFileAsMap(configPath)
 				Expect(err).ToNot(BeNil())
@@ -636,6 +662,15 @@ var _ = Describe("Miscellaneous Tests", func() {
 	})
 
 })
+
+func emptyStatefulSet(name, namespace string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
 
 func generateSnapshotList(n int) brtypes.SnapList {
 	snapList := brtypes.SnapList{}

--- a/pkg/server/backrestoreserver_test.go
+++ b/pkg/server/backrestoreserver_test.go
@@ -3,34 +3,42 @@ package server
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("backrestoreserver tests", func() {
-	const podName = "etcd-test-pod-0"
 	var (
-		initialAdvertisePeerURLs string
+		memberPeerURL string
+		brServer      *BackupRestoreServer
+		err           error
 	)
+
+	BeforeEach(func() {
+		brServer, err = NewBackupRestoreServer(logrus.New(), &BackupRestoreComponentConfig{})
+		Expect(err).ToNot(HaveOccurred())
+	})
 
 	Describe("testing isPeerURLTLSEnabled", func() {
 		Context("testing with non-TLS enabled peer url", func() {
 			BeforeEach(func() {
-				initialAdvertisePeerURLs = "http@etcd-main-peer@default@2380"
+				memberPeerURL = "http://etcd-main-peer.default.svc:2380"
 			})
 			It("test", func() {
-				enabled, err := isPeerURLTLSEnabled(initialAdvertisePeerURLs, podName)
+				enabled := brServer.isPeerURLTLSEnabled(memberPeerURL)
 				Expect(err).To(BeNil())
 				Expect(enabled).To(BeFalse())
 			})
 
 		})
+
 		Context("testing with TLS enabled peer url", func() {
 			BeforeEach(func() {
-				initialAdvertisePeerURLs = "https@etcd-main-peer@default@2380"
+				memberPeerURL = "https://etcd-main-peer.default.svc:2380"
 			})
 			It("test", func() {
-				enabled, err := isPeerURLTLSEnabled(initialAdvertisePeerURLs, podName)
+				enabled := brServer.isPeerURLTLSEnabled(memberPeerURL)
 				Expect(err).To(BeNil())
-				Expect(enabled).To(BeFalse())
+				Expect(enabled).To(BeTrue())
 			})
 		})
 	})

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -224,22 +224,22 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 			}
 			_ = miscellaneous.SleepWithContext(ctx, retryTimeout)
 		}
-	} else {
-		// when OriginalClusterSize = 1
-		m := member.NewMemberControl(b.config.EtcdConnectionConfig)
-		err := retry.OnError(retry.DefaultBackoff, func(err error) bool {
-			return err != nil
-		}, func() error {
-			cli, err := etcdutil.NewFactory(*b.config.EtcdConnectionConfig).NewCluster()
-			if err != nil {
-				return err
-			}
-			_, err = m.UpdateMemberPeerURL(ctx, cli)
-			return err
-		})
+	}
+
+	// when OriginalClusterSize = 1
+	m := member.NewMemberControl(b.config.EtcdConnectionConfig)
+	err := retry.OnError(retry.DefaultBackoff, func(err error) bool {
+		return err != nil
+	}, func() error {
+		cli, err := etcdutil.NewFactory(*b.config.EtcdConnectionConfig).NewCluster()
 		if err != nil {
-			b.logger.Error("unable to update the member")
+			return err
 		}
+		_, err = m.UpdateMemberPeerURL(ctx, cli)
+		return err
+	})
+	if err != nil {
+		b.logger.Error("unable to update the member")
 	}
 
 	leaderCallbacks := &brtypes.LeaderCallbacks{

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -236,7 +236,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 		return err
 	})
 	if err != nil {
-		b.logger.Error("unable to update the member")
+		b.logger.Error("unable to update the member: %v", err)
 	}
 
 	leaderCallbacks := &brtypes.LeaderCallbacks{

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -111,20 +111,6 @@ func (b *BackupRestoreServer) Run(ctx context.Context) error {
 		return err
 	}
 
-	//podName, err := miscellaneous.GetEnvVarOrError("POD_NAME")
-	//if err != nil {
-	//	b.logger.Fatalf("Error reading POD_NAME env var : %v", err)
-	//}
-	//
-	//initialAdvertisePeerURLs := config["initial-advertise-peer-urls"].(string)
-	//peerURLTLSEnabled, err = isPeerURLTLSEnabled(initialAdvertisePeerURLs, podName)
-	//if err != nil {
-	//	b.logger.WithFields(logrus.Fields{
-	//		"podName":                     podName,
-	//		"initial-advertise-peer-urls": initialAdvertisePeerURLs,
-	//	}).Fatalf("failed to parse initial-advertise-peer-urls: %v", err)
-	//}
-
 	initialClusterSize, err := miscellaneous.GetClusterSize(fmt.Sprint(config["initial-cluster"]))
 	if err != nil {
 		b.logger.Fatal("Please provide initial cluster value for embedded ETCD")

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -236,7 +236,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 		return err
 	})
 	if err != nil {
-		b.logger.Error("unable to update the member: %v", err)
+		b.logger.Errorf("unable to update the member: %v", err)
 	}
 
 	leaderCallbacks := &brtypes.LeaderCallbacks{

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -62,7 +62,6 @@ var (
 	// runServerWithSnapshotter indicates whether to start server with or without snapshotter.
 	runServerWithSnapshotter bool = true
 	retryTimeout                  = 5 * time.Second
-	//peerURLTLSEnabled        bool
 )
 
 const (

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -226,11 +226,8 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 		}
 	}
 
-	// when OriginalClusterSize = 1
 	m := member.NewMemberControl(b.config.EtcdConnectionConfig)
-	err := retry.OnError(retry.DefaultBackoff, func(err error) bool {
-		return err != nil
-	}, func() error {
+	err := retry.OnError(retry.DefaultBackoff, errors.AnyError, func() error {
 		cli, err := etcdutil.NewFactory(*b.config.EtcdConnectionConfig).NewCluster()
 		if err != nil {
 			return err

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -220,7 +220,7 @@ func (ssr *Snapshotter) TriggerDeltaSnapshot() (*brtypes.Snapshot, error) {
 		return nil, fmt.Errorf("snapshotter is not active")
 	}
 	if ssr.config.DeltaSnapshotPeriod.Duration < brtypes.DeltaSnapshotIntervalThreshold {
-		return nil, fmt.Errorf("Found delta snapshot interval %s less than %v. Delta snapshotting is disabled. ", ssr.config.DeltaSnapshotPeriod.Duration, time.Duration(brtypes.DeltaSnapshotIntervalThreshold))
+		return nil, fmt.Errorf("found delta snapshot interval %s less than %v. Delta snapshotting is disabled. ", ssr.config.DeltaSnapshotPeriod.Duration, time.Duration(brtypes.DeltaSnapshotIntervalThreshold))
 	}
 	ssr.logger.Info("Triggering out of schedule delta snapshot...")
 	ssr.deltaSnapshotReqCh <- emptyStruct
@@ -231,6 +231,7 @@ func (ssr *Snapshotter) TriggerDeltaSnapshot() (*brtypes.Snapshot, error) {
 // stop stops the snapshotter. Once stopped any subsequent calls will
 // not have any effect.
 func (ssr *Snapshotter) stop() {
+	ssr.logger.Info("Closing the Snapshotter...")
 	ssr.SsrStateMutex.Lock()
 	if ssr.fullSnapshotTimer != nil {
 		ssr.fullSnapshotTimer.Stop()

--- a/pkg/types/leaderelection.go
+++ b/pkg/types/leaderelection.go
@@ -27,8 +27,8 @@ import (
 const (
 	// DefaultReelectionPeriod defines default time period for Reelection.
 	DefaultReelectionPeriod = 5 * time.Second
-	// DefaultEtcdConnecTimeout defines default ConnectionTimeout for etcd client.
-	DefaultEtcdConnecTimeout = 5 * time.Second
+	// DefaultEtcdStatusConnecTimeout defines default ConnectionTimeout for etcd client to get Etcd endpoint status.
+	DefaultEtcdStatusConnecTimeout = 5 * time.Second
 )
 
 // LeaderCallbacks are callbacks that are triggered to start/stop the snapshottter when leader's currentState changes.
@@ -67,7 +67,7 @@ type Config struct {
 func NewLeaderElectionConfig() *Config {
 	return &Config{
 		ReelectionPeriod:      wrappers.Duration{Duration: DefaultReelectionPeriod},
-		EtcdConnectionTimeout: wrappers.Duration{Duration: DefaultEtcdConnecTimeout},
+		EtcdConnectionTimeout: wrappers.Duration{Duration: DefaultEtcdStatusConnecTimeout},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cherry picks commits for the following PRs

1. Fix the ProbeEtcd timeout. - https://github.com/gardener/etcd-backup-restore/pull/532
2. Member Peer URL not updated when scaled to multi-node, scale identification is also not correct - https://github.com/gardener/etcd-backup-restore/pull/534
3. Update to golang 1.18.6 - https://github.com/gardener/etcd-backup-restore/pull/535

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bugfix operator github.com/gardener/etcd-backup-restore #532 @ishan16696 
To avoid potential race-condition between go-routines updated `probeEtcd func()` to use shorter timeout.
```
```improvement operator github.com/gardener/etcd-backup-restore #534 @unmarshall 
Always update member peer URL, changed the way scale-up of etcd cluster is identified.
```
```noteworthy operator github.com/gardener/etcd-backup-restore #535 @aaronfern 
Updated golang version used to build images to 1.18.6
```
```noteworthy operator github.com/gardener/etcd-backup-restore #535 @aaronfern 
Updated golang version to 1.18
```