### PR TITLE
[rel-v0.20] UpdateMemberPeerURL only logs an error in case of failure

### DIFF
--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -226,7 +226,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to update member peer url: %w", err)
+		b.logger.Errorf("failed to update member peer url: %v", err)
 	}
 
 	peerURLTLSEnabled := b.isPeerURLTLSEnabled(memberPeerURL)


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry pick [`685178`](https://github.com/gardener/etcd-backup-restore/pull/540/commits/685178e784e0bb12991df893d4f632ad1e14bfe9)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator github.com/gardener/etcd-backup-restore #540 @aaronfern 
[bug-fix] backup-restore does not return error when it fails to update PeerURL of member.
```
