### PR TITLE
Bump alpine base version for Docker build to 3.18.2

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 
 RUN make build
 
-FROM alpine:3.15.8
+FROM alpine:3.18.2
 
 RUN apk add --update bash curl
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump alpine base version for Docker build to `3.18.2`, which includes fixes for CVEs [CVE-2023-1255](https://security.alpinelinux.org/vuln/CVE-2023-1255) and [CVE-2023-2650](https://security.alpinelinux.org/vuln/CVE-2023-2650).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @aaronfern 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Bump alpine base version for Docker build to `3.18.2`.
```
