### PR TITLE
Update member_control.go

### DIFF
--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -178,7 +178,7 @@ func getMemberPeerURL(configFile string, podName string) (string, error) {
 	}
 	initAdPeerURL := config["initial-advertise-peer-urls"]
 	if initAdPeerURL == nil {
-		return "", errors.New("initial-advertise-peer-urls must be set in etcd config.")
+		return "", errors.New("initial-advertise-peer-urls must be set in etcd config")
 	}
 	peerURL, err := miscellaneous.ParsePeerURL(initAdPeerURL.(string), podName)
 	if err != nil {

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -177,6 +177,9 @@ func getMemberPeerURL(configFile string, podName string) (string, error) {
 		return "", err
 	}
 	initAdPeerURL := config["initial-advertise-peer-urls"]
+	if initAdPeerURL == nil {
+		return "", fmt.Errorf("initial-advertise-peer-urls must be set in etcd config.", err)
+	}
 	peerURL, err := miscellaneous.ParsePeerURL(initAdPeerURL.(string), podName)
 	if err != nil {
 		return "", fmt.Errorf("could not parse peer URL from the config file : %v", err)

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -178,7 +178,7 @@ func getMemberPeerURL(configFile string, podName string) (string, error) {
 	}
 	initAdPeerURL := config["initial-advertise-peer-urls"]
 	if initAdPeerURL == nil {
-		return "", fmt.Errorf("initial-advertise-peer-urls must be set in etcd config.", err)
+		return "", errors.New("initial-advertise-peer-urls must be set in etcd config.")
 	}
 	peerURL, err := miscellaneous.ParsePeerURL(initAdPeerURL.(string), podName)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds an error message and catches an avoidable crash.

**Special notes for your reviewer**:
In case "initial-advertise-peer-urls" is not set in the etcd config, the controller crashes with a panic because it tries to call the string function of a nil-pointer. With this PR you get a quick hint what needs to be changed.

**Release note**:
<!--  Write your release note:
NONE


Format of block header: <category> <target_group>
Possible values:
- category:       improvement
- target_group:   user
-->
```improvement user
Better error message if setting in etcd config is missing
```
