### PR TITLE
Removed unused code which was left while removing ownerCheck.

### DIFF
--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -529,15 +529,6 @@ func handleSsrStopRequest(ctx context.Context, handler *HTTPHandler, ssr *snapsh
 	}
 }
 
-func (b *BackupRestoreServer) stopSnapshotter(handler *HTTPHandler) {
-	b.logger.Infof("Stopping snapshotter...")
-	atomic.StoreUint32(&handler.AckState, HandlerAckWaiting)
-	handler.Logger.Info("Changing handler state...")
-	handler.ReqCh <- emptyStruct
-	handler.Logger.Info("Waiting for acknowledgment...")
-	<-handler.AckCh
-}
-
 func (b *BackupRestoreServer) isPeerURLTLSEnabled(memberPeerURL string) bool {
 	peerURL, err := url.Parse(memberPeerURL)
 	if err != nil {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -22,7 +22,6 @@ import (
 const (
 	defaultServerPort              = 8080
 	defaultDefragmentationSchedule = "0 0 */3 * *"
-	defaultEtcdProcessName         = "etcd"
 )
 
 // BackupRestoreComponentConfig holds the component configuration.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the dead code which was left while removing the ownercheck code. Please refer [here](https://github.com/gardener/etcd-backup-restore/pull/555#pullrequestreview-1205898995)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
None
```
