### PR TITLE
Upgrade to go 1.20.3

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -42,13 +42,13 @@ etcd-backup-restore:
                 build: ~
     steps:
       check:
-        image: 'golang:1.19.5'
+        image: 'golang:1.20.3'
       unit_test:
-        image: 'golang:1.19.5'
+        image: 'golang:1.20.3'
       integration_test:
         image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'
       build:
-        image: 'golang:1.19.5'
+        image: 'golang:1.20.3'
         output_dir: 'binary'
 
   jobs:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19.5 as builder
+FROM golang:1.20.3 as builder
 
 WORKDIR /go/src/github.com/gardener/backup-restore
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/etcd-backup-restore
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go v0.51.0


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR upgrades the golang runtime and build version to `go 1.20`.

/area quality

**Which issue(s) this PR fixes**:
Fixes [critical vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2023-24537).

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Upgrade to go 1.20.3
```
