### PR TITLE
Fix and optimize restoration of delta snapshots

### DIFF
--- a/.ci/unit_test
+++ b/.ci/unit_test
@@ -71,6 +71,7 @@ if [ -z $COVER ] || [ "$COVER" = false ] ; then
   ginkgo -race -trace $GINKGO_COMMON_FLAGS -gcflags=all=-d=checkptr=0 --randomizeAllSpecs --randomizeSuites --failOnPending --skip="NEGATIVE\:.*" ${TEST_PACKAGES}
 
   if [ "$RUN_NEGATIVE" = "true" ] ; then
+    echo "[INFO] Running negative tests now..."
     #run negative scenario in a sequenced manner (removed failOnPending as one spec in restore test is marked as 'X' for excluding)
     ginkgo -race -trace $GINKGO_COMMON_FLAGS -gcflags=all=-d=checkptr=0 --focus="NEGATIVE\:.*" ${TEST_PACKAGES}
   fi

--- a/pkg/compactor/compactor_suite_test.go
+++ b/pkg/compactor/compactor_suite_test.go
@@ -36,13 +36,13 @@ const (
 )
 
 var (
-	testSuitDir, testEtcdDir, testSnapshotDir string
-	testCtx                                   = context.Background()
-	logger                                    = logrus.New().WithField("suite", "compactor")
-	etcd                                      *embed.Etcd
-	err                                       error
-	keyTo                                     int
-	endpoints                                 []string
+	testSuiteDir, testEtcdDir, testSnapshotDir string
+	testCtx                                    = context.Background()
+	logger                                     = logrus.New().WithField("suite", "compactor")
+	etcd                                       *embed.Etcd
+	err                                        error
+	keyTo                                      int
+	endpoints                                  []string
 )
 
 func TestCompactor(t *testing.T) {
@@ -56,13 +56,13 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	)
 
 	// Create a directory for compaction test cases
-	testSuitDir, err = os.MkdirTemp("/tmp", "compactor-test")
+	testSuiteDir, err = os.MkdirTemp("/tmp", "compactor-test-")
 	Expect(err).ShouldNot(HaveOccurred())
 
 	// Directory for the main ETCD process
-	testEtcdDir := fmt.Sprintf("%s/etcd/default.etcd", testSuitDir)
+	testEtcdDir := fmt.Sprintf("%s/etcd/default.etcd", testSuiteDir)
 	// Directory for storing the backups
-	testSnapshotDir := fmt.Sprintf("%s/etcd/snapshotter.bkp", testSuitDir)
+	testSnapshotDir := fmt.Sprintf("%s/etcd/snapshotter.bkp", testSuiteDir)
 
 	logger.Infof("ETCD Directory is: %s", testEtcdDir)
 	logger.Infof("Snapshot Directory is: %s", testSnapshotDir)
@@ -91,7 +91,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	err = utils.RunSnapshotter(logger, snapstoreConfig, deltaSnapshotPeriod, endpoints, ctx.Done(), true, compressionConfig)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	// Wait unitil the populator finishes with populating ETCD
+	// Wait until the populator finishes with populating ETCD
 	wg.Wait()
 
 	keyTo = resp.KeyTo
@@ -106,7 +106,7 @@ func cleanUp() {
 	etcd.Server.Stop()
 	etcd.Close()
 
-	logger.Infof("All tests are done for compactor suite. %s is being removed.", testSuitDir)
-	err = os.RemoveAll(testSuitDir)
+	logger.Infof("All tests are done for compactor suite. %s is being removed.", testSuiteDir)
+	err = os.RemoveAll(testSuiteDir)
 	Expect(err).ShouldNot(HaveOccurred())
 }

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Running Compactor", func() {
 					InitialCluster:           restoreCluster,
 					InitialClusterToken:      restoreClusterToken,
 					DataDir:                  tempDataDir,
-					TempDir:                  tempRestorationSnapshotsDir,
+					TempSnapshotsDir:         tempRestorationSnapshotsDir,
 					InitialAdvertisePeerURLs: restorePeerURLs,
 					Name:                     restoreName,
 					SkipHashCheck:            skipHashCheck,

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -114,21 +114,21 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 }
 
 // NewInitializer creates an etcd initializer object.
-func NewInitializer(options *brtypes.RestoreOptions, snapstoreConfig *brtypes.SnapstoreConfig, etcdConnectionConfig *brtypes.EtcdConnectionConfig, logger *logrus.Logger) *EtcdInitializer {
+func NewInitializer(restoreOptions *brtypes.RestoreOptions, snapstoreConfig *brtypes.SnapstoreConfig, etcdConnectionConfig *brtypes.EtcdConnectionConfig, logger *logrus.Logger) *EtcdInitializer {
 	zapLogger, _ := zap.NewProduction()
 	etcdInit := &EtcdInitializer{
 		Config: &Config{
 			SnapstoreConfig:      snapstoreConfig,
-			RestoreOptions:       options,
+			RestoreOptions:       restoreOptions,
 			EtcdConnectionConfig: etcdConnectionConfig,
 		},
 		Validator: &validator.DataValidator{
 			Config: &validator.Config{
-				DataDir:                options.Config.RestoreDataDir,
-				EmbeddedEtcdQuotaBytes: options.Config.EmbeddedEtcdQuotaBytes,
+				DataDir:                restoreOptions.Config.DataDir,
+				EmbeddedEtcdQuotaBytes: restoreOptions.Config.EmbeddedEtcdQuotaBytes,
 				SnapstoreConfig:        snapstoreConfig,
 			},
-			OriginalClusterSize: options.OriginalClusterSize,
+			OriginalClusterSize: restoreOptions.OriginalClusterSize,
 			Logger:              logger,
 			ZapLogger:           zapLogger,
 		},
@@ -144,7 +144,7 @@ func NewInitializer(options *brtypes.RestoreOptions, snapstoreConfig *brtypes.Sn
 func (e *EtcdInitializer) restoreCorruptData() (bool, error) {
 	logger := e.Logger
 	tempRestoreOptions := *(e.Config.RestoreOptions.DeepCopy())
-	dataDir := tempRestoreOptions.Config.RestoreDataDir
+	dataDir := tempRestoreOptions.Config.DataDir
 
 	if e.Config.SnapstoreConfig == nil || len(e.Config.SnapstoreConfig.Provider) == 0 {
 		logger.Warnf("No snapstore storage provider configured.")
@@ -170,9 +170,9 @@ func (e *EtcdInitializer) restoreCorruptData() (bool, error) {
 
 	tempRestoreOptions.BaseSnapshot = baseSnap
 	tempRestoreOptions.DeltaSnapList = deltaSnapList
-	tempRestoreOptions.Config.RestoreDataDir = fmt.Sprintf("%s.%s", tempRestoreOptions.Config.RestoreDataDir, "part")
+	tempRestoreOptions.Config.DataDir = fmt.Sprintf("%s.%s", tempRestoreOptions.Config.DataDir, "part")
 
-	if err := e.removeDir(tempRestoreOptions.Config.RestoreDataDir); err != nil {
+	if err := e.removeDir(tempRestoreOptions.Config.DataDir); err != nil {
 		return false, fmt.Errorf("failed to delete previous temporary data directory: %v", err)
 	}
 
@@ -196,7 +196,7 @@ func (e *EtcdInitializer) restoreCorruptData() (bool, error) {
 // and false if directory removal failed or if directory
 // never existed (bootstrap case)
 func (e *EtcdInitializer) restoreWithEmptySnapstore() (bool, error) {
-	dataDir := e.Config.RestoreOptions.Config.RestoreDataDir
+	dataDir := e.Config.RestoreOptions.Config.DataDir
 	e.Logger.Infof("Removing directory(%s) since snapstore is empty.", dataDir)
 
 	// If data directory doesn't exist, it means we are bootstrapping
@@ -248,7 +248,7 @@ func (e *EtcdInitializer) restoreInMultiNode(ctx context.Context) error {
 		return fmt.Errorf("unable to remove the member %v", err)
 	}
 
-	if err := e.removeDir(e.Config.RestoreOptions.Config.RestoreDataDir); err != nil {
+	if err := e.removeDir(e.Config.RestoreOptions.Config.DataDir); err != nil {
 		return fmt.Errorf("unable to remove the data-dir %v", err)
 	}
 

--- a/pkg/initializer/validator/datavalidator.go
+++ b/pkg/initializer/validator/datavalidator.go
@@ -365,7 +365,7 @@ func (d *DataValidator) checkFullRevisionConsistency(dataDir string, latestSnaps
 	d.Logger.Info("Starting embedded etcd server...")
 	ro := &brtypes.RestoreOptions{
 		Config: &brtypes.RestorationConfig{
-			RestoreDataDir:         dataDir,
+			DataDir:                dataDir,
 			EmbeddedEtcdQuotaBytes: d.Config.EmbeddedEtcdQuotaBytes,
 			MaxRequestBytes:        defaultMaxRequestBytes,
 			MaxTxnOps:              defaultMaxTxnOps,

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -152,7 +152,7 @@ func getStructuredBackupList(snapList brtypes.SnapList) []backup {
 // StartEmbeddedEtcd starts the embedded etcd server.
 func StartEmbeddedEtcd(logger *logrus.Entry, ro *brtypes.RestoreOptions) (*embed.Etcd, error) {
 	cfg := embed.NewConfig()
-	cfg.Dir = filepath.Join(ro.Config.RestoreDataDir)
+	cfg.Dir = filepath.Join(ro.Config.DataDir)
 	DefaultListenPeerURLs := "http://localhost:0"
 	DefaultListenClientURLs := "http://localhost:0"
 	DefaultInitialAdvertisePeerURLs := "http://localhost:0"

--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -155,7 +155,8 @@ func (r *Restorer) Restore(ro brtypes.RestoreOptions, m member.Control) (*embed.
 func (r *Restorer) restoreFromBaseSnapshot(ro brtypes.RestoreOptions) error {
 	var err error
 	if path.Join(ro.BaseSnapshot.SnapDir, ro.BaseSnapshot.SnapName) == "" {
-		return fmt.Errorf("base snapshot path not provided")
+		r.logger.Warnf("Base snapshot path not provided. Will do nothing.")
+		return nil
 	}
 	r.logger.Infof("Restoring from base snapshot: %s", path.Join(ro.BaseSnapshot.SnapDir, ro.BaseSnapshot.SnapName))
 	cfg := etcdserver.ServerConfig{

--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -101,16 +101,16 @@ func (r *Restorer) Restore(ro brtypes.RestoreOptions, m member.Control) (*embed.
 	}
 
 	r.logger.Infof("Attempting to apply %d delta snapshots for restoration.", len(ro.DeltaSnapList))
-	r.logger.Infof("Creating temporary directory %s for persisting delta snapshots locally.", ro.Config.TempDir)
+	r.logger.Infof("Creating temporary directory %s for persisting delta snapshots locally.", ro.Config.TempSnapshotsDir)
 
-	err := os.MkdirAll(ro.Config.TempDir, 0700)
+	err := os.MkdirAll(ro.Config.TempSnapshotsDir, 0700)
 	if err != nil {
 		return nil, err
 	}
 
 	defer func() {
-		if err := os.RemoveAll(ro.Config.TempDir); err != nil {
-			r.logger.Errorf("Failed to remove restoration temp directory %s: %v", ro.Config.TempDir, err)
+		if err := os.RemoveAll(ro.Config.TempSnapshotsDir); err != nil {
+			r.logger.Errorf("Failed to remove restoration temp directory %s: %v", ro.Config.TempSnapshotsDir, err)
 		}
 	}()
 
@@ -441,7 +441,7 @@ func (r *Restorer) applyDeltaSnapshots(clientKV client.KVCloser, ro brtypes.Rest
 	go r.applySnaps(clientKV, remainingSnaps, applierInfoCh, errCh, stopCh, &wg)
 
 	for f := 0; f < numFetchers; f++ {
-		go r.fetchSnaps(f, fetcherInfoCh, applierInfoCh, snapLocationsCh, errCh, stopCh, &wg, ro.Config.TempDir)
+		go r.fetchSnaps(f, fetcherInfoCh, applierInfoCh, snapLocationsCh, errCh, stopCh, &wg, ro.Config.TempSnapshotsDir)
 	}
 
 	for i, remainingSnap := range remainingSnaps {

--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -193,6 +193,7 @@ func (r *Restorer) makeDB(snapDir string, snap *brtypes.Snapshot, commit int, sk
 	if err != nil {
 		return err
 	}
+	defer rc.Close()
 
 	startTime := time.Now()
 	isCompressed, compressionPolicy, err := compressor.IsSnapshotCompressed(snap.CompressionSuffix)
@@ -206,7 +207,6 @@ func (r *Restorer) makeDB(snapDir string, snap *brtypes.Snapshot, commit int, sk
 			return fmt.Errorf("unable to decompress the snapshot: %v", err)
 		}
 	}
-	defer rc.Close()
 
 	if err := os.MkdirAll(snapDir, 0700); err != nil {
 		return err
@@ -815,7 +815,7 @@ func getNormalizedSnapshotReadCloser(rc io.ReadCloser, snap *brtypes.Snapshot) (
 		}
 	}
 
-	return rc, false, "", nil
+	return rc, isCompressed, compressionPolicy, nil
 }
 
 func (r *Restorer) readSnapshotContentsFromReadCloser(rc io.ReadCloser, snap *brtypes.Snapshot) ([]byte, error) {

--- a/pkg/snapshot/restorer/restorer_suite_test.go
+++ b/pkg/snapshot/restorer/restorer_suite_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os"
 	"path"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -34,18 +35,19 @@ import (
 
 const (
 	outputDir          = "../../../test/output"
-	etcdDir            = outputDir + "/default.etcd"
-	snapstoreDir       = outputDir + "/snapshotter.bkp"
 	embeddedEtcdPortNo = "9089"
 )
 
 var (
-	testCtx   = context.Background()
-	logger    = logrus.New().WithField("suite", "restorer")
-	etcd      *embed.Etcd
-	err       error
-	keyTo     int
-	endpoints []string
+	etcdDir      = filepath.Join(outputDir, "default.etcd")
+	tempDir      = filepath.Join(outputDir, "default.restore.tmp")
+	snapstoreDir = filepath.Join(outputDir, "snapshotter.bkp")
+	testCtx      = context.Background()
+	logger       = logrus.New().WithField("suite", "restorer")
+	etcd         *embed.Etcd
+	err          error
+	keyTo        int
+	endpoints    []string
 )
 
 func TestRestorer(t *testing.T) {

--- a/pkg/snapshot/restorer/restorer_test.go
+++ b/pkg/snapshot/restorer/restorer_test.go
@@ -926,6 +926,45 @@ var _ = Describe("Running Restorer when both v1 and v2 directory structures are 
 	})
 })
 
+var _ = Describe("Unit testing individual functions for restorer package", func() {
+	Describe("testing ErrorArrayToError", func() {
+		var (
+			errs []error
+		)
+		Context("when error array has no elements", func() {
+			It("should return nil", func() {
+				errs = []error{}
+				Expect(ErrorArrayToError(errs)).Should(BeNil())
+			})
+		})
+		Context("when error array has one element", func() {
+			It("should return nil", func() {
+				errs = []error{
+					fmt.Errorf("error0"),
+				}
+				expectedErr := fmt.Errorf("error0")
+
+				err := ErrorArrayToError(errs)
+				Expect(err).Should(Equal(expectedErr))
+			})
+		})
+		Context("when error array has more than one element", func() {
+			It("should return nil", func() {
+				errs = []error{
+					fmt.Errorf("error0"),
+					fmt.Errorf("error1"),
+					fmt.Errorf("error2"),
+				}
+				expectedErr := fmt.Errorf("error0\nerror1\nerror2")
+
+				err := ErrorArrayToError(errs)
+				Expect(err).Should(Equal(expectedErr))
+			})
+		})
+	})
+
+})
+
 // corruptEtcdDir corrupts the etcd directory by deleting it
 func corruptEtcdDir() error {
 	if _, err := os.Stat(etcdDir); os.IsNotExist(err) {

--- a/pkg/snapshot/restorer/restorer_test.go
+++ b/pkg/snapshot/restorer/restorer_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Running Restorer", func() {
 			restoreOpts = brtypes.RestoreOptions{
 				Config: &brtypes.RestorationConfig{
 					DataDir:                  etcdDir,
-					TempDir:                  tempDir,
+					TempSnapshotsDir:         tempDir,
 					InitialClusterToken:      restoreClusterToken,
 					InitialCluster:           restoreCluster,
 					Name:                     restoreName,
@@ -263,7 +263,7 @@ var _ = Describe("Running Restorer", func() {
 
 			restorationConfig = &brtypes.RestorationConfig{
 				DataDir:                  etcdDir,
-				TempDir:                  tempDir,
+				TempSnapshotsDir:         tempDir,
 				InitialClusterToken:      restoreClusterToken,
 				InitialCluster:           restoreCluster,
 				Name:                     restoreName,
@@ -735,7 +735,7 @@ var _ = Describe("Running Restorer when both v1 and v2 directory structures are 
 
 		restorationConfig = &brtypes.RestorationConfig{
 			DataDir:                  etcdDataDir,
-			TempDir:                  restoreTempDir,
+			TempSnapshotsDir:         restoreTempDir,
 			InitialClusterToken:      restoreClusterToken,
 			InitialCluster:           restoreCluster,
 			Name:                     restoreName,

--- a/pkg/snapshot/restorer/types_test.go
+++ b/pkg/snapshot/restorer/types_test.go
@@ -33,7 +33,7 @@ var _ = Describe("restorer types", func() {
 				InitialCluster:           s,
 				InitialClusterToken:      s,
 				DataDir:                  s,
-				TempDir:                  s,
+				TempSnapshotsDir:         s,
 				InitialAdvertisePeerURLs: []string{s, s},
 				Name:                     s,
 				SkipHashCheck:            b,

--- a/pkg/snapshot/restorer/types_test.go
+++ b/pkg/snapshot/restorer/types_test.go
@@ -32,7 +32,8 @@ var _ = Describe("restorer types", func() {
 			return &brtypes.RestorationConfig{
 				InitialCluster:           s,
 				InitialClusterToken:      s,
-				RestoreDataDir:           s,
+				DataDir:                  s,
+				TempDir:                  s,
 				InitialAdvertisePeerURLs: []string{s, s},
 				Name:                     s,
 				SkipHashCheck:            b,

--- a/pkg/types/restorer.go
+++ b/pkg/types/restorer.go
@@ -62,7 +62,7 @@ type RestorationConfig struct {
 	InitialCluster           string   `json:"initialCluster"`
 	InitialClusterToken      string   `json:"initialClusterToken,omitempty"`
 	DataDir                  string   `json:"dataDir,omitempty"`
-	TempDir                  string   `json:"tempDir,omitempty"`
+	TempSnapshotsDir         string   `json:"tempDir,omitempty"`
 	InitialAdvertisePeerURLs []string `json:"initialAdvertisePeerURLs"`
 	Name                     string   `json:"name"`
 	SkipHashCheck            bool     `json:"skipHashCheck,omitempty"`
@@ -81,7 +81,7 @@ func NewRestorationConfig() *RestorationConfig {
 		InitialCluster:           initialClusterFromName(defaultName),
 		InitialClusterToken:      defaultInitialClusterToken,
 		DataDir:                  fmt.Sprintf("%s.etcd", defaultName),
-		TempDir:                  fmt.Sprintf("%s.restore.tmp", defaultName),
+		TempSnapshotsDir:         fmt.Sprintf("%s.restoration.tmp", defaultName),
 		InitialAdvertisePeerURLs: []string{defaultInitialAdvertisePeerURLs},
 		Name:                     defaultName,
 		SkipHashCheck:            false,
@@ -100,7 +100,7 @@ func (c *RestorationConfig) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.InitialCluster, "initial-cluster", c.InitialCluster, "initial cluster configuration for restore bootstrap")
 	fs.StringVar(&c.InitialClusterToken, "initial-cluster-token", c.InitialClusterToken, "initial cluster token for the etcd cluster during restore bootstrap")
 	fs.StringVarP(&c.DataDir, "data-dir", "d", c.DataDir, "path to the data directory")
-	fs.StringVar(&c.TempDir, "restoration-temp-dir", c.TempDir, "path to the temporary directory to store snapshot files during restoration")
+	fs.StringVar(&c.TempSnapshotsDir, "restoration-temp-snapshots-dir", c.TempSnapshotsDir, "path to the temporary directory to store snapshot files during restoration")
 	fs.StringArrayVar(&c.InitialAdvertisePeerURLs, "initial-advertise-peer-urls", c.InitialAdvertisePeerURLs, "list of this member's peer URLs to advertise to the rest of the cluster")
 	fs.StringVar(&c.Name, "name", c.Name, "human-readable name for this member")
 	fs.BoolVar(&c.SkipHashCheck, "skip-hash-check", c.SkipHashCheck, "ignore snapshot integrity hash value (required if copied from data directory)")
@@ -134,7 +134,7 @@ func (c *RestorationConfig) Validate() error {
 		return fmt.Errorf("UnSupported auto-compaction-mode")
 	}
 	c.DataDir = path.Clean(c.DataDir)
-	c.TempDir = path.Clean(c.TempDir)
+	c.TempSnapshotsDir = path.Clean(c.TempSnapshotsDir)
 	return nil
 }
 

--- a/pkg/types/restorer.go
+++ b/pkg/types/restorer.go
@@ -61,7 +61,8 @@ type RestoreOptions struct {
 type RestorationConfig struct {
 	InitialCluster           string   `json:"initialCluster"`
 	InitialClusterToken      string   `json:"initialClusterToken,omitempty"`
-	RestoreDataDir           string   `json:"restoreDataDir,omitempty"`
+	DataDir                  string   `json:"dataDir,omitempty"`
+	TempDir                  string   `json:"tempDir,omitempty"`
 	InitialAdvertisePeerURLs []string `json:"initialAdvertisePeerURLs"`
 	Name                     string   `json:"name"`
 	SkipHashCheck            bool     `json:"skipHashCheck,omitempty"`
@@ -79,7 +80,8 @@ func NewRestorationConfig() *RestorationConfig {
 	return &RestorationConfig{
 		InitialCluster:           initialClusterFromName(defaultName),
 		InitialClusterToken:      defaultInitialClusterToken,
-		RestoreDataDir:           fmt.Sprintf("%s.etcd", defaultName),
+		DataDir:                  fmt.Sprintf("%s.etcd", defaultName),
+		TempDir:                  fmt.Sprintf("%s.restore.tmp", defaultName),
 		InitialAdvertisePeerURLs: []string{defaultInitialAdvertisePeerURLs},
 		Name:                     defaultName,
 		SkipHashCheck:            false,
@@ -97,7 +99,8 @@ func NewRestorationConfig() *RestorationConfig {
 func (c *RestorationConfig) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.InitialCluster, "initial-cluster", c.InitialCluster, "initial cluster configuration for restore bootstrap")
 	fs.StringVar(&c.InitialClusterToken, "initial-cluster-token", c.InitialClusterToken, "initial cluster token for the etcd cluster during restore bootstrap")
-	fs.StringVarP(&c.RestoreDataDir, "data-dir", "d", c.RestoreDataDir, "path to the data directory")
+	fs.StringVarP(&c.DataDir, "data-dir", "d", c.DataDir, "path to the data directory")
+	fs.StringVar(&c.TempDir, "restore-temp-dir", c.TempDir, "path to the temporary directory to store snapshot files during restoration")
 	fs.StringArrayVar(&c.InitialAdvertisePeerURLs, "initial-advertise-peer-urls", c.InitialAdvertisePeerURLs, "list of this member's peer URLs to advertise to the rest of the cluster")
 	fs.StringVar(&c.Name, "name", c.Name, "human-readable name for this member")
 	fs.BoolVar(&c.SkipHashCheck, "skip-hash-check", c.SkipHashCheck, "ignore snapshot integrity hash value (required if copied from data directory)")
@@ -125,12 +128,13 @@ func (c *RestorationConfig) Validate() error {
 		return fmt.Errorf("max fetchers should be greater than zero")
 	}
 	if c.EmbeddedEtcdQuotaBytes <= 0 {
-		return fmt.Errorf("Etcd Quota size for etcd must be greater than 0")
+		return fmt.Errorf("etcd quota size for etcd must be greater than 0")
 	}
 	if c.AutoCompactionMode != "periodic" && c.AutoCompactionMode != "revision" {
 		return fmt.Errorf("UnSupported auto-compaction-mode")
 	}
-	c.RestoreDataDir = path.Clean(c.RestoreDataDir)
+	c.DataDir = path.Clean(c.DataDir)
+	c.TempDir = path.Clean(c.TempDir)
 	return nil
 }
 

--- a/pkg/types/restorer.go
+++ b/pkg/types/restorer.go
@@ -191,8 +191,8 @@ type FetcherInfo struct {
 
 // ApplierInfo stores the info about applier
 type ApplierInfo struct {
-	EventsFilePath string
-	SnapIndex      int
+	SnapFilePath string
+	SnapIndex    int
 }
 
 // DeepCopyInto copies the structure deeply from in to out.

--- a/pkg/types/restorer.go
+++ b/pkg/types/restorer.go
@@ -100,7 +100,7 @@ func (c *RestorationConfig) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.InitialCluster, "initial-cluster", c.InitialCluster, "initial cluster configuration for restore bootstrap")
 	fs.StringVar(&c.InitialClusterToken, "initial-cluster-token", c.InitialClusterToken, "initial cluster token for the etcd cluster during restore bootstrap")
 	fs.StringVarP(&c.DataDir, "data-dir", "d", c.DataDir, "path to the data directory")
-	fs.StringVar(&c.TempDir, "restore-temp-dir", c.TempDir, "path to the temporary directory to store snapshot files during restoration")
+	fs.StringVar(&c.TempDir, "restoration-temp-dir", c.TempDir, "path to the temporary directory to store snapshot files during restoration")
 	fs.StringArrayVar(&c.InitialAdvertisePeerURLs, "initial-advertise-peer-urls", c.InitialAdvertisePeerURLs, "list of this member's peer URLs to advertise to the rest of the cluster")
 	fs.StringVar(&c.Name, "name", c.Name, "human-readable name for this member")
 	fs.BoolVar(&c.SkipHashCheck, "skip-hash-check", c.SkipHashCheck, "ignore snapshot integrity hash value (required if copied from data directory)")


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix cleanup of temporary directory used for restoration and improve and optimize restoration in general. As part of this task, this PR does the following:
- [x] Instead of cleaning up the temp files *after* restoration succeeds, cleanup each temp delta snapshot file as and when the delta snapshot is successfully applied to the embedded etcd
- [x] Create temp directory before restoration, and remove the temp directory after restoration (to avoid any minute chances of leftover temp files), so temp files are removed even if restoration of delta snapshots fails
- [x] Make the restoration temp dir configurable via CLI flag `--restoration-temp-snapshots-dir`
- [x] Decompress downloaded delta snapshots just before applying them instead of persisting decompressed snapshot files to disk, thus saving disk space
- [x] Name the temp files after delta snapshot file names to make debugging easier
- [x] Improve logging for restoration of delta snapshots
- [x] Change behavior of compactor package to re-use `--data-dir` CLI flag for restoration of etcd
- [x] Cosmetic changes to compactor package

**Which issue(s) this PR fixes**:
Fixes #604 

**Special notes for your reviewer**:
/invite @unmarshall @aaronfern @ishan16696 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Optimize disk usage during restoration of delta snapshots, and remove scope for errors in the process.
```
```improvement user
Introduce CLI flag `--restoration-temp-snapshots-dir` to configure directory used for temporarily persisting delta snapshots during restoration.
```
```improvement user
Fix behavior of `--data-dir` for `etcdbrctl compact` command to be consistent with the flag's usage in other `etcdbrctl` commands.
```