### PR TITLE
Introduces file watcher to handle non-TLS->TLS case

### DIFF
--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -53,6 +53,8 @@ import (
 const (
 	// NoLeaderState defines the state when etcd returns LeaderID as 0.
 	NoLeaderState uint64 = 0
+	// EtcdConfigFileDirPath is directory path which has etcd configuration file.
+	EtcdConfigFileDirPath string = "/var/etcd/config"
 	// EtcdConfigFilePath is the file path where the etcd config map is mounted.
 	EtcdConfigFilePath string = "/var/etcd/config/etcd.conf.yaml"
 	// ClusterStateNew defines the "new" state of etcd cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces file watcher to watch config map which will help in handling `non-TLS -> TLS` case and call `MemberUpdate` API only when etcd is up.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
Introduces file watcher to handle peerUrl non-TLS -> peerUrl TLS case.
```
```bugfix operator
Call `MemberUpdate` API only when etcd is up to update etcd member's peerUrl.
```
