### PR TITLE
Implement Configurable Retention Period for Delta Snapshots

### DIFF
--- a/doc/usage/garbage_collection.md
+++ b/doc/usage/garbage_collection.md
@@ -1,30 +1,28 @@
-
 # Garbage Collection (GC) Feature
 
-The etcd-backup-restore project incorporates a Garbage Collection (GC) feature that effectively manages storage space by systematically discarding older backups. The [`RunGarbageCollector`](pkg/snapshot/snapshotter/garbagecollector.go) function orchestrates this process, marking older backups as disposable and subsequently removing them according to predefined rules.
+The etcd-backup-restore project incorporates a Garbage Collection (GC) feature designed to manage storage space effectively by systematically discarding older backups. The [`RunGarbageCollector`](pkg/snapshot/snapshotter/garbagecollector.go) function controls this process, marking older backups as disposable and subsequently removing them based on predefined rules.
 
 ## GC Policies
 
-Garbage Collection policies fall into two categories:
+Garbage Collection policies fall into two categories, each of which can be configured with appropriate flags:
 
-1. **Exponential Policy**: This policy operates on the principle of retaining the most recent snapshots and discarding older ones, with decisions based on the age of snapshots and the time they were captured. The garbage collection process under this policy unfolds as follows:
+1. **Exponential Policy**: This policy operates on the principle of retaining the most recent snapshots and discarding older ones, based on the age and capture time of the snapshots. You can configure this policy with the following flag: `--garbage-collection-policy='Exponential'`. The garbage collection process under this policy unfolds as follows:
 
    - The most recent full snapshot and its associated delta snapshots are perpetually retained, irrespective of the `delta-snapshot-retention-period` setting. This mechanism is vital for potential data recovery.
    - All delta snapshots that fall within the `delta-snapshot-retention-period` are preserved.
-   - For the current hour, all full snapshots are maintained.
+   - Full snapshots are retained for the current hour.
    - For the past 24 hours, the most recent full snapshot from each hour is kept.
    - For the past week (up to 7 days), the most recent full snapshot from each day is kept.
    - For the past month (up to 4 weeks), the most recent full snapshot from each week is kept.
-   - Any full snapshots beyond 5 weeks of age are discarded.
+   - Full snapshots older than 5 weeks are discarded.
 
-2. **Limit-Based Policy**: This policy ensures that the total number of snapshots does not exceed a specific limit, as defined in the configuration:
+2. **Limit-Based Policy**: This policy aims to keep the snapshot count under a specific limit, as determined by the configuration. The policy prioritizes retaining recent snapshots and eliminating older ones. You can configure this policy with the following flags: `--max-backups=10` and `--garbage-collection-policy='LimitBased'`. The garbage collection process under this policy unfolds as follows:
 
    - The most recent full snapshot and its associated delta snapshots are always retained, regardless of the `delta-snapshot-retention-period` setting. This is essential for potential data recovery.
    - Full snapshots are retained up to the limit set in the configuration. Any full snapshots beyond this limit are removed.
 
 ## Retention Period for Delta Snapshots
 
-`delta-snapshot-retention-period`: This setting determines the retention period for older delta snapshots. It does not include the most recent set of snapshots, which are always retained to ensure data safety. The default value for this configuration is 0.
+The `delta-snapshot-retention-period` setting determines the retention period for older delta snapshots. It does not include the most recent set of snapshots, which are always retained to ensure data safety. The default value for this configuration is 0.
 
-> __Note__: In both policies, the garbage collection process includes listing the snapshots, identifying those that meet deletion criteria, and then removing them. The deletion operation encompasses the removal of associated chunks, which form parts of a larger snapshot.
-
+> **Note**: In both policies, the garbage collection process includes listing the snapshots, identifying those that meet the deletion criteria, and then removing them. The deletion operation encompasses the removal of associated chunks, which form parts of a larger snapshot.

--- a/doc/usage/garbage_collection.md
+++ b/doc/usage/garbage_collection.md
@@ -19,6 +19,7 @@ Garbage Collection policies fall into two categories, each of which can be confi
 2. **Limit-Based Policy**: This policy aims to keep the snapshot count under a specific limit, as determined by the configuration. The policy prioritizes retaining recent snapshots and eliminating older ones. You can configure this policy with the following flags: `--max-backups=10` and `--garbage-collection-policy='LimitBased'`. The garbage collection process under this policy unfolds as follows:
 
    - The most recent full snapshot and its associated delta snapshots are always retained, regardless of the `delta-snapshot-retention-period` setting. This is essential for potential data recovery.
+   - All delta snapshots that fall within the `delta-snapshot-retention-period` are preserved.
    - Full snapshots are retained up to the limit set in the configuration. Any full snapshots beyond this limit are removed.
 
 ## Retention Period for Delta Snapshots

--- a/doc/usage/garbage_collection.md
+++ b/doc/usage/garbage_collection.md
@@ -1,0 +1,30 @@
+
+# Garbage Collection (GC) Feature
+
+The etcd-backup-restore project incorporates a Garbage Collection (GC) feature that effectively manages storage space by systematically discarding older backups. The [`RunGarbageCollector`](pkg/snapshot/snapshotter/garbagecollector.go) function orchestrates this process, marking older backups as disposable and subsequently removing them according to predefined rules.
+
+## GC Policies
+
+Garbage Collection policies fall into two categories:
+
+1. **Exponential Policy**: This policy operates on the principle of retaining the most recent snapshots and discarding older ones, with decisions based on the age of snapshots and the time they were captured. The garbage collection process under this policy unfolds as follows:
+
+   - The most recent full snapshot and its associated delta snapshots are perpetually retained, irrespective of the `delta-snapshot-retention-period` setting. This mechanism is vital for potential data recovery.
+   - All delta snapshots that fall within the `delta-snapshot-retention-period` are preserved.
+   - For the current hour, all full snapshots are maintained.
+   - For the past 24 hours, the most recent full snapshot from each hour is kept.
+   - For the past week (up to 7 days), the most recent full snapshot from each day is kept.
+   - For the past month (up to 4 weeks), the most recent full snapshot from each week is kept.
+   - Any full snapshots beyond 5 weeks of age are discarded.
+
+2. **Limit-Based Policy**: This policy ensures that the total number of snapshots does not exceed a specific limit, as defined in the configuration:
+
+   - The most recent full snapshot and its associated delta snapshots are always retained, regardless of the `delta-snapshot-retention-period` setting. This is essential for potential data recovery.
+   - Full snapshots are retained up to the limit set in the configuration. Any full snapshots beyond this limit are removed.
+
+## Retention Period for Delta Snapshots
+
+`delta-snapshot-retention-period`: This setting determines the retention period for older delta snapshots. It does not include the most recent set of snapshots, which are always retained to ensure data safety. The default value for this configuration is 0.
+
+> __Note__: In both policies, the garbage collection process includes listing the snapshots, identifying those that meet deletion criteria, and then removing them. The deletion operation encompasses the removal of associated chunks, which form parts of a larger snapshot.
+

--- a/pkg/snapshot/snapshotter/garbagecollector.go
+++ b/pkg/snapshot/snapshotter/garbagecollector.go
@@ -213,8 +213,18 @@ func garbageCollectChunks(store brtypes.SnapStore, snapList brtypes.SnapList, lo
 	}
 }
 
-// GarbageCollectDeltaSnapshots deletes only the delta snapshots from revision sorted <snapStream>. It won't delete the full snapshot
-// in snapstream which supposed to be at index 0 in <snapStream>.
+/*
+GarbageCollectDeltaSnapshots traverses the list of snapshots and removes delta snapshots that are older than the retention period specified in the Snapshotter's configuration.
+
+Parameters:
+
+	snapStream brtypes.SnapList - List of snapshots to perform garbage collection on.
+
+Returns:
+
+	int - Total number of delta snapshots deleted.
+	error - Error information, if any error occurred during the garbage collection. Returns 'nil' if operation is successful.
+*/
 func (ssr *Snapshotter) GarbageCollectDeltaSnapshots(snapStream brtypes.SnapList) (int, error) {
 	totalDeleted := 0
 	cutoffTime := time.Now().UTC().Add(-ssr.config.DeltaSnapshotRetentionPeriod.Duration)

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -580,7 +580,7 @@ var _ = Describe("Snapshotter", func() {
 
 						deleted, err := ssr.GarbageCollectDeltaSnapshots(list)
 						Expect(err).NotTo(HaveOccurred())
-						Expect(deleted).To(Equal(6))
+						Expect(deleted).To(Equal(deltaSnapshotCount))
 
 						list, err = store.List()
 						Expect(err).ShouldNot(HaveOccurred())
@@ -1095,7 +1095,7 @@ Returns:
 
 	brtypes.SnapStore - The populated snapshot store.
 */
-func prepareStoreWithDeltaSnapshots(storeContainer string, noOfDeltaSnapshots int) brtypes.SnapStore {
+func prepareStoreWithDeltaSnapshots(storeContainer string, numDeltaSnapshots int) brtypes.SnapStore {
 	snapstoreConf := &brtypes.SnapstoreConfig{Container: path.Join(outputDir, storeContainer), Prefix: "v2"}
 	store, err := snapstore.GetSnapstore(snapstoreConf)
 	Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -555,7 +555,7 @@ var _ = Describe("Snapshotter", func() {
 				BeforeEach(func() {
 					snapshotterConfig = &brtypes.SnapshotterConfig{
 						FullSnapshotSchedule:     schedule,
-						DeltaSnapshotPeriod:      wrappers.Duration{Duration: 10 * time.Second},
+						DeltaSnapshotPeriod:      wrappers.Duration{Duration: 10 * time.Minute},
 						DeltaSnapshotMemoryLimit: brtypes.DefaultDeltaSnapMemoryLimit,
 						GarbageCollectionPeriod:  wrappers.Duration{Duration: garbageCollectionPeriod},
 						GarbageCollectionPolicy:  brtypes.GarbageCollectionPolicyLimitBased,
@@ -637,7 +637,7 @@ var _ = Describe("Snapshotter", func() {
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(len(list)).Should(Equal(6))
 
-						snapshotterConfig.DeltaSnapshotRetentionPeriod = wrappers.Duration{Duration: 30 * time.Minute}
+						snapshotterConfig.DeltaSnapshotRetentionPeriod = wrappers.Duration{Duration: 35 * time.Minute}
 						ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
 						Expect(err).ShouldNot(HaveOccurred())
 
@@ -1087,7 +1087,7 @@ prepareStoreWithDeltaSnapshots prepares a snapshot store with a specified number
 Parameters:
 
 	storeContainer: string - Specifies the storeContainer path in the output directory.
-	noOfDeltaSnapshots: int - Specifies the number of delta snapshots to create and store.
+	numDeltaSnapshots: int - Specifies the number of delta snapshots to create and store.
 
 The function creates a snapshot store and populates it with delta snapshots. Each delta snapshot is generated at 9-minute intervals.
 
@@ -1100,8 +1100,8 @@ func prepareStoreWithDeltaSnapshots(storeContainer string, numDeltaSnapshots int
 	store, err := snapstore.GetSnapstore(snapstoreConf)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	snapTime := time.Now().Add(-time.Duration(noOfDeltaSnapshots*9) * time.Minute)
-	for i := 0; i < noOfDeltaSnapshots; i++ {
+	snapTime := time.Now().Add(-time.Duration(numDeltaSnapshots*10) * time.Minute)
+	for i := 0; i < numDeltaSnapshots; i++ {
 		snap := brtypes.Snapshot{
 			Kind:          brtypes.SnapshotKindDelta,
 			CreatedOn:     snapTime,
@@ -1109,7 +1109,6 @@ func prepareStoreWithDeltaSnapshots(storeContainer string, numDeltaSnapshots int
 			LastRevision:  int64(i+1) * 10,
 		}
 		snap.GenerateSnapshotName()
-		// snap.GenerateSnapshotDirectory()
 		snapTime = snapTime.Add(time.Duration(time.Minute * 10))
 		store.Save(snap, io.NopCloser(strings.NewReader(fmt.Sprintf("dummy-snapshot-content for snap created on %s", snap.CreatedOn))))
 	}

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -544,7 +544,7 @@ var _ = Describe("Snapshotter", func() {
 				validateLimitBasedSnapshots(list, maxBackups, snapsInV1)
 			})
 
-			Describe("###garbageCollectDeltaSnapshots", func() {
+			Describe("###GarbageCollectDeltaSnapshots", func() {
 				AfterEach(func() {
 					err = os.RemoveAll(outputDir)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -558,13 +558,12 @@ var _ = Describe("Snapshotter", func() {
 						Expect(len(list)).Should(Equal(6))
 
 						snapshotterConfig := &brtypes.SnapshotterConfig{
-							DeltaSnapshotRetentionPeriod: wrappers.Duration{Duration: 10 * time.Minute},
-							FullSnapshotSchedule:         schedule,
-							DeltaSnapshotPeriod:          wrappers.Duration{Duration: 10 * time.Second},
-							DeltaSnapshotMemoryLimit:     brtypes.DefaultDeltaSnapMemoryLimit,
-							GarbageCollectionPeriod:      wrappers.Duration{Duration: garbageCollectionPeriod},
-							GarbageCollectionPolicy:      brtypes.GarbageCollectionPolicyLimitBased,
-							MaxBackups:                   maxBackups,
+							FullSnapshotSchedule:     schedule,
+							DeltaSnapshotPeriod:      wrappers.Duration{Duration: 10 * time.Second},
+							DeltaSnapshotMemoryLimit: brtypes.DefaultDeltaSnapMemoryLimit,
+							GarbageCollectionPeriod:  wrappers.Duration{Duration: garbageCollectionPeriod},
+							GarbageCollectionPolicy:  brtypes.GarbageCollectionPolicyLimitBased,
+							MaxBackups:               maxBackups,
 						}
 
 						ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
@@ -1087,7 +1086,7 @@ Parameters:
 	storeContainer: string - Specifies the storeContainer path in the output directory.
 	noOfDeltaSnapshots: int - Specifies the number of delta snapshots to create and store.
 
-The function creates a snapshot store and populates it with delta snapshots. Each delta snapshot is generated at 10-minute intervals.
+The function creates a snapshot store and populates it with delta snapshots. Each delta snapshot is generated at 9-minute intervals.
 
 Returns:
 
@@ -1098,7 +1097,7 @@ func prepareStoreWithDeltaSnapshots(storeContainer string, noOfDeltaSnapshots in
 	store, err := snapstore.GetSnapstore(snapstoreConf)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	snapTime := time.Now().Add(-time.Duration(noOfDeltaSnapshots*10) * time.Minute)
+	snapTime := time.Now().Add(-time.Duration(noOfDeltaSnapshots*9) * time.Minute)
 	for i := 0; i < noOfDeltaSnapshots; i++ {
 		snap := brtypes.Snapshot{
 			Kind:          brtypes.SnapshotKindDelta,

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -557,6 +557,16 @@ var _ = Describe("Snapshotter", func() {
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(len(list)).Should(Equal(6))
 
+						snapshotterConfig := &brtypes.SnapshotterConfig{
+							DeltaSnapshotRetentionPeriod: wrappers.Duration{Duration: 10 * time.Minute},
+							FullSnapshotSchedule:         schedule,
+							DeltaSnapshotPeriod:          wrappers.Duration{Duration: 10 * time.Second},
+							DeltaSnapshotMemoryLimit:     brtypes.DefaultDeltaSnapMemoryLimit,
+							GarbageCollectionPeriod:      wrappers.Duration{Duration: garbageCollectionPeriod},
+							GarbageCollectionPolicy:      brtypes.GarbageCollectionPolicyLimitBased,
+							MaxBackups:                   maxBackups,
+						}
+
 						ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
 						Expect(err).ShouldNot(HaveOccurred())
 						deleted, err := ssr.GarbageCollectDeltaSnapshots(list)

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -582,6 +582,9 @@ var _ = Describe("Snapshotter", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(deleted).To(Equal(6))
 
+						list, err = store.List()
+						Expect(err).ShouldNot(HaveOccurred())
+						Expect(len(list)).Should(BeZero())
 					})
 				})
 
@@ -599,6 +602,10 @@ var _ = Describe("Snapshotter", func() {
 						deleted, err := ssr.GarbageCollectDeltaSnapshots(list)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(deleted).Should(BeZero())
+
+						list, err = store.List()
+						Expect(err).ShouldNot(HaveOccurred())
+						Expect(len(list)).Should(BeZero())
 					})
 				})
 
@@ -616,6 +623,10 @@ var _ = Describe("Snapshotter", func() {
 						deleted, err := ssr.GarbageCollectDeltaSnapshots(list)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(deleted).Should(BeZero())
+
+						list, err = store.List()
+						Expect(err).ShouldNot(HaveOccurred())
+						Expect(len(list)).Should(Equal(deltaSnapshotCount))
 					})
 				})
 
@@ -633,6 +644,10 @@ var _ = Describe("Snapshotter", func() {
 						deleted, err := ssr.GarbageCollectDeltaSnapshots(list)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(deleted).To(Equal(3))
+
+						list, err = store.List()
+						Expect(err).ShouldNot(HaveOccurred())
+						Expect(len(list)).Should(Equal(3))
 					})
 				})
 			})

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"path"
 	"strconv"
 	"sync"
@@ -516,36 +517,8 @@ var _ = Describe("Snapshotter", func() {
 			})
 
 			// Test to check backward compatibility of garbage collector
-			// Tests garbage collector behaviour (in limit based config) when both v1 and v2 directories are present
+			// Tests garbage collector behaviour (in limit based config) when only v1 directory is present
 			// TODO: Consider removing when backward compatibility no longer needed
-			/*It("should garbage collect limitBased from both v1 and v2 dir structures (backward compatibility test)", func() {
-				now := time.Now().UTC()
-				store := prepareStoreForBackwardCompatibleGC(now, "gc_limit_based_backward_compatible.bkp")
-				snapshotterConfig := &brtypes.SnapshotterConfig{
-					FullSnapshotSchedule:     schedule,
-					DeltaSnapshotPeriod:      wrappers.Duration{Duration: 10 * time.Second},
-					DeltaSnapshotMemoryLimit: brtypes.DefaultDeltaSnapMemoryLimit,
-					GarbageCollectionPeriod:  wrappers.Duration{Duration: garbageCollectionPeriod},
-					GarbageCollectionPolicy:  brtypes.GarbageCollectionPolicyLimitBased,
-					MaxBackups:               maxBackups,
-				}
-
-				ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				gcCtx, cancel := context.WithTimeout(testCtx, testTimeout)
-				defer cancel()
-				ssr.RunGarbageCollector(gcCtx.Done())
-
-				list, err := store.List()
-				Expect(err).ShouldNot(HaveOccurred())
-
-				validateLimitBasedSnapshots(list, maxBackups, snapsInV2)
-			})*/
-
-			//Test to check backward compatibility of garbage collector
-			//Tests garbage collector behaviour (in limit based config) when only v1 directory is present
-			//TODO: Consider removing when backward compatibility no longer needed
 			It("should garbage collect limitBased with only v1 dir structure present (backward compatible test)", func() {
 				now := time.Now().UTC()
 				store, snapstoreConfig := prepareStoreForGarbageCollection(now, "gc_limit_based_backward_compatiblev1.bkp", "v1")
@@ -570,192 +543,287 @@ var _ = Describe("Snapshotter", func() {
 
 				validateLimitBasedSnapshots(list, maxBackups, snapsInV1)
 			})
+
+			Describe("###garbageCollectDeltaSnapshots", func() {
+				AfterEach(func() {
+					err = os.RemoveAll(outputDir)
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+
+				Context("with all delta snapshots older than retention period", func() {
+					It("should delete all delta snapshots", func() {
+						store := prepareStoreWithDeltaSnapshots("garbagecollector_deltasnapshots.bkp", 6)
+						list, err := store.List()
+						Expect(err).ShouldNot(HaveOccurred())
+						Expect(len(list)).Should(Equal(6))
+
+						ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+						Expect(err).ShouldNot(HaveOccurred())
+						deleted, err := ssr.GarbageCollectDeltaSnapshots(list)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(deleted).To(Equal(6))
+
+					})
+				})
+
+				Context("with no delta snapshots", func() {
+					It("should not delete any snapshots", func() {
+						store := prepareStoreWithDeltaSnapshots("garbagecollector_deltasnapshots.bkp", 0)
+						list, err := store.List()
+						Expect(err).ShouldNot(HaveOccurred())
+						Expect(len(list)).Should(Equal(0))
+
+						snapshotterConfig := &brtypes.SnapshotterConfig{
+							DeltaSnapshotRetentionPeriod: wrappers.Duration{Duration: 10 * time.Minute},
+							FullSnapshotSchedule:         schedule,
+							DeltaSnapshotPeriod:          wrappers.Duration{Duration: 10 * time.Second},
+							DeltaSnapshotMemoryLimit:     brtypes.DefaultDeltaSnapMemoryLimit,
+							GarbageCollectionPeriod:      wrappers.Duration{Duration: garbageCollectionPeriod},
+							GarbageCollectionPolicy:      brtypes.GarbageCollectionPolicyLimitBased,
+							MaxBackups:                   maxBackups,
+						}
+						ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+						Expect(err).ShouldNot(HaveOccurred())
+						deleted, err := ssr.GarbageCollectDeltaSnapshots(list)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(deleted).To(Equal(0))
+					})
+				})
+
+				Context("with all delta snapshots younger than retention period", func() {
+					It("should not delete any snapshots", func() {
+						store := prepareStoreWithDeltaSnapshots("garbagecollector_deltasnapshots.bkp", 6)
+						list, err := store.List()
+						Expect(err).ShouldNot(HaveOccurred())
+						Expect(len(list)).Should(Equal(6))
+
+						snapshotterConfig := &brtypes.SnapshotterConfig{
+							DeltaSnapshotRetentionPeriod: wrappers.Duration{Duration: 600 * time.Minute},
+							FullSnapshotSchedule:         schedule,
+							DeltaSnapshotPeriod:          wrappers.Duration{Duration: 10 * time.Second},
+							DeltaSnapshotMemoryLimit:     brtypes.DefaultDeltaSnapMemoryLimit,
+							GarbageCollectionPeriod:      wrappers.Duration{Duration: garbageCollectionPeriod},
+							GarbageCollectionPolicy:      brtypes.GarbageCollectionPolicyLimitBased,
+							MaxBackups:                   maxBackups,
+						}
+
+						ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+						Expect(err).ShouldNot(HaveOccurred())
+						deleted, err := ssr.GarbageCollectDeltaSnapshots(list)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(deleted).To(Equal(0))
+					})
+				})
+
+				Context("with a mix of delta snapshots, some older and some younger than retention period", func() {
+					It("should delete only the delta snapshots older than the retention period", func() {
+						store := prepareStoreWithDeltaSnapshots("garbagecollector_deltasnapshots.bkp", 6)
+						list, err := store.List()
+						Expect(err).ShouldNot(HaveOccurred())
+						Expect(len(list)).Should(Equal(6))
+
+						snapshotterConfig := &brtypes.SnapshotterConfig{
+							DeltaSnapshotRetentionPeriod: wrappers.Duration{Duration: 30 * time.Minute},
+							FullSnapshotSchedule:         schedule,
+							DeltaSnapshotPeriod:          wrappers.Duration{Duration: 10 * time.Second},
+							DeltaSnapshotMemoryLimit:     brtypes.DefaultDeltaSnapMemoryLimit,
+							GarbageCollectionPeriod:      wrappers.Duration{Duration: garbageCollectionPeriod},
+							GarbageCollectionPolicy:      brtypes.GarbageCollectionPolicyLimitBased,
+							MaxBackups:                   maxBackups,
+						}
+						ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+						Expect(err).ShouldNot(HaveOccurred())
+						deleted, err := ssr.GarbageCollectDeltaSnapshots(list)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(deleted).To(Equal(3))
+					})
+				})
+			})
+		})
+
+		Describe("Scenarios to take full-snapshot during startup of backup-restore", func() {
+			var (
+				ssr                    *Snapshotter
+				currentMin             int
+				currentHour            int
+				fullSnapshotTimeWindow float64
+			)
+			BeforeEach(func() {
+				fullSnapshotTimeWindow = 24
+				currentHour = time.Now().Hour()
+				currentMin = time.Now().Minute()
+				snapstoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, "default.bkp")}
+				store, err = snapstore.GetSnapstore(snapstoreConfig)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+			Context("No previous snapshot was taken", func() {
+				It("should return true", func() {
+					snapshotterConfig := &brtypes.SnapshotterConfig{
+						FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", (currentMin+1)%60, (currentHour+2)%24),
+					}
+
+					ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					// No previous snapshot was taken
+					ssr.PrevFullSnapshot = nil
+					isFullSnapMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
+					Expect(isFullSnapMissed).Should(BeTrue())
+				})
+			})
+			Context("If previous snapshot was final full snapshot", func() {
+				It("should return true", func() {
+					snapshotterConfig := &brtypes.SnapshotterConfig{
+						FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", (currentMin+1)%60, (currentHour+2)%24),
+					}
+
+					ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					// If previous snapshot was final full snapshot
+					ssr.PrevFullSnapshot = &brtypes.Snapshot{
+						IsFinal: true,
+					}
+					isFullSnapMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
+					Expect(isFullSnapMissed).Should(BeTrue())
+				})
+			})
+			Context("Previous full snapshot was taken more than 24hrs before", func() {
+				It("should return true", func() {
+					snapshotterConfig := &brtypes.SnapshotterConfig{
+						FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", (currentMin+1)%60, (currentHour+2)%24),
+					}
+
+					ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					// Previous full snapshot was taken 2 days before
+					ssr.PrevFullSnapshot = &brtypes.Snapshot{
+						CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day()-2, currentHour, currentMin, 0, 0, time.Local),
+					}
+					isFullSnapMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
+					Expect(isFullSnapMissed).Should(BeTrue())
+				})
+			})
+
+			Context("Previous full snapshot was taken exactly at scheduled snapshot time, no FullSnapshot was missed", func() {
+				It("should return false", func() {
+					snapshotterConfig := &brtypes.SnapshotterConfig{
+						FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", (currentMin+1)%60, (currentHour+2)%24),
+					}
+
+					ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					// Previous full snapshot was taken 1 days before at exactly at scheduled time
+					ssr.PrevFullSnapshot = &brtypes.Snapshot{
+						CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day()-1, (currentHour+2)%24, (currentMin+1)%60, 0, 0, time.Local),
+					}
+
+					isFullSnapMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
+					Expect(isFullSnapMissed).Should(BeFalse())
+				})
+			})
+
+			Context("Previous snapshot was taken within 24hrs and next schedule full-snapshot will be taken within 24hs of time window", func() {
+				It("should return false", func() {
+					scheduleHour := (currentHour + 4) % 24
+					snapshotterConfig := &brtypes.SnapshotterConfig{
+						FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", currentMin, scheduleHour),
+					}
+
+					ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					// Previous full snapshot was taken 4hrs 10 mins before startup of backup-restore
+					ssr.PrevFullSnapshot = &brtypes.Snapshot{
+						CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), (currentHour-4)%24, (currentMin-10)%60, 0, 0, time.Local),
+					}
+					isFullSnapCanBeMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
+					Expect(isFullSnapCanBeMissed).Should(BeFalse())
+				})
+			})
+
+			Context("Previous snapshot was taken within 24hrs and next schedule full-snapshot likely to cross 24hs of time window", func() {
+				It("should return true", func() {
+					scheduleHour := (currentHour + 8) % 24
+					snapshotterConfig := &brtypes.SnapshotterConfig{
+						FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", currentMin, scheduleHour),
+					}
+
+					ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					// Previous full snapshot was taken 18hrs(<24hrs) before startup of backup-restore
+					ssr.PrevFullSnapshot = &brtypes.Snapshot{
+						CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), (currentHour-18)%24, (currentMin)%60, 0, 0, time.Local),
+					}
+					isFullSnapCanBeMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
+					Expect(isFullSnapCanBeMissed).Should(BeTrue())
+				})
+			})
+		})
+
+		Describe("Scenarios to get maximum time window for full snapshot", func() {
+			var (
+				ssr                    *Snapshotter
+				currentMin             int
+				currentHour            int
+				fullSnapshotTimeWindow float64
+			)
+			BeforeEach(func() {
+				fullSnapshotTimeWindow = 24
+				currentHour = time.Now().Hour()
+				currentMin = time.Now().Minute()
+				snapstoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, "default.bkp")}
+				store, err = snapstore.GetSnapstore(snapstoreConfig)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+			Context("Full snapshot schedule for once a day", func() {
+				It("should return 24hours of timeWindow", func() {
+					snapshotterConfig := &brtypes.SnapshotterConfig{
+						FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", currentMin, currentHour),
+					}
+
+					ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					timeWindow := ssr.GetFullSnapshotMaxTimeWindow(snapshotterConfig.FullSnapshotSchedule)
+					Expect(timeWindow).Should(Equal(fullSnapshotTimeWindow))
+				})
+			})
+
+			Context("Full snapshot schedule for once in a week", func() {
+				It("should return 24*7 hours of timeWindow", func() {
+					snapshotterConfig := &brtypes.SnapshotterConfig{
+						FullSnapshotSchedule: fmt.Sprintf("%d %d * * %d", currentMin, currentHour, time.Thursday),
+					}
+
+					ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					timeWindow := ssr.GetFullSnapshotMaxTimeWindow(snapshotterConfig.FullSnapshotSchedule)
+					Expect(timeWindow).Should(Equal(fullSnapshotTimeWindow * 7))
+				})
+			})
+
+			Context("Full snapshot schedule for every 4 hours", func() {
+				It("should return 4 hours of timeWindow", func() {
+					// every 4 hour
+					scheduleHour := 4
+					snapshotterConfig := &brtypes.SnapshotterConfig{
+						FullSnapshotSchedule: fmt.Sprintf("%d */%d * * *", 0, scheduleHour),
+					}
+
+					ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					timeWindow := ssr.GetFullSnapshotMaxTimeWindow(snapshotterConfig.FullSnapshotSchedule)
+					Expect(timeWindow).Should(Equal(float64(scheduleHour)))
+				})
+			})
 		})
 	})
-
-	Describe("Scenarios to take full-snapshot during startup of backup-restore", func() {
-		var (
-			ssr                    *Snapshotter
-			currentMin             int
-			currentHour            int
-			fullSnapshotTimeWindow float64
-		)
-		BeforeEach(func() {
-			fullSnapshotTimeWindow = 24
-			currentHour = time.Now().Hour()
-			currentMin = time.Now().Minute()
-			snapstoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, "default.bkp")}
-			store, err = snapstore.GetSnapstore(snapstoreConfig)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-		Context("No previous snapshot was taken", func() {
-			It("should return true", func() {
-				snapshotterConfig := &brtypes.SnapshotterConfig{
-					FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", (currentMin+1)%60, (currentHour+2)%24),
-				}
-
-				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				// No previous snapshot was taken
-				ssr.PrevFullSnapshot = nil
-				isFullSnapMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
-				Expect(isFullSnapMissed).Should(BeTrue())
-			})
-		})
-		Context("If previous snapshot was final full snapshot", func() {
-			It("should return true", func() {
-				snapshotterConfig := &brtypes.SnapshotterConfig{
-					FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", (currentMin+1)%60, (currentHour+2)%24),
-				}
-
-				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				// If previous snapshot was final full snapshot
-				ssr.PrevFullSnapshot = &brtypes.Snapshot{
-					IsFinal: true,
-				}
-				isFullSnapMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
-				Expect(isFullSnapMissed).Should(BeTrue())
-			})
-		})
-		Context("Previous full snapshot was taken more than 24hrs before", func() {
-			It("should return true", func() {
-				snapshotterConfig := &brtypes.SnapshotterConfig{
-					FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", (currentMin+1)%60, (currentHour+2)%24),
-				}
-
-				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				// Previous full snapshot was taken 2 days before
-				ssr.PrevFullSnapshot = &brtypes.Snapshot{
-					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day()-2, currentHour, currentMin, 0, 0, time.Local),
-				}
-				isFullSnapMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
-				Expect(isFullSnapMissed).Should(BeTrue())
-			})
-		})
-
-		Context("Previous full snapshot was taken exactly at scheduled snapshot time, no FullSnapshot was missed", func() {
-			It("should return false", func() {
-				snapshotterConfig := &brtypes.SnapshotterConfig{
-					FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", (currentMin+1)%60, (currentHour+2)%24),
-				}
-
-				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				// Previous full snapshot was taken 1 days before at exactly at scheduled time
-				ssr.PrevFullSnapshot = &brtypes.Snapshot{
-					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day()-1, (currentHour+2)%24, (currentMin+1)%60, 0, 0, time.Local),
-				}
-
-				isFullSnapMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
-				Expect(isFullSnapMissed).Should(BeFalse())
-			})
-		})
-
-		Context("Previous snapshot was taken within 24hrs and next schedule full-snapshot will be taken within 24hs of time window", func() {
-			It("should return false", func() {
-				scheduleHour := (currentHour + 4) % 24
-				snapshotterConfig := &brtypes.SnapshotterConfig{
-					FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", currentMin, scheduleHour),
-				}
-
-				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				// Previous full snapshot was taken 4hrs 10 mins before startup of backup-restore
-				ssr.PrevFullSnapshot = &brtypes.Snapshot{
-					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), (currentHour-4)%24, (currentMin-10)%60, 0, 0, time.Local),
-				}
-				isFullSnapCanBeMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
-				Expect(isFullSnapCanBeMissed).Should(BeFalse())
-			})
-		})
-
-		Context("Previous snapshot was taken within 24hrs and next schedule full-snapshot likely to cross 24hs of time window", func() {
-			It("should return true", func() {
-				scheduleHour := (currentHour + 8) % 24
-				snapshotterConfig := &brtypes.SnapshotterConfig{
-					FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", currentMin, scheduleHour),
-				}
-
-				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				// Previous full snapshot was taken 18hrs(<24hrs) before startup of backup-restore
-				ssr.PrevFullSnapshot = &brtypes.Snapshot{
-					CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), (currentHour-18)%24, (currentMin)%60, 0, 0, time.Local),
-				}
-				isFullSnapCanBeMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
-				Expect(isFullSnapCanBeMissed).Should(BeTrue())
-			})
-		})
-	})
-
-	Describe("Scenarios to get maximum time window for full snapshot", func() {
-		var (
-			ssr                    *Snapshotter
-			currentMin             int
-			currentHour            int
-			fullSnapshotTimeWindow float64
-		)
-		BeforeEach(func() {
-			fullSnapshotTimeWindow = 24
-			currentHour = time.Now().Hour()
-			currentMin = time.Now().Minute()
-			snapstoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, "default.bkp")}
-			store, err = snapstore.GetSnapstore(snapstoreConfig)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-		Context("Full snapshot schedule for once a day", func() {
-			It("should return 24hours of timeWindow", func() {
-				snapshotterConfig := &brtypes.SnapshotterConfig{
-					FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", currentMin, currentHour),
-				}
-
-				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				timeWindow := ssr.GetFullSnapshotMaxTimeWindow(snapshotterConfig.FullSnapshotSchedule)
-				Expect(timeWindow).Should(Equal(fullSnapshotTimeWindow))
-			})
-		})
-
-		Context("Full snapshot schedule for once in a week", func() {
-			It("should return 24*7 hours of timeWindow", func() {
-				snapshotterConfig := &brtypes.SnapshotterConfig{
-					FullSnapshotSchedule: fmt.Sprintf("%d %d * * %d", currentMin, currentHour, time.Thursday),
-				}
-
-				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				timeWindow := ssr.GetFullSnapshotMaxTimeWindow(snapshotterConfig.FullSnapshotSchedule)
-				Expect(timeWindow).Should(Equal(fullSnapshotTimeWindow * 7))
-			})
-		})
-
-		Context("Full snapshot schedule for every 4 hours", func() {
-			It("should return 4 hours of timeWindow", func() {
-				// every 4 hour
-				scheduleHour := 4
-				snapshotterConfig := &brtypes.SnapshotterConfig{
-					FullSnapshotSchedule: fmt.Sprintf("%d */%d * * *", 0, scheduleHour),
-				}
-
-				ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				timeWindow := ssr.GetFullSnapshotMaxTimeWindow(snapshotterConfig.FullSnapshotSchedule)
-				Expect(timeWindow).Should(Equal(float64(scheduleHour)))
-			})
-		})
-	})
-
 })
 
 // prepareExpectedSnapshotsList prepares the expected snapshotlist based on directory structure
@@ -869,129 +937,6 @@ func prepareExpectedSnapshotsList(snapTime time.Time, now time.Time, expectedSna
 	fmt.Println("Incremental snapshot list prepared")
 	return expectedSnapList
 }
-
-/*func prepareExpectedSnapshotsList(snapTime time.Time, now time.Time, mode string) brtypes.SnapList {
-	var expectedSnapList brtypes.SnapList
-	var dir string
-
-	// weekly snapshot
-	for i := 1; i <= 4; i++ {
-		snapTime = snapTime.Add(time.Duration(time.Hour * 24 * 7))
-		if (mode == snapsInV1) || (mode == mixed && (i == 1 || i == 2)) {
-			dir = fmt.Sprintf("Backup-%d", snapTime.Unix())
-		} else {
-			dir = ""
-		}
-		snap := &brtypes.Snapshot{
-			Kind:          brtypes.SnapshotKindFull,
-			CreatedOn:     snapTime,
-			StartRevision: 0,
-			LastRevision:  1001,
-			SnapDir:       dir,
-		}
-		snap.GenerateSnapshotName()
-		expectedSnapList = append(expectedSnapList, snap)
-	}
-	fmt.Println("Weekly snapshot list prepared")
-	fmt.Printf("len: %d", len(expectedSnapList))
-
-	// daily snapshot
-	for i := 1; i <= 7; i++ {
-		snapTime = snapTime.Add(time.Duration(time.Hour * 24))
-		if mode == snapsInV1 {
-			dir = fmt.Sprintf("Backup-%d", snapTime.Unix())
-		} else {
-			dir = ""
-		}
-		snap := &brtypes.Snapshot{
-			Kind:          brtypes.SnapshotKindFull,
-			CreatedOn:     snapTime,
-			StartRevision: 0,
-			LastRevision:  1001,
-			SnapDir:       dir,
-		}
-		snap.GenerateSnapshotName()
-		expectedSnapList = append(expectedSnapList, snap)
-	}
-	fmt.Println("Daily snapshot list prepared")
-
-	// hourly snapshot
-	snapTime = snapTime.Add(time.Duration(time.Hour))
-	for now.Truncate(time.Hour).Sub(snapTime) > 0 {
-		if mode == snapsInV1 {
-			dir = fmt.Sprintf("Backup-%d", snapTime.Unix())
-		} else {
-			dir = ""
-		}
-		snap := &brtypes.Snapshot{
-			Kind:          brtypes.SnapshotKindFull,
-			CreatedOn:     snapTime,
-			StartRevision: 0,
-			LastRevision:  1001,
-			SnapDir:       dir,
-		}
-		snap.GenerateSnapshotName()
-		expectedSnapList = append(expectedSnapList, snap)
-		snapTime = snapTime.Add(time.Duration(time.Hour))
-	}
-	fmt.Println("Hourly snapshot list prepared")
-
-	// current hour
-	snapTime = now.Truncate(time.Hour)
-	if mode == snapsInV1 {
-		dir = fmt.Sprintf("Backup-%d", snapTime.Unix())
-	} else {
-		dir = ""
-	}
-	snap := &brtypes.Snapshot{
-		Kind:          brtypes.SnapshotKindFull,
-		CreatedOn:     snapTime,
-		StartRevision: 0,
-		LastRevision:  1001,
-		SnapDir:       dir,
-	}
-	snap.GenerateSnapshotName()
-	expectedSnapList = append(expectedSnapList, snap)
-	snapTime = snapTime.Add(time.Duration(time.Minute * 30))
-	for now.Sub(snapTime) >= 0 {
-		if mode == snapsInV1 {
-			dir = fmt.Sprintf("Backup-%d", snapTime.Unix())
-		} else {
-			dir = ""
-		}
-		snap := &brtypes.Snapshot{
-			Kind:          brtypes.SnapshotKindFull,
-			CreatedOn:     snapTime,
-			StartRevision: 0,
-			LastRevision:  1001,
-			SnapDir:       dir,
-		}
-		snap.GenerateSnapshotName()
-		expectedSnapList = append(expectedSnapList, snap)
-		snapTime = snapTime.Add(time.Duration(time.Minute * 30))
-	}
-	fmt.Println("Current hour full snapshot list prepared")
-
-	// delta snapshots
-	snapTime = snapTime.Add(time.Duration(-time.Minute * 30))
-	snapTime = snapTime.Add(time.Duration(time.Minute * 10))
-	for now.Sub(snapTime) >= 0 {
-		snap := &brtypes.Snapshot{
-			Kind:          brtypes.SnapshotKindDelta,
-			CreatedOn:     snapTime,
-			StartRevision: 0,
-			LastRevision:  1001,
-			SnapDir:       dir,
-		}
-		snap.GenerateSnapshotName()
-		expectedSnapList = append(expectedSnapList, snap)
-		snapTime = snapTime.Add(time.Duration(time.Minute * 10))
-	}
-	fmt.Println("Incremental snapshot list prepared")
-
-	return expectedSnapList
-}
-*/
 
 // prepareStoreForGarbageCollection populates the store with dummy snapshots for garbage collection tests
 func prepareStoreForGarbageCollection(forTime time.Time, storeContainer string, storePrefix string) (brtypes.SnapStore, *brtypes.SnapstoreConfig) {
@@ -1122,4 +1067,40 @@ func validateLimitBasedSnapshots(list brtypes.SnapList, maxBackups uint, mode st
 			}
 		}
 	}
+}
+
+/*
+prepareStoreWithDeltaSnapshots prepares a snapshot store with a specified number of delta snapshots.
+
+Parameters:
+
+	storeContainer: string - Specifies the storeContainer path in the output directory.
+	noOfDeltaSnapshots: int - Specifies the number of delta snapshots to create and store.
+
+The function creates a snapshot store and populates it with delta snapshots. Each delta snapshot is generated at 10-minute intervals.
+
+Returns:
+
+	brtypes.SnapStore - The populated snapshot store.
+*/
+func prepareStoreWithDeltaSnapshots(storeContainer string, noOfDeltaSnapshots int) brtypes.SnapStore {
+	snapstoreConf := &brtypes.SnapstoreConfig{Container: path.Join(outputDir, storeContainer), Prefix: "v2"}
+	store, err := snapstore.GetSnapstore(snapstoreConf)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	snapTime := time.Now().Add(-time.Duration(noOfDeltaSnapshots*10) * time.Minute)
+	for i := 0; i < noOfDeltaSnapshots; i++ {
+		snap := brtypes.Snapshot{
+			Kind:          brtypes.SnapshotKindDelta,
+			CreatedOn:     snapTime,
+			StartRevision: int64(i) * 10,
+			LastRevision:  int64(i+1) * 10,
+		}
+		snap.GenerateSnapshotName()
+		// snap.GenerateSnapshotDirectory()
+		snapTime = snapTime.Add(time.Duration(time.Minute * 10))
+		store.Save(snap, io.NopCloser(strings.NewReader(fmt.Sprintf("dummy-snapshot-content for snap created on %s", snap.CreatedOn))))
+	}
+
+	return store
 }

--- a/pkg/types/snapshotter.go
+++ b/pkg/types/snapshotter.go
@@ -56,12 +56,13 @@ type SnapshotterState int
 
 // SnapshotterConfig holds the snapshotter config.
 type SnapshotterConfig struct {
-	FullSnapshotSchedule     string            `json:"schedule,omitempty"`
-	DeltaSnapshotPeriod      wrappers.Duration `json:"deltaSnapshotPeriod,omitempty"`
-	DeltaSnapshotMemoryLimit uint              `json:"deltaSnapshotMemoryLimit,omitempty"`
-	GarbageCollectionPeriod  wrappers.Duration `json:"garbageCollectionPeriod,omitempty"`
-	GarbageCollectionPolicy  string            `json:"garbageCollectionPolicy,omitempty"`
-	MaxBackups               uint              `json:"maxBackups,omitempty"`
+	FullSnapshotSchedule         string            `json:"schedule,omitempty"`
+	DeltaSnapshotPeriod          wrappers.Duration `json:"deltaSnapshotPeriod,omitempty"`
+	DeltaSnapshotMemoryLimit     uint              `json:"deltaSnapshotMemoryLimit,omitempty"`
+	GarbageCollectionPeriod      wrappers.Duration `json:"garbageCollectionPeriod,omitempty"`
+	GarbageCollectionPolicy      string            `json:"garbageCollectionPolicy,omitempty"`
+	MaxBackups                   uint              `json:"maxBackups,omitempty"`
+	DeltaSnapshotRetentionPeriod wrappers.Duration `json:"deltaSnapshotRetentionPeriod,omitempty"`
 }
 
 // AddFlags adds the flags to flagset.
@@ -72,6 +73,7 @@ func (c *SnapshotterConfig) AddFlags(fs *flag.FlagSet) {
 	fs.DurationVar(&c.GarbageCollectionPeriod.Duration, "garbage-collection-period", c.GarbageCollectionPeriod.Duration, "Period for garbage collecting old backups")
 	fs.StringVar(&c.GarbageCollectionPolicy, "garbage-collection-policy", c.GarbageCollectionPolicy, "Policy for garbage collecting old backups")
 	fs.UintVarP(&c.MaxBackups, "max-backups", "m", c.MaxBackups, "maximum number of previous backups to keep")
+	fs.DurationVar(&c.DeltaSnapshotRetentionPeriod.Duration, "delta-snapshot-retention-period", c.DeltaSnapshotRetentionPeriod.Duration, "Defines the retention period for older delta snapshots, excluding the latest snapshot set which is always retained for data safety.")
 }
 
 // Validate validates the config.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR resolves the request for a configurable retention period for delta snapshots. This feature aims to provide users with more flexibility in preserving delta snapshots for both GC policies (`Exponential` and `Limit-Based`) 

#### Changes introduced in this PR include:

- Added a new `delta-snapshot-retention-period` parameter in the `SnapshotterConfig` to allow for the customization of the retention period for delta snapshots. This new setting can be adjusted via command-line flags.
- Modified the `GarbageCollectDeltaSnapshots` function, formerly `garbageCollectDeltaSnapshots`, to utilize the `DeltaSnapshotRetentionPeriod` parameter when identifying delta snapshots for deletion. This change ensures that delta snapshots within the user-specified retention period will not be deleted.
- Added documentation on the garbage collection mechanism (`doc/usage/garbage_collection.md`) to include a detailed explanation of the new `delta-snapshot-retention-period` setting.
- Exported function `GarbageCollectDeltaSnapshots` to add unit tests. 
- Removed dead code from `snapshotter_test.go`

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/etcd-backup-restore/issues/639

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Introduced `delta-snapshot-retention-period` CLI flag to extend the configurable retention period for delta snapshots in `etcd-backup-restore`, enhancing flexibility for backup retention.
```
