### PR TITLE
Improve scale-up detection.

### DIFF
--- a/pkg/member/member_control_test.go
+++ b/pkg/member/member_control_test.go
@@ -232,21 +232,5 @@ var _ = Describe("Membercontrol", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 		})
-
-		Context("When statefulset has scale-up annotation", func() {
-			It("should return true", func() {
-				sts.Annotations = map[string]string{
-					miscellaneous.ScaledToMultiNodeAnnotationKey: "",
-				}
-
-				clientSet := miscellaneous.GetFakeKubernetesClientSet()
-				err := clientSet.Create(testCtx, sts)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				isScaleUp, err := m.IsClusterScaledUp(testCtx, clientSet)
-				Expect(isScaleUp).Should(BeTrue())
-				Expect(err).ShouldNot(HaveOccurred())
-			})
-		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
First, try to determine scale-up case by checking whether member is already part of cluster or not. In case of failure of api call then check for `ScaledToMultiNodeAnnotationKey` annotation in etcd statefulset. This will remove any case of false positive for scale-up scenario.


**Which issue(s) this PR fixes**:
Fixes #623 and Fixes #622

**Special notes for your reviewer**:

**Release note**:
```improvement operator
None
```
