### PR TITLE
Allow for flexible build opts for other CI tools

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -47,7 +47,7 @@ cd "${SOURCE_PATH}"
 ###############################################################################
 
 VERSION_FILE="$(${READLINK_BIN}  -f "${SOURCE_PATH}/VERSION")"
-VERSION="${VERSION:="$(cat "${VERSION_FILE}")"}"
+VERSION="${VERSION:-"$(cat "${VERSION_FILE}")"}"
 GIT_SHA="${GIT_SHA:-$(git rev-parse --short HEAD || echo "GitNotFound")}"
 
 CGO_ENABLED=0  go build \

--- a/.ci/build
+++ b/.ci/build
@@ -47,8 +47,8 @@ cd "${SOURCE_PATH}"
 ###############################################################################
 
 VERSION_FILE="$(${READLINK_BIN}  -f "${SOURCE_PATH}/VERSION")"
-VERSION="$(cat "${VERSION_FILE}")"
-GIT_SHA=$(git rev-parse --short HEAD || echo "GitNotFound")
+VERSION="${VERSION:="$(cat "${VERSION_FILE}")"}"
+GIT_SHA="${GIT_SHA:-$(git rev-parse --short HEAD || echo "GitNotFound")}"
 
 CGO_ENABLED=0  go build \
   -v \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION             := $(shell cat VERSION)
+VERSION             ?= $(shell cat VERSION)
 REGISTRY            ?= eu.gcr.io/gardener-project/gardener
 IMAGE_REPOSITORY    := $(REGISTRY)/etcdbrctl
 IMAGE_TAG           := $(VERSION)


### PR DESCRIPTION
This is a cherry-pick of https://github.com/gardener/etcd-backup-restore/pull/475 due to failing CI job on that PR as the PR is quite old now.

**What this PR does / why we need it**:
These changes allow for flexibility to specify the VERSION and GIT_SHA using env vars. This is useful for other CI environments where e.g. `git` isn't present.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Allow for flexible build opts for other CI tools.
```
