### PR TITLE
Restrict `safe_guard` file permissions

### DIFF
--- a/pkg/initializer/validator/datavalidator.go
+++ b/pkg/initializer/validator/datavalidator.go
@@ -101,7 +101,7 @@ func (d *DataValidator) sanityCheck(failBelowRevision int64) (DataDirStatus, err
 		if _, err := os.Stat(path); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				data := []byte(namespace)
-				err := os.WriteFile(path, data, 0644)
+				err := os.WriteFile(path, data, 0600)
 				if err != nil {
 					d.Logger.Fatalf("can't create `safe_guard` file because : %v", err)
 				}

--- a/pkg/initializer/validator/datavalidator_test.go
+++ b/pkg/initializer/validator/datavalidator_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Running Datavalidator", func() {
 			// change the content of safe_guard file to indicate wrong volume mount
 			path := outputDir + "/" + "safe_guard"
 			data := []byte("abcd")
-			err = os.WriteFile(path, data, 0644)
+			err = os.WriteFile(path, data, 0600)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			dataDirStatus, err := validator.Validate(Sanity, 0)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the file permissions of `safe_guard` file from 644 to 600. The `etcd` pods must have file permissions set to 600 or more restrictive.
This PR is in sync with Kubernetes' STIG.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Restrict the file permissions of `safe_guard` file from 644 to 600.
```
