### PR TITLE
Update to golang 1.19.5, alpine 3.15.7

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -42,13 +42,13 @@ etcd-backup-restore:
                 build: ~
     steps:
       check:
-        image: 'golang:1.19.3'
+        image: 'golang:1.19.5'
       unit_test:
-        image: 'golang:1.19.3'
+        image: 'golang:1.19.5'
       integration_test:
         image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'
       build:
-        image: 'golang:1.19.3'
+        image: 'golang:1.19.5'
         output_dir: 'binary'
 
   jobs:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19.3 as builder 
+FROM golang:1.19.5 as builder
 
 WORKDIR /go/src/github.com/gardener/backup-restore
 COPY . .
 
 RUN make build
 
-FROM alpine:3.15.6 
+FROM alpine:3.15.7
 
 RUN apk add --update bash curl
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates golang to `1.19.5` and alpine to `3.15.7`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Update alpine base image to `3.15.7`.
```
```noteworthy developer
Update golang build version to `1.19.5`.
```

