### PR TITLE
Enhancing the scale-up detection conditions.

### DIFF
--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -69,8 +69,6 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 			}
 			// return here after adding non-voting member(learner) as no restoration or validation needed
 			return nil
-		} else if err != nil {
-			return err
 		}
 	}
 

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -54,7 +54,7 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 	//Etcd cluster scale-up case
 	if miscellaneous.IsMultiNode(e.Logger.WithField("actor", "initializer")) {
 		m := member.NewMemberControl(e.Config.EtcdConnectionConfig)
-		isScaleup, err := member.IsScaleup(ctx, m)
+		isScaleup, err := m.IsClusterScaledup(ctx)
 		if isScaleup && err == nil {
 			retry.OnError(retry.DefaultBackoff, errors.AnyError, func() error {
 				return m.AddMemberAsLearner(ctx)

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -62,11 +62,9 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 		m := member.NewMemberControl(e.Config.EtcdConnectionConfig)
 		isScaleup, err := m.IsClusterScaledUp(ctx, clientSet)
 		if isScaleup && err == nil {
-			if err := retry.OnError(retry.DefaultBackoff, errors.AnyError, func() error {
+			retry.OnError(retry.DefaultBackoff, errors.AnyError, func() error {
 				return m.AddMemberAsLearner(ctx)
-			}); err != nil {
-				logger.Fatalf("Cluster scale-up detected but unable to add new member as learner: %v", err)
-			}
+			})
 			// return here after adding non-voting member(learner) as no restoration or validation needed
 			return nil
 		}

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -52,15 +52,10 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 	ctx := context.Background()
 	var err error
 
-	clientSet, err := miscellaneous.GetKubernetesClientSetOrError()
-	if err != nil {
-		logger.Fatalf("failed to create clientset, %v", err)
-	}
-
 	//Etcd cluster scale-up case
 	if miscellaneous.IsMultiNode(logger) {
 		m := member.NewMemberControl(e.Config.EtcdConnectionConfig)
-		isScaleup, err := m.IsClusterScaledUp(ctx, clientSet)
+		isScaleup, err := m.IsClusterScaledUp(ctx)
 		if isScaleup && err == nil {
 			retry.OnError(retry.DefaultBackoff, errors.AnyError, func() error {
 				return m.AddMemberAsLearner(ctx)

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -60,7 +60,7 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 	//Etcd cluster scale-up case
 	if miscellaneous.IsMultiNode(logger) {
 		m := member.NewMemberControl(e.Config.EtcdConnectionConfig)
-		isScaleup, err := m.IsClusterScaledup(ctx, clientSet)
+		isScaleup, err := m.IsClusterScaledUp(ctx, clientSet)
 		if isScaleup && err == nil {
 			if err := retry.OnError(retry.DefaultBackoff, errors.AnyError, func() error {
 				return m.AddMemberAsLearner(ctx)
@@ -69,6 +69,8 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 			}
 			// return here after adding non-voting member(learner) as no restoration or validation needed
 			return nil
+		} else if err != nil {
+			return err
 		}
 	}
 

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -325,8 +325,8 @@ func (m *memberControl) IsClusterScaledUp(ctx context.Context, clientSet client.
 	}
 
 	isEtcdMemberPresent, err := m.IsMemberInCluster(ctx)
-	if err != nil || isEtcdMemberPresent {
+	if err != nil {
 		return false, err
 	}
-	return true, nil
+	return !isEtcdMemberPresent, nil
 }

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -18,7 +18,7 @@ import (
 	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
 	"go.etcd.io/etcd/etcdserver/etcdserverpb"
 	"k8s.io/client-go/util/retry"
-	//"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -43,7 +43,7 @@ type Control interface {
 	AddMemberAsLearner(context.Context) error
 
 	// IsClusterScaledUp determines whether a etcd cluster is getting scale-up or not.
-	IsClusterScaledUp(context.Context) (bool, error)
+	IsClusterScaledUp(context.Context, client.Client) (bool, error)
 
 	// IsMemberInCluster checks is the current members peer URL is already part of the etcd cluster
 	IsMemberInCluster(context.Context) (bool, error)
@@ -316,12 +316,7 @@ func (m *memberControl) IsLearnerPresent(ctx context.Context) (bool, error) {
 }
 
 // IsClusterScaledUp determines whether a etcd cluster is getting scale-up or not and returns a boolean
-func (m *memberControl) IsClusterScaledUp(ctx context.Context) (bool, error) {
-	clientSet, err := miscellaneous.GetKubernetesClientSetOrError()
-	if err != nil {
-		m.logger.Fatalf("failed to create clientset, %v", err)
-	}
-
+func (m *memberControl) IsClusterScaledUp(ctx context.Context, clientSet client.Client) (bool, error) {
 	state, err := miscellaneous.GetInitialClusterStateIfScaleup(ctx, m.logger, clientSet, m.podName, m.podNamespace)
 	if err != nil {
 		m.logger.Errorf("annotation: %v is not present: %v", miscellaneous.ScaledToMultiNodeAnnotationKey, err)

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -18,7 +18,7 @@ import (
 	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
 	"go.etcd.io/etcd/etcdserver/etcdserverpb"
 	"k8s.io/client-go/util/retry"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	//"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -43,7 +43,7 @@ type Control interface {
 	AddMemberAsLearner(context.Context) error
 
 	// IsClusterScaledUp determines whether a etcd cluster is getting scale-up or not.
-	IsClusterScaledUp(context.Context, client.Client) (bool, error)
+	IsClusterScaledUp(context.Context) (bool, error)
 
 	// IsMemberInCluster checks is the current members peer URL is already part of the etcd cluster
 	IsMemberInCluster(context.Context) (bool, error)
@@ -316,7 +316,12 @@ func (m *memberControl) IsLearnerPresent(ctx context.Context) (bool, error) {
 }
 
 // IsClusterScaledUp determines whether a etcd cluster is getting scale-up or not and returns a boolean
-func (m *memberControl) IsClusterScaledUp(ctx context.Context, clientSet client.Client) (bool, error) {
+func (m *memberControl) IsClusterScaledUp(ctx context.Context) (bool, error) {
+	clientSet, err := miscellaneous.GetKubernetesClientSetOrError()
+	if err != nil {
+		m.logger.Fatalf("failed to create clientset, %v", err)
+	}
+
 	state, err := miscellaneous.GetInitialClusterStateIfScaleup(ctx, m.logger, clientSet, m.podName, m.podNamespace)
 	if err != nil {
 		m.logger.Errorf("unable to check scale-up case :%v", err)

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -42,8 +42,8 @@ type Control interface {
 	// AddMemberAsLearner add a new member as a learner to the etcd cluster
 	AddMemberAsLearner(context.Context) error
 
-	// IsClusterScaledup determines whether a etcd cluster is getting scale-up or not.
-	IsClusterScaledup(context.Context, client.Client) (bool, error)
+	// IsClusterScaledUp determines whether a etcd cluster is getting scale-up or not.
+	IsClusterScaledUp(context.Context, client.Client) (bool, error)
 
 	// IsMemberInCluster checks is the current members peer URL is already part of the etcd cluster
 	IsMemberInCluster(context.Context) (bool, error)
@@ -315,8 +315,8 @@ func (m *memberControl) IsLearnerPresent(ctx context.Context) (bool, error) {
 	return miscellaneous.CheckIfLearnerPresent(learnerCtx, cli)
 }
 
-// ClusterScaled determines whether a etcd cluster is getting scale-up or not and returns a boolean
-func (m *memberControl) IsClusterScaledup(ctx context.Context, clientSet client.Client) (bool, error) {
+// IsClusterScaledUp determines whether a etcd cluster is getting scale-up or not and returns a boolean
+func (m *memberControl) IsClusterScaledUp(ctx context.Context, clientSet client.Client) (bool, error) {
 	state, err := miscellaneous.GetInitialClusterStateIfScaleup(ctx, m.logger, clientSet, m.podName, m.podNamespace)
 	if err != nil {
 		m.logger.Errorf("unable to check scale-up case :%v", err)

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -324,14 +324,14 @@ func (m *memberControl) IsClusterScaledUp(ctx context.Context) (bool, error) {
 
 	state, err := miscellaneous.GetInitialClusterStateIfScaleup(ctx, m.logger, clientSet, m.podName, m.podNamespace)
 	if err != nil {
-		m.logger.Errorf("unable to check scale-up case :%v", err)
+		m.logger.Errorf("annotation: %v is not present: %v", miscellaneous.ScaledToMultiNodeAnnotationKey, err)
 	} else if state != nil && *state == miscellaneous.ClusterStateExisting {
 		return true, nil
 	}
 
 	isEtcdMemberPresent, err := m.IsMemberInCluster(ctx)
-	if err != nil {
+	if err != nil || isEtcdMemberPresent {
 		return false, err
 	}
-	return !isEtcdMemberPresent, nil
+	return true, nil
 }

--- a/pkg/member/member_control_test.go
+++ b/pkg/member/member_control_test.go
@@ -24,7 +24,8 @@ var _ = Describe("Membercontrol", func() {
 		cl                   *mockfactory.MockClusterCloser
 	)
 	const (
-		podName = "test-pod"
+		podName      = "test-pod"
+		podNamespace = "test-podnamespace"
 	)
 
 	BeforeEach(func() {
@@ -35,6 +36,7 @@ var _ = Describe("Membercontrol", func() {
 		etcdConnectionConfig.DefragTimeout.Duration = 30 * time.Second
 
 		os.Setenv("POD_NAME", podName)
+		os.Setenv("POD_NAMESPACE", podNamespace)
 
 		ctrl = gomock.NewController(GinkgoT())
 		factory = mockfactory.NewMockFactory(ctrl)
@@ -66,6 +68,7 @@ var _ = Describe("Membercontrol", func() {
 	AfterEach(func() {
 		os.Unsetenv("POD_NAME")
 		os.Unsetenv("ETCD_CONF")
+		os.Unsetenv("POD_NAMESPACE")
 	})
 
 	Describe("Creating NewMemberControl", func() {

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -567,11 +567,12 @@ func GetPrevScheduledSnapTime(nextSnapSchedule time.Time, timeWindow float64) ti
 	)
 }
 
-// GetBackoff returns the backoff with Factor=2
-func GetBackoff(retryPeriod time.Duration, steps int) wait.Backoff {
-	backoff := retry.DefaultBackoff
-	backoff.Duration = retryPeriod
-	backoff.Factor = 2
-	backoff.Steps = steps
-	return backoff
+// CreateBackoff returns the backoff with Factor=2
+func CreateBackoff(retryPeriod time.Duration, steps int) wait.Backoff {
+	return wait.Backoff{
+		Duration: retryPeriod,
+		Factor:   2,
+		Jitter:   retry.DefaultBackoff.Jitter,
+		Steps:    steps,
+	}
 }

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -60,6 +60,9 @@ const (
 	// ClusterStateExisting defines the "existing" state of etcd cluster.
 	ClusterStateExisting = "existing"
 
+	// ScaledToMultiNodeAnnotationKey defines annotation key for scale-up to multi-node cluster.
+	ScaledToMultiNodeAnnotationKey = "gardener.cloud/scaled-to-multi-node"
+
 	https = "https"
 )
 
@@ -420,8 +423,6 @@ func IsBackupBucketEmpty(snapStoreConfig *brtypes.SnapstoreConfig, logger *logru
 	}
 	return true
 }
-
-const ScaledToMultiNodeAnnotationKey = "gardener.cloud/scaled-to-multi-node"
 
 // GetInitialClusterStateIfScaleup checks if it is the Scale-up scenario and returns the cluster state either `new` or `existing`.
 func GetInitialClusterStateIfScaleup(ctx context.Context, logger logrus.Entry, clientSet client.Client, podName string, podNS string) (*string, error) {

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -421,7 +421,7 @@ func IsBackupBucketEmpty(snapStoreConfig *brtypes.SnapstoreConfig, logger *logru
 	return true
 }
 
-const scaledToMultiNodeAnnotationKey = "gardener.cloud/scaled-to-multi-node"
+const ScaledToMultiNodeAnnotationKey = "gardener.cloud/scaled-to-multi-node"
 
 // GetInitialClusterStateIfScaleup checks if it is the Scale-up scenario and returns the cluster state either `new` or `existing`.
 func GetInitialClusterStateIfScaleup(ctx context.Context, logger logrus.Entry, clientSet client.Client, podName string, podNS string) (*string, error) {
@@ -436,7 +436,7 @@ func GetInitialClusterStateIfScaleup(ctx context.Context, logger logrus.Entry, c
 		return nil, err
 	}
 
-	if metav1.HasAnnotation(curSts.ObjectMeta, scaledToMultiNodeAnnotationKey) {
+	if metav1.HasAnnotation(curSts.ObjectMeta, ScaledToMultiNodeAnnotationKey) {
 		return pointer.StringPtr(ClusterStateExisting), nil
 	}
 

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -40,6 +40,8 @@ import (
 	"go.etcd.io/etcd/pkg/types"
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -563,4 +565,13 @@ func GetPrevScheduledSnapTime(nextSnapSchedule time.Time, timeWindow float64) ti
 		nextSnapSchedule.Nanosecond(),
 		nextSnapSchedule.Location(),
 	)
+}
+
+// GetBackoff returns the backoff with Factor=2
+func GetBackoff(retryPeriod time.Duration, steps int) wait.Backoff {
+	backoff := retry.DefaultBackoff
+	backoff.Duration = retryPeriod
+	backoff.Factor = 2
+	backoff.Steps = steps
+	return backoff
 }

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -548,7 +548,7 @@ var _ = Describe("Miscellaneous Tests", func() {
 					UpdatedReplicas: 3,
 				}
 				sts.Annotations = map[string]string{
-					scaledToMultiNodeAnnotationKey: "",
+					ScaledToMultiNodeAnnotationKey: "",
 				}
 			})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the scale-up detection conditions to avoid potential failure while migrating single node etcd to multi-node etcd cluster.

**Which issue(s) this PR fixes**:
Fixes #606 

**Special notes for your reviewer**:


**Release note**:
```improvement operator
Enhances the scale-up detection conditions to avoid potential failure while from migrating single node etcd to multi-node etcd cluster.
```
