### PR TITLE
Update `k8s.io/client-go` to a human-readable version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	k8s.io/api v0.20.6
 	k8s.io/apiextensions-apiserver v0.20.6 // indirect
 	k8s.io/apimachinery v0.20.6
-	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
+	k8s.io/client-go v0.20.6
 	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009
 	sigs.k8s.io/controller-runtime v0.8.3
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1146,7 +1146,7 @@ k8s.io/cli-runtime/pkg/kustomize/k8sdeps/transformer/patch
 k8s.io/cli-runtime/pkg/kustomize/k8sdeps/validator
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
-# k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible => k8s.io/client-go v0.19.6
+# k8s.io/client-go v0.20.6 => k8s.io/client-go v0.19.6
 ## explicit; go 1.15
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached/disk


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:
This change does not really change the `k8s.io/client-go` version as there is a replace directive to ping the dependency to v0.19.6:

https://github.com/gardener/etcd-backup-restore/blob/c12013e0773e0adc6264e15ecc752663a7195258/go.mod#L183-L201

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6807

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
