### PR TITLE
Added support for Application credentials to authenticate openstack.

### DIFF
--- a/example/storage-provider-secrets/02-openstack-swift-storage-secret.yaml
+++ b/example/storage-provider-secrets/02-openstack-swift-storage-secret.yaml
@@ -31,3 +31,45 @@ stringData:
     "tenantName": "admin",
     "username": "admin"
     } 
+
+#### OR ####
+
+--- 
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-backup
+  namespace: example-swift
+type: Opaque
+data:
+  authURL: aHR0cDovL2V4YW1wbGUuY29tL3Yz # http://example.com/v3
+  domainName: ZXhhbXBsZS5jb20= # example.com
+  region: ZXUtbmwtMDA3 # eu-nl-007
+  tenantName: YWRtaW4= # admin
+  applicationCredentialID:  YWRtaW4= # admin
+  applicationCredentialName:  YWRtaW4= # admin
+  applicationCredentialSecret:  c2VjcmV0 # secret
+
+
+#### OR ####
+
+--- 
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-backup
+  namespace: example-json-swift
+type: Opaque
+stringData:
+  secret.json: |-
+    {
+    "authURL": "http://example.com/v3",
+    "domainName": "example.com",
+    "applicationCredentialID": "admin",
+    "applicationCredentialName": "admin",
+    "applicationCredentialSecret": "secret",
+    "region": "eu-nl-007",
+    "tenantName": "admin"
+    } 

--- a/pkg/snapstore/swift_snapstore.go
+++ b/pkg/snapstore/swift_snapstore.go
@@ -304,7 +304,7 @@ func readSwiftCredentialDir(dirName string) (*swiftCredentials, error) {
 		}
 	}
 
-	if err := isSwiftConfigEmpty(cred); err != nil {
+	if err := isSwiftConfigCorrect(cred); err != nil {
 		return nil, err
 	}
 	return cred, nil
@@ -526,8 +526,10 @@ func getSwiftHash(config *swiftCredentials) string {
 	return getHash(data)
 }
 
-func isSwiftConfigEmpty(config *swiftCredentials) error {
-	if config.AuthType == authTypePassword {
+func isSwiftConfigCorrect(config *swiftCredentials) error {
+	if (len(config.ApplicationCredentialSecret) != 0 || len(config.ApplicationCredentialID) != 0) && (len(config.Password) != 0 || len(config.Username) != 0) {
+		return fmt.Errorf("openstack swift credentials are not passed correctly")
+	} else if config.AuthType == authTypePassword {
 		if len(config.AuthURL) != 0 && len(config.TenantName) != 0 && len(config.Password) != 0 && len(config.Username) != 0 && len(config.DomainName) != 0 {
 			return nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for passing [Application credentials](https://docs.openstack.org/keystone/latest/user/application_credentials.html) to authenticate Openstack.
This PR supports the backward compatibility, it doesn't removes the old way(username/password) of passing Openstack credentials.

**Which issue(s) this PR fixes**:
Fixes #575 

**Special notes for your reviewer**:

**Release note**:
```noteworthy operator
Added support for Application credentials to authenticate Openstack client for Openstack backup buckets.
```
