### PR TITLE
[Cherry pick of #537]To decrease the likelihood of race condition while closing the snapshotter

### DIFF
--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -178,7 +178,7 @@ func (ssr *Snapshotter) Run(stopCh <-chan struct{}, startWithFullSnapshot bool) 
 				return nil
 			}
 			if err != nil {
-				return fmt.Errorf("Failed to collect events for first delta snapshot(s): %v", err)
+				return fmt.Errorf("failed to collect events for first delta snapshot(s): %v", err)
 			}
 		}
 		if err := ssr.resetFullSnapshotTimer(); err != nil {
@@ -600,6 +600,7 @@ func newEvent(e *clientv3.Event) *event {
 func (ssr *Snapshotter) snapshotEventHandler(stopCh <-chan struct{}) error {
 	leaseUpdateCtx, leaseUpdateCancel := context.WithCancel(context.TODO())
 	defer leaseUpdateCancel()
+	ssr.logger.Info("Starting the Snapshot EventHandler.")
 	for {
 		select {
 		case isFinal := <-ssr.fullSnapshotReqCh:
@@ -684,6 +685,7 @@ func (ssr *Snapshotter) snapshotEventHandler(stopCh <-chan struct{}) error {
 			}
 
 		case <-stopCh:
+			ssr.logger.Info("Closing the Snapshot EventHandler.")
 			leaseUpdateCancel()
 			ssr.cleanupInMemoryEvents()
 			return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry Pick of PR: https://github.com/gardener/etcd-backup-restore/pull/537

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator #537 @ishan16696 
Decreases the likelihood of potential race condition between the go-routines while closing the snapshotter.
```
