### PR TITLE
UpdateMemberPeerURL only logs an error in case of failure

### DIFF
--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -226,7 +226,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to update member peer url: %w", err)
+		b.logger.Errorf("failed to update member peer url: %v", err)
 	}
 
 	peerURLTLSEnabled := b.isPeerURLTLSEnabled(memberPeerURL)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updated the functionality of etcd member peer URL updation to only log an error in case of failure.
This is needed as sometimes etcd restoration takes longer to complete and etcd member peer URL updation failure will then cause the container to crash before the restoration can complete

**Which issue(s) this PR fixes**:
Fixes #539 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
[bug-fix] backup-restore does not return error when it fails to update PeerURL of member.
```
