### PR TITLE
Upgrade alpine base image to 3.15.8

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 
 RUN make build
 
-FROM alpine:3.15.7
+FROM alpine:3.15.8
 
 RUN apk add --update bash curl
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade alpine base image version used from `v3.15.7` to `v3.15.8`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Base alpine image upgraded from `3.15.7` to `3.15.8`
```
