### PR TITLE
Removes the closing of snapshotter during initialization.

### DIFF
--- a/pkg/server/httpAPI.go
+++ b/pkg/server/httpAPI.go
@@ -28,7 +28,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 	etcdclient "github.com/gardener/etcd-backup-restore/pkg/etcdutil/client"
@@ -233,15 +232,7 @@ func (h *HTTPHandler) serveInitialize(rw http.ResponseWriter, req *http.Request)
 		go func() {
 			var mode validator.Mode
 
-			// This is needed to stop the currently running snapshotter.
-			if h.Snapshotter != nil {
-				h.SetStatus(http.StatusServiceUnavailable)
-				atomic.StoreUint32(&h.AckState, HandlerAckWaiting)
-				h.Logger.Info("Changed handler state.")
-				h.ReqCh <- emptyStruct
-				h.Logger.Info("Waiting for acknowledgment...")
-				<-h.AckCh
-			}
+			h.SetStatus(http.StatusServiceUnavailable)
 
 			failBelowRevisionStr := req.URL.Query().Get("failbelowrevision")
 			h.Logger.Infof("Validation failBelowRevision: %s", failBelowRevisionStr)


### PR DESCRIPTION
**What this PR does / why we need it**:
It has been observed that whenever etcd goes down or restarted then [initialization](https://github.com/gardener/etcd-backup-restore/blob/bd4f088085e43aaa23101e1b98699a2b626532d1/pkg/server/httpAPI.go#L225) request closes the snapshotter but there is no need of that as snapshotter will get close by [handleSsrStopRequest](https://github.com/gardener/etcd-backup-restore/blob/bd4f088085e43aaa23101e1b98699a2b626532d1/pkg/server/backuprestoreserver.go#L593) if `backup-leader` moves to `UnkownState` and cancels the context as etcd is down.
This PR removes the closing of `snapshotter` during initialization phase to removes the redundancy of closing of snapshotter.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@unmarshall 

**Release note**:
```improvement operator
Removes the redundant closing of snapshotter during initialization.
```
