### PR TITLE
Use distroless images and use user home dir to create files

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,10 +19,8 @@ COPY . .
 
 RUN make build
 
-FROM alpine:3.18.2
+FROM gcr.io/distroless/static-debian11:nonroot AS backup-restore
 
-RUN apk add --update bash curl
-
-COPY --from=builder /go/src/github.com/gardener/backup-restore/bin/etcdbrctl /usr/local/bin/etcdbrctl
+COPY --from=builder /go/src/github.com/gardener/backup-restore/bin/etcdbrctl /etcdbrctl
 WORKDIR /
-ENTRYPOINT ["/usr/local/bin/etcdbrctl"]
+ENTRYPOINT ["/etcdbrctl"]

--- a/pkg/server/httpAPI.go
+++ b/pkg/server/httpAPI.go
@@ -27,6 +27,7 @@ import (
 	"net/http/pprof"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -389,7 +390,13 @@ func (h *HTTPHandler) serveLatestSnapshotMetadata(rw http.ResponseWriter, req *h
 
 func (h *HTTPHandler) serveConfig(rw http.ResponseWriter, req *http.Request) {
 	inputFileName := miscellaneous.EtcdConfigFilePath
-	outputFileName := "/etc/etcd.conf.yaml"
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		h.Logger.Warnf("Unable to get user home dir: %v", err)
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	outputFileName := filepath.Join(dir, "etcd.conf.yaml") //"/etc/etcd.conf.yaml"
 	configYML, err := ioutil.ReadFile(inputFileName)
 	if err != nil {
 		h.Logger.Warnf("Unable to read etcd config file: %v", err)

--- a/pkg/server/httpAPI.go
+++ b/pkg/server/httpAPI.go
@@ -396,7 +396,7 @@ func (h *HTTPHandler) serveConfig(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	outputFileName := filepath.Join(dir, "etcd.conf.yaml") //"/etc/etcd.conf.yaml"
+	outputFileName := filepath.Join(dir, "etcd.conf.yaml")
 	configYML, err := ioutil.ReadFile(inputFileName)
 	if err != nil {
 		h.Logger.Warnf("Unable to read etcd config file: %v", err)

--- a/pkg/snapstore/utils.go
+++ b/pkg/snapstore/utils.go
@@ -76,7 +76,15 @@ func GetSnapstore(config *brtypes.SnapstoreConfig) (brtypes.SnapStore, error) {
 		if config.Container == "" {
 			config.Container = defaultLocalStore
 		}
-		return NewLocalSnapStore(path.Join(config.Container, config.Prefix))
+		if strings.HasPrefix(config.Container, "../../../test/output") {
+			// To be used only by unit tests
+			return NewLocalSnapStore(path.Join(config.Container, config.Prefix))
+		}
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		return NewLocalSnapStore(path.Join(homeDir, config.Container, config.Prefix))
 	case brtypes.SnapstoreProviderS3:
 		return NewS3SnapStore(config)
 	case brtypes.SnapstoreProviderABS:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates `etcd-backup-restore` to use distroless images and as a result updats file paths of files created by itself to use the user home directory

**Which issue(s) this PR fixes**:
Fixes #635 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Etcd-backup-restore now uses a distroless image as its base image. It is no longer compatible with [etcd-custom-image](https://github.com/gardener/etcd-custom-image), and must be used with [etcd-wrapper](https://github.com/gardener/etcd-wrapper) instead. 
```
```noteworthy operator
Etcd-backup-restore now uses the user home directory to create files.
```
