### PR TITLE
[Feat] min-chunk-size flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please refer to the [Gardener contributor guide](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md).
+Please refer to [Contributing to Gardener](https://gardener.cloud/docs/contribute/)

--- a/pkg/snapstore/abs_snapstore_test.go
+++ b/pkg/snapstore/abs_snapstore_test.go
@@ -45,7 +45,7 @@ func newFakeABSSnapstore() brtypes.SnapStore {
 	Expect(err).ShouldNot(HaveOccurred())
 	serviceURL := azblob.NewServiceURL(*u, p)
 	containerURL := serviceURL.NewContainerURL(bucket)
-	a, err := GetABSSnapstoreFromClient(bucket, prefixV2, "/tmp", 5, &containerURL)
+	a, err := GetABSSnapstoreFromClient(bucket, prefixV2, "/tmp", 5, brtypes.MinChunkSize, &containerURL)
 	Expect(err).ShouldNot(HaveOccurred())
 	return a
 }

--- a/pkg/snapstore/ecs_s3_snapstore.go
+++ b/pkg/snapstore/ecs_s3_snapstore.go
@@ -35,7 +35,7 @@ func NewECSSnapStore(config *brtypes.SnapstoreConfig) (*S3SnapStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newGenericS3FromAuthOpt(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads, ao)
+	return newGenericS3FromAuthOpt(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads, config.MinChunkSize, ao)
 }
 
 // ecsAuthOptionsFromEnv gets ECS provider configuration from environment variables.

--- a/pkg/snapstore/generic_s3_snapstore.go
+++ b/pkg/snapstore/generic_s3_snapstore.go
@@ -36,7 +36,7 @@ type s3AuthOptions struct {
 }
 
 // newGenericS3FromAuthOpt creates a new S3 snapstore object from the specified authentication options.
-func newGenericS3FromAuthOpt(bucket, prefix, tempDir string, maxParallelChunkUploads uint, ao s3AuthOptions) (*S3SnapStore, error) {
+func newGenericS3FromAuthOpt(bucket, prefix, tempDir string, maxParallelChunkUploads uint, minChunkSize int64, ao s3AuthOptions) (*S3SnapStore, error) {
 	httpClient := http.DefaultClient
 	if !ao.disableSSL {
 		httpClient.Transport = &http.Transport{
@@ -56,5 +56,5 @@ func newGenericS3FromAuthOpt(bucket, prefix, tempDir string, maxParallelChunkUpl
 		return nil, fmt.Errorf("could not create S3 session: %v", err)
 	}
 	cli := s3.New(sess)
-	return NewS3FromClient(bucket, prefix, tempDir, maxParallelChunkUploads, cli), nil
+	return NewS3FromClient(bucket, prefix, tempDir, maxParallelChunkUploads, minChunkSize, cli), nil
 }

--- a/pkg/snapstore/init.go
+++ b/pkg/snapstore/init.go
@@ -22,6 +22,7 @@ import (
 func NewSnapstoreConfig() *brtypes.SnapstoreConfig {
 	return &brtypes.SnapstoreConfig{
 		MaxParallelChunkUploads: 5,
+		MinChunkSize:            brtypes.MinChunkSize,
 		TempDir:                 "/tmp",
 	}
 }

--- a/pkg/snapstore/ocs_s3_snapstore.go
+++ b/pkg/snapstore/ocs_s3_snapstore.go
@@ -44,7 +44,7 @@ func NewOCSSnapStore(config *brtypes.SnapstoreConfig) (*S3SnapStore, error) {
 		return nil, err
 	}
 
-	return newGenericS3FromAuthOpt(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads, ocsAuthOptionsToGenericS3(*credentials))
+	return newGenericS3FromAuthOpt(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads, config.MinChunkSize, ocsAuthOptionsToGenericS3(*credentials))
 }
 
 func getOCSAuthOptions(prefix string) (*ocsAuthOptions, error) {

--- a/pkg/snapstore/snapstore.go
+++ b/pkg/snapstore/snapstore.go
@@ -17,9 +17,6 @@ package snapstore
 import "time"
 
 const (
-	// minChunkSize is set to 5Mib since it is lower chunk size limit for AWS.
-	minChunkSize int64 = 5 * (1 << 20) //5 MiB
-
 	// chunkUploadTimeout is timeout for uploading chunk.
 	chunkUploadTimeout = 180 * time.Second
 	// providerConnectionTimeout is timeout for connection/short queries to cloud provider.

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -102,29 +102,29 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 		expectedVal5 = []byte("value5")
 
 		snapstores = map[string]brtypes.SnapStore{
-			"s3": NewS3FromClient(bucket, prefixV2, "/tmp", 5, &mockS3Client{
+			"s3": NewS3FromClient(bucket, prefixV2, "/tmp", 5, brtypes.MinChunkSize, &mockS3Client{
 				objects:          objectMap,
 				prefix:           prefixV2,
 				multiPartUploads: map[string]*[][]byte{},
 			}),
-			"swift": NewSwiftSnapstoreFromClient(bucket, prefixV2, "/tmp", 5, fake.ServiceClient()),
+			"swift": NewSwiftSnapstoreFromClient(bucket, prefixV2, "/tmp", 5, brtypes.MinChunkSize, fake.ServiceClient()),
 			"ABS":   newFakeABSSnapstore(),
-			"GCS": NewGCSSnapStoreFromClient(bucket, prefixV2, "/tmp", 5, &mockGCSClient{
+			"GCS": NewGCSSnapStoreFromClient(bucket, prefixV2, "/tmp", 5, brtypes.MinChunkSize, &mockGCSClient{
 				objects: objectMap,
 				prefix:  prefixV2,
 			}),
-			"OSS": NewOSSFromBucket(prefixV2, "/tmp", 5, &mockOSSBucket{
+			"OSS": NewOSSFromBucket(prefixV2, "/tmp", 5, brtypes.MinChunkSize, &mockOSSBucket{
 				objects:          objectMap,
 				prefix:           prefixV2,
 				multiPartUploads: map[string]*[][]byte{},
 				bucketName:       bucket,
 			}),
-			"ECS": NewS3FromClient(bucket, prefixV2, "/tmp", 5, &mockS3Client{
+			"ECS": NewS3FromClient(bucket, prefixV2, "/tmp", 5, brtypes.MinChunkSize, &mockS3Client{
 				objects:          objectMap,
 				prefix:           prefixV2,
 				multiPartUploads: map[string]*[][]byte{},
 			}),
-			"OCS": NewS3FromClient(bucket, prefixV2, "/tmp", 5, &mockS3Client{
+			"OCS": NewS3FromClient(bucket, prefixV2, "/tmp", 5, brtypes.MinChunkSize, &mockS3Client{
 				objects:          objectMap,
 				prefix:           prefixV2,
 				multiPartUploads: map[string]*[][]byte{},

--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -60,8 +60,8 @@ const (
 
 	backupFormatVersion = "v2"
 
-	// minChunkSize is set to 5Mib since it is lower chunk size limit for AWS.
-	minChunkSize int64 = 5 * (1 << 20) //5 MiB
+	// MinChunkSize is set to 5Mib since it is lower chunk size limit for AWS.
+	MinChunkSize int64 = 5 * (1 << 20) //5 MiB
 )
 
 // SnapStore is the interface to be implemented for different
@@ -194,7 +194,7 @@ func (c *SnapstoreConfig) addFlags(fs *flag.FlagSet, parameterPrefix string) {
 	fs.StringVar(&c.Container, parameterPrefix+"store-container", c.Container, "container which will be used as snapstore")
 	fs.StringVar(&c.Prefix, parameterPrefix+"store-prefix", c.Prefix, "prefix or directory inside container under which snapstore is created")
 	fs.UintVar(&c.MaxParallelChunkUploads, parameterPrefix+"max-parallel-chunk-uploads", c.MaxParallelChunkUploads, "maximum number of parallel chunk uploads allowed")
-	fs.Int64Var(&c.MinChunkSize, parameterPrefix+"min-chunk-size", minChunkSize, "Minimum size for multipart upload chunk")
+	fs.Int64Var(&c.MinChunkSize, parameterPrefix+"min-chunk-size", c.MinChunkSize, "Minimum size for multipart upload chunk")
 	fs.StringVar(&c.TempDir, parameterPrefix+"snapstore-temp-directory", c.TempDir, "temporary directory for processing")
 }
 
@@ -203,7 +203,7 @@ func (c *SnapstoreConfig) Validate() error {
 	if c.MaxParallelChunkUploads <= 0 {
 		return fmt.Errorf("max parallel chunk uploads should be greater than zero")
 	}
-	if c.MinChunkSize < minChunkSize {
+	if c.MinChunkSize < MinChunkSize {
 		return fmt.Errorf("min size for multi-part upload chunk should be greater than 5 MiB")
 	}
 	return nil

--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -171,7 +171,7 @@ type SnapstoreConfig struct {
 	Prefix string `json:"prefix,omitempty"`
 	// MaxParallelChunkUploads holds the maximum number of parallel chunk uploads allowed.
 	MaxParallelChunkUploads uint `json:"maxParallelChunkUploads,omitempty"`
-	// MinChunkSize holds the minimum size for a multi-part upload chunk.
+	// MinChunkSize holds the minimum size for a multi-part chunk upload.
 	MinChunkSize int64 `json:"minChunkSize,omitempty"`
 	// Temporary Directory
 	TempDir string `json:"tempDir,omitempty"`
@@ -194,7 +194,7 @@ func (c *SnapstoreConfig) addFlags(fs *flag.FlagSet, parameterPrefix string) {
 	fs.StringVar(&c.Container, parameterPrefix+"store-container", c.Container, "container which will be used as snapstore")
 	fs.StringVar(&c.Prefix, parameterPrefix+"store-prefix", c.Prefix, "prefix or directory inside container under which snapstore is created")
 	fs.UintVar(&c.MaxParallelChunkUploads, parameterPrefix+"max-parallel-chunk-uploads", c.MaxParallelChunkUploads, "maximum number of parallel chunk uploads allowed")
-	fs.Int64Var(&c.MinChunkSize, parameterPrefix+"min-chunk-size", c.MinChunkSize, "Minimum size for multipart upload chunk")
+	fs.Int64Var(&c.MinChunkSize, parameterPrefix+"min-chunk-size", c.MinChunkSize, "Minimum size for multipart chunk upload")
 	fs.StringVar(&c.TempDir, parameterPrefix+"snapstore-temp-directory", c.TempDir, "temporary directory for processing")
 }
 
@@ -204,7 +204,7 @@ func (c *SnapstoreConfig) Validate() error {
 		return fmt.Errorf("max parallel chunk uploads should be greater than zero")
 	}
 	if c.MinChunkSize < MinChunkSize {
-		return fmt.Errorf("min size for multi-part upload chunk should be greater than 5 MiB")
+		return fmt.Errorf("min chunk size for multi-part chunk upload should be greater than 5 MiB")
 	}
 	return nil
 }

--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -204,7 +204,7 @@ func (c *SnapstoreConfig) Validate() error {
 		return fmt.Errorf("max parallel chunk uploads should be greater than zero")
 	}
 	if c.MinChunkSize < MinChunkSize {
-		return fmt.Errorf("min chunk size for multi-part chunk upload should be greater than 5 MiB")
+		return fmt.Errorf("min chunk size for multi-part chunk upload should be greater than or equal to 5 MiB")
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Addition of min-chunk-size flag, it allows to fine tune multi-part upload across different store providers

**Which issue(s) this PR fixes**:

none

**Special notes for your reviewer**:

**Release note**:
```improvement operator
 making chunk-size configurable by introducing flag: `--min-chunk-size` (default value 5MB), it will be helpful in fine tuning the multi-part chunk upload size for different storage provider.
```
