### PR TITLE
If scale-up is detected then add learner with backoff.

### DIFF
--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -36,8 +36,8 @@ import (
 )
 
 const (
-	// retrySteps is the no. of steps used for exponential backoff to add a learner.
-	retrySteps = 6
+	// addLearnerAttempts are the total number of attempts that will be made to add a learner
+	addLearnerAttempts = 6
 )
 
 // Initialize has the following steps:
@@ -67,12 +67,12 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 		isScaleup, err := m.IsClusterScaledUp(ctx, clientSet)
 		if err != nil {
 			logger.Errorf("scale-up not detected: %v", err)
-		} else if isScaleup && err == nil {
+		} else if isScaleup {
 			logger.Info("Etcd cluster scale-up is detected")
 			// Add a learner(non-voting member) to a etcd cluster with retry
 			// If backup-restore is unable to add a learner in a cluster
 			// restart the `initialization` by exiting the backup-restore.
-			if err := m.AddLearnerWithRetry(ctx, retrySteps, e.Config.RestoreOptions.Config.DataDir); err != nil {
+			if err := member.AddLearnerWithRetry(ctx, m, addLearnerAttempts, e.Config.RestoreOptions.Config.DataDir); err != nil {
 				logger.Fatalf("unable to add a learner in a cluster: %v", err)
 			}
 			// return here after adding learner(non-voting member) as no restoration or validation required.

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	utilError "github.com/gardener/etcd-backup-restore/pkg/errors"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 	etcdClient "github.com/gardener/etcd-backup-restore/pkg/etcdutil/client"
 	"github.com/gardener/etcd-backup-restore/pkg/metrics"
@@ -341,9 +342,7 @@ func (m *memberControl) IsClusterScaledUp(ctx context.Context, clientSet client.
 func AddLearnerWithRetry(ctx context.Context, m Control, retrySteps int, dataDir string) error {
 	backoff := miscellaneous.CreateBackoff(RetryPeriod, retrySteps)
 
-	if err := retry.OnError(backoff, func(err error) bool {
-		return err != nil
-	}, func() error {
+	if err := retry.OnError(backoff, utilError.IsErrNotNil, func() error {
 		// Remove data-dir(if exist) before adding a learner as a additional safety check.
 		if err := miscellaneous.RemoveDir(dataDir); err != nil {
 			return err

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -589,3 +589,15 @@ func CreateBackoff(retryPeriod time.Duration, steps int) wait.Backoff {
 		Steps:    steps,
 	}
 }
+
+// RemoveDir removes the directory(if exist) and do nothing if directory doesn't exist.
+func RemoveDir(dir string) error {
+	if _, err := os.Stat(dir); err == nil {
+		if err := os.RemoveAll(filepath.Join(dir)); err != nil {
+			return fmt.Errorf("failed to remove directory %s with err: %v", dir, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -580,13 +580,14 @@ func GetPrevScheduledSnapTime(nextSnapSchedule time.Time, timeWindow float64) ti
 	)
 }
 
-// CreateBackoff returns the backoff with Factor=2
+// CreateBackoff returns the backoff with Factor=2 with upper limit of 120sec.
 func CreateBackoff(retryPeriod time.Duration, steps int) wait.Backoff {
 	return wait.Backoff{
 		Duration: retryPeriod,
 		Factor:   2,
 		Jitter:   retry.DefaultBackoff.Jitter,
 		Steps:    steps,
+		Cap:      120 * time.Second,
 	}
 }
 

--- a/pkg/miscellaneous/miscellaneous_suite_test.go
+++ b/pkg/miscellaneous/miscellaneous_suite_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 var (
+	etcdDir = "./default.etcd"
 	testCtx = context.TODO()
 	logger  = logrus.New().WithField("suite", "miscellaneous")
 )

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -768,6 +768,28 @@ initial-cluster: etcd1=http://0.0.0.0:2380`
 		})
 	})
 
+	Describe("Remove data-dir", func() {
+		Context("If path exist and can be removed", func() {
+			It("should return nil", func() {
+				err := os.Mkdir(etcdDir, 0700)
+				Expect(err).ShouldNot(HaveOccurred())
+				err = RemoveDir(etcdDir)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+		Context("If path doesn't exist", func() {
+			It("should return nil", func() {
+				err := RemoveDir(etcdDir)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+		Context("If path exist but can't be removed", func() {
+			It("should return error", func() {
+				err := RemoveDir(".")
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+	})
 })
 
 func emptyStatefulSet(name, namespace string) *appsv1.StatefulSet {


### PR DESCRIPTION
**What this PR does / why we need it**:
If scale-up case is detected then better to add a learner with exponential backoff.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/gardener/etcd-backup-restore/pull/608#discussion_r1155803217

**Special notes for your reviewer**:


**Release note**:
```improvement operator
Add a learner with backoff in case of scale-up feature is triggered.
```
