### PR TITLE
Add unit tests for func IsClusterScaledUp.

### DIFF
--- a/pkg/compactor/compactor_suite_test.go
+++ b/pkg/compactor/compactor_suite_test.go
@@ -68,7 +68,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	logger.Infof("Snapshot Directory is: %s", testSnapshotDir)
 
 	// Start the main ETCD process that will run untill all compaction test cases are run
-	etcd, err = utils.StartEmbeddedEtcd(testCtx, testEtcdDir, logger, embeddedEtcdPortNo)
+	etcd, err = utils.StartEmbeddedEtcd(testCtx, testEtcdDir, logger, utils.DefaultEtcdName, embeddedEtcdPortNo)
 	Expect(err).ShouldNot(HaveOccurred())
 	endpoints = []string{etcd.Clients[0].Addr().String()}
 	logger.Infof("endpoints: %s", endpoints)

--- a/pkg/defragmentor/defragmentor_suite_test.go
+++ b/pkg/defragmentor/defragmentor_suite_test.go
@@ -54,7 +54,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	err = os.RemoveAll(outputDir)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, embeddedEtcdPortNo)
+	etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, utils.DefaultEtcdName, embeddedEtcdPortNo)
 	Expect(err).ShouldNot(HaveOccurred())
 	endpoints = []string{etcd.Clients[0].Addr().String()}
 	logger.Infof("endpoints: %s", endpoints)

--- a/pkg/health/heartbeat/heartbeat_suite_test.go
+++ b/pkg/health/heartbeat/heartbeat_suite_test.go
@@ -33,7 +33,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	err = os.RemoveAll(outputDir)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, "")
+	etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, utils.DefaultEtcdName, "")
 	Expect(err).ShouldNot(HaveOccurred())
 	var data []byte
 	return data

--- a/pkg/initializer/validator/datavalidator_test.go
+++ b/pkg/initializer/validator/datavalidator_test.go
@@ -233,7 +233,7 @@ var _ = Describe("Running Datavalidator", func() {
 			}()
 
 			// start etcd
-			etcd, err := utils.StartEmbeddedEtcd(testCtx, restoreDataDir, logger, embeddedEtcdPortNo)
+			etcd, err := utils.StartEmbeddedEtcd(testCtx, restoreDataDir, logger, utils.DefaultEtcdName, embeddedEtcdPortNo)
 			Expect(err).ShouldNot(HaveOccurred())
 			endpoints := []string{etcd.Clients[0].Addr().String()}
 			// populate etcd but with lesser data than previous populate call, so that the new db has a lower revision
@@ -272,7 +272,7 @@ var _ = Describe("Running Datavalidator", func() {
 			}()
 
 			// start etcd
-			etcd, err := utils.StartEmbeddedEtcd(testCtx, restoreDataDir, logger, embeddedEtcdPortNo)
+			etcd, err := utils.StartEmbeddedEtcd(testCtx, restoreDataDir, logger, utils.DefaultEtcdName, embeddedEtcdPortNo)
 			Expect(err).ShouldNot(HaveOccurred())
 			endpoints := []string{etcd.Clients[0].Addr().String()}
 

--- a/pkg/initializer/validator/validator_suite_test.go
+++ b/pkg/initializer/validator/validator_suite_test.go
@@ -51,7 +51,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	err = os.RemoveAll(outputDir)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, embeddedEtcdPortNo)
+	etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, utils.DefaultEtcdName, embeddedEtcdPortNo)
 	Expect(err).ShouldNot(HaveOccurred())
 	defer func() {
 		etcd.Server.Stop()

--- a/pkg/member/member_control_suite_test.go
+++ b/pkg/member/member_control_suite_test.go
@@ -20,8 +20,10 @@ var (
 )
 
 const (
-	outputDir = "../../../test/output"
-	etcdDir   = outputDir + "/default.etcd"
+	outputDir    = "../../../test/output"
+	etcdDir      = outputDir + "/default.etcd"
+	podName      = "etcd-test-0"
+	podNamespace = "test-podnamespace"
 )
 
 func TestMembergarbagecollector(t *testing.T) {
@@ -33,7 +35,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	err = os.RemoveAll(outputDir)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, "")
+	etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, podName, "")
 	Expect(err).ShouldNot(HaveOccurred())
 	var data []byte
 	return data

--- a/pkg/snapshot/copier/copier_suite_test.go
+++ b/pkg/snapshot/copier/copier_suite_test.go
@@ -59,7 +59,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	err = os.RemoveAll(outputDir)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, "")
+	etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, utils.DefaultEtcdName, "")
 	Expect(err).ShouldNot(HaveOccurred())
 	endpoints = []string{etcd.Clients[0].Addr().String()}
 	logger.Infof("endpoints: %s", endpoints)

--- a/pkg/snapshot/restorer/restorer_suite_test.go
+++ b/pkg/snapshot/restorer/restorer_suite_test.go
@@ -63,7 +63,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	err = os.RemoveAll(outputDir)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, embeddedEtcdPortNo)
+	etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, utils.DefaultEtcdName, embeddedEtcdPortNo)
 	Expect(err).ShouldNot(HaveOccurred())
 	defer func() {
 		etcd.Server.Stop()

--- a/pkg/snapshot/restorer/restorer_test.go
+++ b/pkg/snapshot/restorer/restorer_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Running Restorer", func() {
 
 		BeforeEach(func() {
 			deltaSnapshotPeriod = time.Second
-			etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, embeddedEtcdPortNo)
+			etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, utils.DefaultEtcdName, embeddedEtcdPortNo)
 			Expect(err).ShouldNot(HaveOccurred())
 			endpoints = []string{etcd.Clients[0].Addr().String()}
 
@@ -720,7 +720,7 @@ var _ = Describe("Running Restorer when both v1 and v2 directory structures are 
 		etcdDataDir = filepath.Join(testDir, "default.etcd")
 		restoreTempDir = filepath.Join(testDir, "default.restore.tmp")
 		storeDir = filepath.Join(testDir, "snapshotter.bkp")
-		etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDataDir, logger, embeddedEtcdPortNo)
+		etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDataDir, logger, utils.DefaultEtcdName, embeddedEtcdPortNo)
 		Expect(err).ShouldNot(HaveOccurred())
 		ep = []string{etcd.Clients[0].Addr().String()}
 

--- a/pkg/snapshot/snapshotter/snapshotter_suite_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_suite_test.go
@@ -49,7 +49,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	err = os.RemoveAll(outputDir)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, embeddedEtcdPortNo)
+	etcd, err = utils.StartEmbeddedEtcd(testCtx, etcdDir, logger, utils.DefaultEtcdName, embeddedEtcdPortNo)
 	Expect(err).ShouldNot(HaveOccurred())
 	var data []byte
 	return data

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -41,13 +41,19 @@ const (
 	ValuePrefix = "val-"
 	// EmbeddedEtcdPortNo defines PortNo which can be used to start EmbeddedEtcd.
 	EmbeddedEtcdPortNo = "12379"
+	// DefaultEtcdName defines the default etcd name used to start EmbeddedEtcd.
+	DefaultEtcdName = "default"
 )
 
 // StartEmbeddedEtcd starts the embedded etcd for test purpose with minimal configuration at a given port.
 // To get the exact client endpoints it is listening on, use returns etcd.Clients[0].Addr().String()
-func StartEmbeddedEtcd(ctx context.Context, etcdDir string, logger *logrus.Entry, port string) (*embed.Etcd, error) {
+func StartEmbeddedEtcd(ctx context.Context, etcdDir string, logger *logrus.Entry, name string, port string) (*embed.Etcd, error) {
 	logger.Infoln("Starting embedded etcd...")
 	cfg := embed.NewConfig()
+	cfg.Name = name
+	if len(name) == 0 {
+		cfg.Name = DefaultEtcdName
+	}
 	cfg.Dir = etcdDir
 	cfg.EnableV2 = false
 	cfg.Debug = false
@@ -241,7 +247,7 @@ func RunSnapshotter(logger *logrus.Entry, snapstoreConfig brtypes.SnapstoreConfi
 
 // CheckDataConsistency starts an embedded etcd and checks for correctness of the values stored in etcd against the keys 'keyFrom' through 'keyTo'
 func CheckDataConsistency(ctx context.Context, dir string, keyTo int, logger *logrus.Entry) error {
-	etcd, err := StartEmbeddedEtcd(ctx, dir, logger, EmbeddedEtcdPortNo)
+	etcd, err := StartEmbeddedEtcd(ctx, dir, logger, DefaultEtcdName, EmbeddedEtcdPortNo)
 	if err != nil {
 		return fmt.Errorf("unable to start embedded etcd server: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds unit tests for func `IsClusterScaledUp`:
https://github.com/gardener/etcd-backup-restore/blob/281a6ca98d91a22d76fae9b4ebbf429a97cf7784/pkg/member/member_control.go#L319


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
None
```
