### PR TITLE
Enhances the decision to take full snapshot during startup to avoid missing of any full-snapshot.

### DIFF
--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -561,5 +561,6 @@ func GetPrevDayScheduledSnapTime(nextSnapSchedule time.Time) time.Time {
 		nextSnapSchedule.Minute(),
 		nextSnapSchedule.Second(),
 		nextSnapSchedule.Nanosecond(),
-		nextSnapSchedule.Location())
+		nextSnapSchedule.Location(),
+	)
 }

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -357,7 +357,6 @@ func IsMultiNode(logger *logrus.Entry) bool {
 	}
 
 	config := map[string]interface{}{}
-	err = yaml.Unmarshal([]byte(configYML), &config)
 	if err := yaml.Unmarshal([]byte(configYML), &config); err != nil {
 		return false
 	}
@@ -551,13 +550,14 @@ func IsPeerURLTLSEnabled() (bool, error) {
 	return peerURL.Scheme == https, nil
 }
 
-// GetPrevDayScheduledSnapTime returns the previous day schedule snapshot time.
-func GetPrevDayScheduledSnapTime(nextSnapSchedule time.Time) time.Time {
+// GetPrevScheduledSnapTime returns the previous schedule snapshot time.
+// TODO: Previous full snapshot time should be calculated on basis of previous cron schedule of full snapshot.
+func GetPrevScheduledSnapTime(nextSnapSchedule time.Time, timeWindow float64) time.Time {
 	return time.Date(
 		nextSnapSchedule.Year(),
 		nextSnapSchedule.Month(),
-		nextSnapSchedule.Day()-1,
-		nextSnapSchedule.Hour(),
+		nextSnapSchedule.Day(),
+		nextSnapSchedule.Hour()-int(timeWindow),
 		nextSnapSchedule.Minute(),
 		nextSnapSchedule.Second(),
 		nextSnapSchedule.Nanosecond(),

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -550,3 +550,16 @@ func IsPeerURLTLSEnabled() (bool, error) {
 
 	return peerURL.Scheme == https, nil
 }
+
+// GetPrevDayScheduledSnapTime returns the previous day schedule snapshot time.
+func GetPrevDayScheduledSnapTime(nextSnapSchedule time.Time) time.Time {
+	return time.Date(
+		nextSnapSchedule.Year(),
+		nextSnapSchedule.Month(),
+		nextSnapSchedule.Day()-1,
+		nextSnapSchedule.Hour(),
+		nextSnapSchedule.Minute(),
+		nextSnapSchedule.Second(),
+		nextSnapSchedule.Nanosecond(),
+		nextSnapSchedule.Location())
+}

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -307,8 +307,8 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 // for the case when backup-restore becomes leading sidecar.
 func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Context, handler *HTTPHandler, ssr *snapshotter.Snapshotter, ss brtypes.SnapStore, ssrStopCh chan struct{}, ackCh chan struct{}) {
 	var (
-		err                       error
-		initialDeltaSnapshotTaken bool
+		err                      error
+		initialFullSnapshotTaken bool
 	)
 
 	for {
@@ -354,8 +354,31 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 			// is taken and the regular snapshot schedule comes into effect.
 
 			fullSnapshotMaxTimeWindowInHours := ssr.GetFullSnapshotMaxTimeWindow(b.config.SnapshotterConfig.FullSnapshotSchedule)
-			initialDeltaSnapshotTaken = false
-			if ssr.PrevFullSnapshot != nil && !ssr.PrevFullSnapshot.IsFinal && !ssr.WasScheduledFullSnapshotMissed(fullSnapshotMaxTimeWindowInHours) && !ssr.IsNextFullSnapCrossTimeWindow(fullSnapshotMaxTimeWindowInHours) {
+			initialFullSnapshotTaken = false
+			if ssr.PrevFullSnapshot == nil || ssr.PrevFullSnapshot.IsFinal || ssr.IsTakingFullSnapRequiresAtStartup(fullSnapshotMaxTimeWindowInHours) {
+				// need to take a full snapshot here
+				var snapshot *brtypes.Snapshot
+				metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: brtypes.SnapshotKindDelta}).Set(0)
+				metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: brtypes.SnapshotKindFull}).Set(1)
+				if snapshot, err = ssr.TakeFullSnapshotAndResetTimer(false); err != nil {
+					metrics.SnapshotterOperationFailure.With(prometheus.Labels{metrics.LabelError: err.Error()}).Inc()
+					b.logger.Errorf("Failed to take substitute first full snapshot: %v", err)
+					continue
+				}
+				initialFullSnapshotTaken = true
+				if b.config.HealthConfig.SnapshotLeaseRenewalEnabled {
+					leaseUpdatectx, cancel := context.WithTimeout(ctx, brtypes.LeaseUpdateTimeoutDuration)
+					defer cancel()
+					if err = heartbeat.FullSnapshotCaseLeaseUpdate(leaseUpdatectx, b.logger, snapshot, ssr.K8sClientset, b.config.HealthConfig.FullSnapshotLeaseName, b.config.HealthConfig.DeltaSnapshotLeaseName); err != nil {
+						b.logger.Warnf("Snapshot lease update failed : %v", err)
+					}
+				}
+				if b.backoffConfig.Start {
+					b.backoffConfig.ResetExponentialBackoff()
+				}
+			}
+
+			if !initialFullSnapshotTaken {
 				ssrStopped, err := ssr.CollectEventsSincePrevSnapshot(ssrStopCh)
 				if ssrStopped {
 					b.logger.Info("Snapshotter stopped.")
@@ -368,7 +391,6 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 						b.logger.Warnf("Failed to take first delta snapshot: snapshotter failed with error: %v", err)
 						continue
 					}
-					initialDeltaSnapshotTaken = true
 					if b.config.HealthConfig.SnapshotLeaseRenewalEnabled {
 						leaseUpdatectx, cancel := context.WithTimeout(ctx, brtypes.LeaseUpdateTimeoutDuration)
 						defer cancel()
@@ -384,28 +406,6 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 				}
 			}
 
-			if !initialDeltaSnapshotTaken {
-				// need to take a full snapshot here
-				var snapshot *brtypes.Snapshot
-				metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: brtypes.SnapshotKindDelta}).Set(0)
-				metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: brtypes.SnapshotKindFull}).Set(1)
-				if snapshot, err = ssr.TakeFullSnapshotAndResetTimer(false); err != nil {
-					metrics.SnapshotterOperationFailure.With(prometheus.Labels{metrics.LabelError: err.Error()}).Inc()
-					b.logger.Errorf("Failed to take substitute first full snapshot: %v", err)
-					continue
-				}
-				if b.config.HealthConfig.SnapshotLeaseRenewalEnabled {
-					leaseUpdatectx, cancel := context.WithTimeout(ctx, brtypes.LeaseUpdateTimeoutDuration)
-					defer cancel()
-					if err = heartbeat.FullSnapshotCaseLeaseUpdate(leaseUpdatectx, b.logger, snapshot, ssr.K8sClientset, b.config.HealthConfig.FullSnapshotLeaseName, b.config.HealthConfig.DeltaSnapshotLeaseName); err != nil {
-						b.logger.Warnf("Snapshot lease update failed : %v", err)
-					}
-				}
-				if b.backoffConfig.Start {
-					b.backoffConfig.ResetExponentialBackoff()
-				}
-			}
-
 			// Set snapshotter state to Active
 			ssr.SetSnapshotterActive()
 
@@ -416,7 +416,7 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 
 			// Start snapshotter
 			b.logger.Infof("Starting snapshotter...")
-			startWithFullSnapshot := ssr.PrevFullSnapshot == nil || ssr.PrevFullSnapshot.IsFinal || ssr.WasScheduledFullSnapshotMissed(fullSnapshotMaxTimeWindowInHours) || ssr.IsNextFullSnapCrossTimeWindow(fullSnapshotMaxTimeWindowInHours)
+			startWithFullSnapshot := ssr.PrevFullSnapshot == nil || ssr.PrevFullSnapshot.IsFinal || ssr.IsTakingFullSnapRequiresAtStartup(fullSnapshotMaxTimeWindowInHours)
 			if err := ssr.Run(ssrStopCh, startWithFullSnapshot); err != nil {
 				if etcdErr, ok := err.(*errors.EtcdError); ok {
 					metrics.SnapshotterOperationFailure.With(prometheus.Labels{metrics.LabelError: etcdErr.Error()}).Inc()

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -353,16 +353,12 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 			// the delta snapshot memory limit), after which a full snapshot
 			// is taken and the regular snapshot schedule comes into effect.
 
-			// TODO: write code to find out if prev full snapshot is older than it is
-			// supposed to be, according to the given cron schedule, instead of the
-			// hard-coded "24 hours" full snapshot interval
-
 			// Temporary fix for missing alternate full snapshots for Gardener shoots
 			// with hibernation schedule set: change value from 24 ot 23.5 to
 			// accommodate for slight pod spin-up delays on shoot wake-up
 			const recentFullSnapshotPeriodInHours = 23.5
 			initialDeltaSnapshotTaken = false
-			if ssr.PrevFullSnapshot != nil && !ssr.PrevFullSnapshot.IsFinal && time.Since(ssr.PrevFullSnapshot.CreatedOn).Hours() <= recentFullSnapshotPeriodInHours {
+			if ssr.PrevFullSnapshot != nil && !ssr.PrevFullSnapshot.IsFinal && !ssr.IsScheduledFullSnapshotMissed() {
 				ssrStopped, err := ssr.CollectEventsSincePrevSnapshot(ssrStopCh)
 				if ssrStopped {
 					b.logger.Info("Snapshotter stopped.")

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -355,7 +355,7 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 
 			fullSnapshotMaxTimeWindowInHours := ssr.GetFullSnapshotMaxTimeWindow(b.config.SnapshotterConfig.FullSnapshotSchedule)
 			initialFullSnapshotTaken = false
-			if ssr.IsTakingFullSnapRequiresAtStartup(fullSnapshotMaxTimeWindowInHours) {
+			if ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotMaxTimeWindowInHours) {
 				// need to take a full snapshot here
 				var snapshot *brtypes.Snapshot
 				metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: brtypes.SnapshotKindDelta}).Set(0)
@@ -416,7 +416,7 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 
 			// Start snapshotter
 			b.logger.Infof("Starting snapshotter...")
-			startWithFullSnapshot := ssr.IsTakingFullSnapRequiresAtStartup(fullSnapshotMaxTimeWindowInHours)
+			startWithFullSnapshot := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotMaxTimeWindowInHours)
 			if err := ssr.Run(ssrStopCh, startWithFullSnapshot); err != nil {
 				if etcdErr, ok := err.(*errors.EtcdError); ok {
 					metrics.SnapshotterOperationFailure.With(prometheus.Labels{metrics.LabelError: etcdErr.Error()}).Inc()

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -355,7 +355,7 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 
 			fullSnapshotMaxTimeWindowInHours := ssr.GetFullSnapshotMaxTimeWindow(b.config.SnapshotterConfig.FullSnapshotSchedule)
 			initialFullSnapshotTaken = false
-			if ssr.PrevFullSnapshot == nil || ssr.PrevFullSnapshot.IsFinal || ssr.IsTakingFullSnapRequiresAtStartup(fullSnapshotMaxTimeWindowInHours) {
+			if ssr.IsTakingFullSnapRequiresAtStartup(fullSnapshotMaxTimeWindowInHours) {
 				// need to take a full snapshot here
 				var snapshot *brtypes.Snapshot
 				metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: brtypes.SnapshotKindDelta}).Set(0)
@@ -416,7 +416,7 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 
 			// Start snapshotter
 			b.logger.Infof("Starting snapshotter...")
-			startWithFullSnapshot := ssr.PrevFullSnapshot == nil || ssr.PrevFullSnapshot.IsFinal || ssr.IsTakingFullSnapRequiresAtStartup(fullSnapshotMaxTimeWindowInHours)
+			startWithFullSnapshot := ssr.IsTakingFullSnapRequiresAtStartup(fullSnapshotMaxTimeWindowInHours)
 			if err := ssr.Run(ssrStopCh, startWithFullSnapshot); err != nil {
 				if etcdErr, ok := err.(*errors.EtcdError); ok {
 					metrics.SnapshotterOperationFailure.With(prometheus.Labels{metrics.LabelError: etcdErr.Error()}).Inc()

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -753,7 +753,7 @@ func (ssr *Snapshotter) checkSnapstoreSecretUpdate() bool {
 
 // IsTakingFullSnapRequiresAtStartup checks whether to take a full-snapshot or not during startup of backup-restore.
 func (ssr *Snapshotter) IsTakingFullSnapRequiresAtStartup(timeWindow float64) bool {
-	if time.Since(ssr.PrevFullSnapshot.CreatedOn).Hours() > timeWindow {
+	if ssr.PrevFullSnapshot == nil || ssr.PrevFullSnapshot.IsFinal || time.Since(ssr.PrevFullSnapshot.CreatedOn).Hours() > timeWindow {
 		return true
 	}
 

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -793,11 +793,11 @@ func (ssr *Snapshotter) GetFullSnapshotMaxTimeWindow(fullSnapScheduleSpec string
 		return defaultFullSnapMaxTimeWindow
 	}
 
-	if schedule[dayOfMonth] == "*" && schedule[dayOfWeek] == "*" && !strings.Contains(schedule[hour], "/") {
-		return defaultFullSnapMaxTimeWindow
-	} else if schedule[dayOfWeek] != "*" {
+	if schedule[dayOfWeek] != "*" {
 		return defaultFullSnapMaxTimeWindow * 7
-	} else if schedule[dayOfMonth] == "*" && schedule[dayOfWeek] == "*" && strings.Contains(schedule[hour], "/") {
+	}
+
+	if schedule[dayOfMonth] == "*" && schedule[dayOfWeek] == "*" && strings.Contains(schedule[hour], "/") {
 		if timeWindow, err := strconv.ParseFloat(schedule[hour][strings.Index(schedule[hour], "/")+1:], 64); err == nil {
 			return timeWindow
 		}

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -745,7 +745,7 @@ func (ssr *Snapshotter) checkSnapstoreSecretUpdate() bool {
 	return true
 }
 
-// IsScheduledFullSnapshotMissed checked whether the last scheduled full-snapshot was missed or not.
+// IsScheduledFullSnapshotMissed checked whether the last scheduled full-snapshot is missed or scheduled full-snapshot can be missed.
 func (ssr *Snapshotter) IsScheduledFullSnapshotMissed() bool {
 	if time.Since(ssr.PrevFullSnapshot.CreatedOn).Hours() > recentFullSnapshotPeriodInHours {
 		return true
@@ -759,5 +759,6 @@ func (ssr *Snapshotter) IsScheduledFullSnapshotMissed() bool {
 		return false
 	}
 
+	// to check whether schedule full-snapshot can be missed.
 	return timeLeftToTakeNextSnap.Hours()+time.Since(ssr.PrevFullSnapshot.CreatedOn).Hours() > recentFullSnapshotPeriodInHours
 }

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -792,10 +793,14 @@ func (ssr *Snapshotter) GetFullSnapshotMaxTimeWindow(fullSnapScheduleSpec string
 		return defaultFullSnapMaxTimeWindow
 	}
 
-	if schedule[dayOfMonth] == "*" && schedule[dayOfWeek] == "*" {
+	if schedule[dayOfMonth] == "*" && schedule[dayOfWeek] == "*" && !strings.Contains(schedule[hour], "/") {
 		return defaultFullSnapMaxTimeWindow
 	} else if schedule[dayOfWeek] != "*" {
 		return defaultFullSnapMaxTimeWindow * 7
+	} else if schedule[dayOfMonth] == "*" && schedule[dayOfWeek] == "*" && strings.Contains(schedule[hour], "/") {
+		if timeWindow, err := strconv.ParseFloat(schedule[hour][strings.Index(schedule[hour], "/")+1:], 64); err == nil {
+			return timeWindow
+		}
 	}
 
 	return defaultFullSnapMaxTimeWindow

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -768,7 +768,6 @@ func (ssr *Snapshotter) WasScheduledFullSnapshotMissed(timeWindow float64) bool 
 	now := time.Now()
 	nextSnapSchedule := ssr.schedule.Next(now)
 
-	ssr.logger.Infof(" previous schedule: %v", miscellaneous.GetPrevScheduledSnapTime(nextSnapSchedule, timeWindow))
 	if miscellaneous.GetPrevScheduledSnapTime(nextSnapSchedule, timeWindow) == ssr.PrevFullSnapshot.CreatedOn {
 		ssr.logger.Info("previous full snapshot was taken at scheduled time, skipping the full snapshot at startup")
 		return false

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -334,6 +334,94 @@ var _ = Describe("Snapshotter", func() {
 				})
 			})
 		})
+	})
+
+	Describe("Scenarios to take full-snapshot during startup", func() {
+		var (
+			ssr         *Snapshotter
+			currentMin  int
+			currentHour int
+		)
+		BeforeEach(func() {
+			currentHour = time.Now().Hour()
+			currentMin = time.Now().Minute()
+			snapstoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, "default.bkp")}
+			store, err = snapstore.GetSnapstore(snapstoreConfig)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		Context("Previous full snapshot was taken more than 24hrs before, so FullSnapshot missed", func() {
+			It("should return true", func() {
+				snapshotterConfig := &brtypes.SnapshotterConfig{
+					FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", (currentMin+1)%60, (currentHour+2)%24),
+				}
+
+				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// Previous full snapshot was taken 2 days before
+				ssr.PrevFullSnapshot = &brtypes.Snapshot{
+					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day()-2, currentHour, currentMin, 0, 0, time.Local),
+				}
+				isFullSnapMissed := ssr.IsScheduledFullSnapshotMissed()
+				Expect(isFullSnapMissed).Should(BeTrue())
+			})
+		})
+
+		Context("Previous full snapshot was taken exactly at scheduled snapshot time, no FullSnapshot missed", func() {
+			It("should return false", func() {
+				snapshotterConfig := &brtypes.SnapshotterConfig{
+					FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", (currentMin+1)%60, (currentHour+2)%24),
+				}
+
+				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// Previous full snapshot was taken 1 days before at exactly at scheduled time
+				ssr.PrevFullSnapshot = &brtypes.Snapshot{
+					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day()-1, (currentHour+2)%24, (currentMin+1)%60, 0, 0, time.Local),
+				}
+				isFullSnapMissed := ssr.IsScheduledFullSnapshotMissed()
+				Expect(isFullSnapMissed).Should(BeFalse())
+			})
+		})
+
+		Context("Previous snapshot was taken within 24hrs and not gonna missed schedule fullsnapshot", func() {
+			It("should return false", func() {
+				scheduleHour := (currentHour + 4) % 24
+				snapshotterConfig := &brtypes.SnapshotterConfig{
+					FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", currentMin, scheduleHour),
+				}
+
+				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// Previous full snapshot was taken 4hrs 10 mins before startup
+				ssr.PrevFullSnapshot = &brtypes.Snapshot{
+					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), (currentHour-4)%24, (currentMin-10)%60, 0, 0, time.Local),
+				}
+				isFullSnapMissed := ssr.IsScheduledFullSnapshotMissed()
+				Expect(isFullSnapMissed).Should(BeFalse())
+			})
+		})
+
+		Context("Previous snapshot was taken within 24hrs and gonna miss 24hrs of schedule fullsnapshot window", func() {
+			It("should return true", func() {
+				scheduleHour := (currentHour + 8) % 24
+				snapshotterConfig := &brtypes.SnapshotterConfig{
+					FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", currentMin, scheduleHour),
+				}
+
+				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// Previous full snapshot was taken 18hrs(<24hrs) before startup
+				ssr.PrevFullSnapshot = &brtypes.Snapshot{
+					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), (currentHour-18)%24, (currentMin)%60, 0, 0, time.Local),
+				}
+				isFullSnapMissed := ssr.IsScheduledFullSnapshotMissed()
+				Expect(isFullSnapMissed).Should(BeTrue())
+			})
+		})
 
 		Context("##GarbageCollector", func() {
 			var (

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -704,7 +704,7 @@ var _ = Describe("Snapshotter", func() {
 			fullSnapshotTimeWindow float64
 		)
 		BeforeEach(func() {
-			fullSnapshotTimeWindow = 23.5
+			fullSnapshotTimeWindow = 24
 			currentHour = time.Now().Hour()
 			currentMin = time.Now().Minute()
 			snapstoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, "default.bkp")}

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -738,6 +738,22 @@ var _ = Describe("Snapshotter", func() {
 				Expect(timeWindow).Should(Equal(fullSnapshotTimeWindow * 7))
 			})
 		})
+
+		Context("Full snapshot schedule for every 4 hours", func() {
+			It("should return 4 hours of timeWindow", func() {
+				// every 4 hour
+				scheduleHour := 4
+				snapshotterConfig := &brtypes.SnapshotterConfig{
+					FullSnapshotSchedule: fmt.Sprintf("%d */%d * * *", 0, scheduleHour),
+				}
+
+				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				timeWindow := ssr.GetFullSnapshotMaxTimeWindow(snapshotterConfig.FullSnapshotSchedule)
+				Expect(timeWindow).Should(Equal(float64(scheduleHour)))
+			})
+		})
 	})
 
 })

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -338,18 +338,20 @@ var _ = Describe("Snapshotter", func() {
 
 	Describe("Scenarios to take full-snapshot during startup", func() {
 		var (
-			ssr         *Snapshotter
-			currentMin  int
-			currentHour int
+			ssr                    *Snapshotter
+			currentMin             int
+			currentHour            int
+			fullSnapshotTimeWindow float64
 		)
 		BeforeEach(func() {
+			fullSnapshotTimeWindow = 24
 			currentHour = time.Now().Hour()
 			currentMin = time.Now().Minute()
 			snapstoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, "default.bkp")}
 			store, err = snapstore.GetSnapstore(snapstoreConfig)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
-		Context("Previous full snapshot was taken more than 24hrs before, so FullSnapshot missed", func() {
+		Context("Previous full snapshot was taken more than 24hrs before", func() {
 			It("should return true", func() {
 				snapshotterConfig := &brtypes.SnapshotterConfig{
 					FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", (currentMin+1)%60, (currentHour+2)%24),
@@ -362,12 +364,12 @@ var _ = Describe("Snapshotter", func() {
 				ssr.PrevFullSnapshot = &brtypes.Snapshot{
 					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day()-2, currentHour, currentMin, 0, 0, time.Local),
 				}
-				isFullSnapMissed := ssr.IsScheduledFullSnapshotMissed()
+				isFullSnapMissed := ssr.WasScheduledFullSnapshotMissed(fullSnapshotTimeWindow)
 				Expect(isFullSnapMissed).Should(BeTrue())
 			})
 		})
 
-		Context("Previous full snapshot was taken exactly at scheduled snapshot time, no FullSnapshot missed", func() {
+		Context("Previous full snapshot was taken exactly at scheduled snapshot time, no FullSnapshot was missed", func() {
 			It("should return false", func() {
 				snapshotterConfig := &brtypes.SnapshotterConfig{
 					FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", (currentMin+1)%60, (currentHour+2)%24),
@@ -380,12 +382,12 @@ var _ = Describe("Snapshotter", func() {
 				ssr.PrevFullSnapshot = &brtypes.Snapshot{
 					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day()-1, (currentHour+2)%24, (currentMin+1)%60, 0, 0, time.Local),
 				}
-				isFullSnapMissed := ssr.IsScheduledFullSnapshotMissed()
+				isFullSnapMissed := ssr.WasScheduledFullSnapshotMissed(fullSnapshotTimeWindow)
 				Expect(isFullSnapMissed).Should(BeFalse())
 			})
 		})
 
-		Context("Previous snapshot was taken within 24hrs and not gonna missed schedule fullsnapshot", func() {
+		Context("Previous snapshot was taken within 24hrs and next schedule full-snapshot will be taken within 24hs of time window", func() {
 			It("should return false", func() {
 				scheduleHour := (currentHour + 4) % 24
 				snapshotterConfig := &brtypes.SnapshotterConfig{
@@ -395,16 +397,16 @@ var _ = Describe("Snapshotter", func() {
 				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				// Previous full snapshot was taken 4hrs 10 mins before startup
+				// Previous full snapshot was taken 4hrs 10 mins before startup of backup-restore
 				ssr.PrevFullSnapshot = &brtypes.Snapshot{
 					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), (currentHour-4)%24, (currentMin-10)%60, 0, 0, time.Local),
 				}
-				isFullSnapMissed := ssr.IsScheduledFullSnapshotMissed()
+				isFullSnapMissed := ssr.IsNextFullSnapCrossTimeWindow(fullSnapshotTimeWindow)
 				Expect(isFullSnapMissed).Should(BeFalse())
 			})
 		})
 
-		Context("Previous snapshot was taken within 24hrs and gonna miss 24hrs of schedule fullsnapshot window", func() {
+		Context("Previous snapshot was taken within 24hrs and next schedule full-snapshot can cross 24hs of time window", func() {
 			It("should return true", func() {
 				scheduleHour := (currentHour + 8) % 24
 				snapshotterConfig := &brtypes.SnapshotterConfig{
@@ -414,11 +416,11 @@ var _ = Describe("Snapshotter", func() {
 				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				// Previous full snapshot was taken 18hrs(<24hrs) before startup
+				// Previous full snapshot was taken 18hrs(<24hrs) before startup of backup-restore
 				ssr.PrevFullSnapshot = &brtypes.Snapshot{
 					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), (currentHour-18)%24, (currentMin)%60, 0, 0, time.Local),
 				}
-				isFullSnapMissed := ssr.IsScheduledFullSnapshotMissed()
+				isFullSnapMissed := ssr.IsNextFullSnapCrossTimeWindow(fullSnapshotTimeWindow)
 				Expect(isFullSnapMissed).Should(BeTrue())
 			})
 		})

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -599,7 +599,7 @@ var _ = Describe("Snapshotter", func() {
 
 				// No previous snapshot was taken
 				ssr.PrevFullSnapshot = nil
-				isFullSnapMissed := ssr.IsTakingFullSnapRequiresAtStartup(fullSnapshotTimeWindow)
+				isFullSnapMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
 				Expect(isFullSnapMissed).Should(BeTrue())
 			})
 		})
@@ -616,7 +616,7 @@ var _ = Describe("Snapshotter", func() {
 				ssr.PrevFullSnapshot = &brtypes.Snapshot{
 					IsFinal: true,
 				}
-				isFullSnapMissed := ssr.IsTakingFullSnapRequiresAtStartup(fullSnapshotTimeWindow)
+				isFullSnapMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
 				Expect(isFullSnapMissed).Should(BeTrue())
 			})
 		})
@@ -633,7 +633,7 @@ var _ = Describe("Snapshotter", func() {
 				ssr.PrevFullSnapshot = &brtypes.Snapshot{
 					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day()-2, currentHour, currentMin, 0, 0, time.Local),
 				}
-				isFullSnapMissed := ssr.IsTakingFullSnapRequiresAtStartup(fullSnapshotTimeWindow)
+				isFullSnapMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
 				Expect(isFullSnapMissed).Should(BeTrue())
 			})
 		})
@@ -652,7 +652,7 @@ var _ = Describe("Snapshotter", func() {
 					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day()-1, (currentHour+2)%24, (currentMin+1)%60, 0, 0, time.Local),
 				}
 
-				isFullSnapMissed := ssr.IsTakingFullSnapRequiresAtStartup(fullSnapshotTimeWindow)
+				isFullSnapMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
 				Expect(isFullSnapMissed).Should(BeFalse())
 			})
 		})
@@ -671,7 +671,7 @@ var _ = Describe("Snapshotter", func() {
 				ssr.PrevFullSnapshot = &brtypes.Snapshot{
 					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), (currentHour-4)%24, (currentMin-10)%60, 0, 0, time.Local),
 				}
-				isFullSnapCanBeMissed := ssr.IsTakingFullSnapRequiresAtStartup(fullSnapshotTimeWindow)
+				isFullSnapCanBeMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
 				Expect(isFullSnapCanBeMissed).Should(BeFalse())
 			})
 		})
@@ -690,7 +690,7 @@ var _ = Describe("Snapshotter", func() {
 				ssr.PrevFullSnapshot = &brtypes.Snapshot{
 					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), (currentHour-18)%24, (currentMin)%60, 0, 0, time.Local),
 				}
-				isFullSnapCanBeMissed := ssr.IsTakingFullSnapRequiresAtStartup(fullSnapshotTimeWindow)
+				isFullSnapCanBeMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
 				Expect(isFullSnapCanBeMissed).Should(BeTrue())
 			})
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enhances the condition of checking whether to take a full snapshot or not during startup of backup-restore to avoid missing of any full-snapshot within 24hrs of window.

**Which issue(s) this PR fixes**:
Fixes #570 

**Special notes for your reviewer**:

**Release note**:
```improvement operator
Enhances the decision to take full snapshot during startup of etcd-backup-restore to avoid missing of any full-snapshot.
```
