### PR TITLE
Block public access to S3 bucket created by integration tests

### DIFF
--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -176,7 +176,10 @@ function delete_aws_secret() {
 function create_s3_bucket() {
   echo "Creating S3 bucket ${TEST_ID} in region ${REGION}"
   aws s3api create-bucket --bucket ${TEST_ID} --region ${REGION} --create-bucket-configuration LocationConstraint=${REGION} --acl private
+  # Block public access to the S3 bucket
   aws s3api put-public-access-block --bucket ${TEST_ID} --public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
+  # Deny non-HTTPS requests to the S3 bucket
+  aws s3api put-bucket-policy --bucket ${TEST_ID} --policy "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"s3:*\",\"Resource\":[\"arn:aws:s3:::${TEST_ID}\",\"arn:aws:s3:::${TEST_ID}/*\"],\"Condition\":{\"Bool\":{\"aws:SecureTransport\":\"false\"},\"NumericLessThan\":{\"s3:TlsVersion\":\"1.2\"}}}]}"
 }
 
 function delete_s3_bucket() {

--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -175,7 +175,8 @@ function delete_aws_secret() {
 
 function create_s3_bucket() {
   echo "Creating S3 bucket ${TEST_ID} in region ${REGION}"
-  aws s3api create-bucket --bucket ${TEST_ID} --region ${REGION} --create-bucket-configuration LocationConstraint=${REGION}
+  aws s3api create-bucket --bucket ${TEST_ID} --region ${REGION} --create-bucket-configuration LocationConstraint=${REGION} --acl private
+  aws s3api put-public-access-block --bucket ${TEST_ID} --public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
 }
 
 function delete_s3_bucket() {


### PR DESCRIPTION
/area backup
/area security
/area compliance
/kind task
/kind test
/platform aws

**What this PR does / why we need it**:
This PR configures the S3 buckets created by integration tests to be blocked from public access as per standard practices. This is achieved by putting a public-access-block on the created bucket, as per [AWS documentation](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-public-access-block.html).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @vlerenc 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Block public access for S3 buckets created by integration tests.
```
