### PR TITLE
Fix a bug which falsely detects scale-up scenario incase of rolling update of statefulset.

### DIFF
--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -322,7 +322,7 @@ func (m *memberControl) IsClusterScaledUp(ctx context.Context, clientSet client.
 	if err != nil {
 		m.logger.Errorf("unable to fetch etcd statefulset: %v", err)
 	} else {
-		if etcdsts != nil && miscellaneous.IsAnnotationPresent(etcdsts, miscellaneous.ScaledToMultiNodeAnnotationKey) {
+		if miscellaneous.IsAnnotationPresent(etcdsts, miscellaneous.ScaledToMultiNodeAnnotationKey) {
 			return true, nil
 		}
 	}

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -437,15 +437,20 @@ func GetInitialClusterStateIfScaleup(ctx context.Context, logger logrus.Entry, c
 		return nil, err
 	}
 
-	if metav1.HasAnnotation(curSts.ObjectMeta, ScaledToMultiNodeAnnotationKey) {
+	if IsAnnotationPresent(curSts, ScaledToMultiNodeAnnotationKey) {
 		return pointer.StringPtr(ClusterStateExisting), nil
 	}
 
-	// fallback - preserves backward compatibility
 	if *curSts.Spec.Replicas > 1 && *curSts.Spec.Replicas > curSts.Status.UpdatedReplicas {
 		return pointer.StringPtr(ClusterStateExisting), nil
 	}
+
 	return nil, nil
+}
+
+// IsAnnotationPresent checks the presence of given annotation in a given statefulset.
+func IsAnnotationPresent(sts *appsv1.StatefulSet, annotation string) bool {
+	return metav1.HasAnnotation(sts.ObjectMeta, annotation)
 }
 
 // DoPromoteMember promotes a given learner to a voting member.

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -622,6 +622,52 @@ var _ = Describe("Miscellaneous Tests", func() {
 		})
 	})
 
+	Describe("Etcd Statefulset", func() {
+		var (
+			sts             *appsv1.StatefulSet
+			statefulSetName = "etcd-test"
+			podName         = "etcd-test-0"
+			namespace       = "test_namespace"
+		)
+		BeforeEach(func() {
+			sts = &appsv1.StatefulSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "StatefulSet",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      statefulSetName,
+					Namespace: namespace,
+				},
+			}
+		})
+		Context("Etcd statefulset exists", func() {
+			It("should return statefulset", func() {
+				clientSet := GetFakeKubernetesClientSet()
+
+				err := clientSet.Create(testCtx, sts)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				etcdSts, err := GetStatefulSet(testCtx, clientSet, namespace, podName)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(etcdSts).ShouldNot(BeNil())
+			})
+		})
+		Context("Etcd statefulset not exist in a given namespace", func() {
+			It("should return error", func() {
+				wrongNS := "wrong-namespace"
+				clientSet := GetFakeKubernetesClientSet()
+
+				err := clientSet.Create(testCtx, sts)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				etcdSts, err := GetStatefulSet(testCtx, clientSet, wrongNS, podName)
+				Expect(err).Should(HaveOccurred())
+				Expect(etcdSts).Should(BeNil())
+			})
+		})
+	})
+
 	Describe("read config file into a map", func() {
 		const testdataPath = "testdata"
 		var (


### PR DESCRIPTION
**What this PR does / why we need it**:
As now we depends on annotation added by druid to [detect scale-up feature](https://github.com/gardener/etcd-backup-restore/blob/96e810ff6a431b74580a74932cb9736fcd7e2f67/pkg/initializer/initializer.go#L62) I noticed when a rolling update happens, this piece of code with sts status:
```go
	if *curSts.Spec.Replicas > 1 && *curSts.Spec.Replicas > curSts.Status.UpdatedReplicas {
		return pointer.StringPtr(ClusterStateExisting), nil
	}
```

etcd statefulset status:
```
status:
  availableReplicas: 2
  collisionCount: 0
  currentReplicas: 2
  currentRevision: etcd-aws-78fcdddc48
  observedGeneration: 4
  readyReplicas: 2
  replicas: 3
  updateRevision: etcd-aws-5d4d79969b
  updatedReplicas: 1
```

returns the cluster state of etcd as `existing` which gives backup-restore a false impression that this is a scale-up case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix operator
Fixes a bug in backup-restore which falsely detects scale-up scenario incase of rolling update of statefulset.
```
