### PR TITLE
Cherry-pick of #PR600

### DIFF
--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -307,8 +307,8 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 // for the case when backup-restore becomes leading sidecar.
 func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Context, handler *HTTPHandler, ssr *snapshotter.Snapshotter, ss brtypes.SnapStore, ssrStopCh chan struct{}, ackCh chan struct{}) {
 	var (
-		err                      error
-		initialFullSnapshotTaken bool
+		err                       error
+		initialDeltaSnapshotTaken bool
 	)
 
 	for {
@@ -354,31 +354,8 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 			// is taken and the regular snapshot schedule comes into effect.
 
 			fullSnapshotMaxTimeWindowInHours := ssr.GetFullSnapshotMaxTimeWindow(b.config.SnapshotterConfig.FullSnapshotSchedule)
-			initialFullSnapshotTaken = false
-			if ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotMaxTimeWindowInHours) {
-				// need to take a full snapshot here
-				var snapshot *brtypes.Snapshot
-				metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: brtypes.SnapshotKindDelta}).Set(0)
-				metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: brtypes.SnapshotKindFull}).Set(1)
-				if snapshot, err = ssr.TakeFullSnapshotAndResetTimer(false); err != nil {
-					metrics.SnapshotterOperationFailure.With(prometheus.Labels{metrics.LabelError: err.Error()}).Inc()
-					b.logger.Errorf("Failed to take substitute first full snapshot: %v", err)
-					continue
-				}
-				initialFullSnapshotTaken = true
-				if b.config.HealthConfig.SnapshotLeaseRenewalEnabled {
-					leaseUpdatectx, cancel := context.WithTimeout(ctx, brtypes.LeaseUpdateTimeoutDuration)
-					defer cancel()
-					if err = heartbeat.FullSnapshotCaseLeaseUpdate(leaseUpdatectx, b.logger, snapshot, ssr.K8sClientset, b.config.HealthConfig.FullSnapshotLeaseName, b.config.HealthConfig.DeltaSnapshotLeaseName); err != nil {
-						b.logger.Warnf("Snapshot lease update failed : %v", err)
-					}
-				}
-				if b.backoffConfig.Start {
-					b.backoffConfig.ResetExponentialBackoff()
-				}
-			}
-
-			if !initialFullSnapshotTaken {
+			initialDeltaSnapshotTaken = false
+			if !ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotMaxTimeWindowInHours) {
 				ssrStopped, err := ssr.CollectEventsSincePrevSnapshot(ssrStopCh)
 				if ssrStopped {
 					b.logger.Info("Snapshotter stopped.")
@@ -391,6 +368,7 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 						b.logger.Warnf("Failed to take first delta snapshot: snapshotter failed with error: %v", err)
 						continue
 					}
+					initialDeltaSnapshotTaken = true
 					if b.config.HealthConfig.SnapshotLeaseRenewalEnabled {
 						leaseUpdatectx, cancel := context.WithTimeout(ctx, brtypes.LeaseUpdateTimeoutDuration)
 						defer cancel()
@@ -403,6 +381,29 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 					}
 				} else {
 					b.logger.Warnf("Failed to collect events for first delta snapshot(s): %v", err)
+				}
+			}
+
+			if !initialDeltaSnapshotTaken {
+				// need to take a full snapshot here
+				// if initial deltaSnapshot is not taken
+				var snapshot *brtypes.Snapshot
+				metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: brtypes.SnapshotKindDelta}).Set(0)
+				metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: brtypes.SnapshotKindFull}).Set(1)
+				if snapshot, err = ssr.TakeFullSnapshotAndResetTimer(false); err != nil {
+					metrics.SnapshotterOperationFailure.With(prometheus.Labels{metrics.LabelError: err.Error()}).Inc()
+					b.logger.Errorf("Failed to take substitute first full snapshot: %v", err)
+					continue
+				}
+				if b.config.HealthConfig.SnapshotLeaseRenewalEnabled {
+					leaseUpdatectx, cancel := context.WithTimeout(ctx, brtypes.LeaseUpdateTimeoutDuration)
+					defer cancel()
+					if err = heartbeat.FullSnapshotCaseLeaseUpdate(leaseUpdatectx, b.logger, snapshot, ssr.K8sClientset, b.config.HealthConfig.FullSnapshotLeaseName, b.config.HealthConfig.DeltaSnapshotLeaseName); err != nil {
+						b.logger.Warnf("Snapshot lease update failed : %v", err)
+					}
+				}
+				if b.backoffConfig.Start {
+					b.backoffConfig.ResetExponentialBackoff()
 				}
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick of https://github.com/gardener/etcd-backup-restore/commit/b980beecb81485314c721500b3e51efefddc8af2

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix operator
Fixes a bug in snapshotter loop when backup-restore fails to collect events or fails to apply watch if required etcd revision has been compacted.
```
