### PR TITLE
Update to golang 1.19.2

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -42,13 +42,13 @@ etcd-backup-restore:
                 build: ~
     steps:
       check:
-        image: 'golang:1.18.6'
+        image: 'golang:1.19.2'
       unit_test:
-        image: 'golang:1.18.6'
+        image: 'golang:1.19.2'
       integration_test:
         image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'
       build:
-        image: 'golang:1.18.6'
+        image: 'golang:1.19.2'
         output_dir: 'binary'
 
   jobs:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18.6 as builder
+FROM golang:1.19.2 as builder 
 
 WORKDIR /go/src/github.com/gardener/backup-restore
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updated the golang version used to build images from `1.18.6` to `1.19.2`
This PR also updated the pipeline definitions to use go `1.19.2`

**Which issue(s) this PR fixes**:
Fixes
[CVE-2022-2879](https://nvd.nist.gov/vuln/detail/CVE-2022-2879)
[CVE-2022-2880](https://nvd.nist.gov/vuln/detail/CVE-2022-2880)
[CVE-2022-41715](https://nvd.nist.gov/vuln/detail/CVE-2022-41715)


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Updated golang version used to build images to 1.19.2
```