### PR TITLE
Removes taking full snapshot after defragmentation to avoid race-condintion.

### DIFF
--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -252,7 +252,6 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 
 				// set "http handler" with the latest snapshotter object
 				handler.SetSnapshotter(ssr)
-				defragCallBack = ssr.TriggerFullSnapshot
 				go handleSsrStopRequest(leCtx, handler, ssr, ackCh, ssrStopCh, b.logger)
 			}
 			go b.runEtcdProbeLoopWithSnapshotter(leCtx, handler, ssr, ss, ssrStopCh, ackCh)

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -492,9 +492,7 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 			}
 
 			// Set snapshotter state to Active
-			ssr.SsrStateMutex.Lock()
-			ssr.SsrState = brtypes.SnapshotterActive
-			ssr.SsrStateMutex.Unlock()
+			ssr.SetSnapshotterActive()
 
 			// Start owner check watchdog
 			var ownerCheckWatchdog common.Watchdog

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -241,6 +241,7 @@ func (ssr *Snapshotter) stop() {
 		ssr.deltaSnapshotTimer.Stop()
 		ssr.deltaSnapshotTimer = nil
 	}
+	ssr.SetSnapshotterInactive()
 	ssr.closeEtcdClient()
 }
 
@@ -697,9 +698,7 @@ func (ssr *Snapshotter) snapshotEventHandler(stopCh <-chan struct{}) error {
 
 		case <-stopCh:
 			ssr.logger.Info("Closing the Snapshot EventHandler.")
-			leaseUpdateCancel()
 			ssr.cleanupInMemoryEvents()
-			ssr.SetSnapshotterInactive()
 			return nil
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes triggering the out-of-schedule full snapshot after defragmentation as triggering the out-of-schedule full snapshot and closing of snapshotter can cause potential deadlock situation.

**Which issue(s) this PR fixes**:
temporary fixes: [issue: 553](https://github.com/gardener/etcd-backup-restore/issues/553)

**Special notes for your reviewer**:

**Release note**:
```bugfix operator
To avoid race-condition between closing of snapshotter and taking snapshot after defrag, removing the out-of-schedule full snapshot triggered after defragmentation of etcd.
```
