### PR TITLE
Add CVE categorization for etcd-backup-restore

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -40,6 +40,15 @@ etcd-backup-restore:
                 source: ~
               steps:
                 build: ~
+            resource_labels:
+            - name: 'gardener.cloud/cve-categorisation'
+              value:
+                network_exposure: 'protected'
+                authentication_enforced: false
+                user_interaction: 'gardener-operator'
+                confidentiality_requirement: 'high'
+                integrity_requirement: 'high'
+                availability_requirement: 'high'
     steps:
       check:
         image: 'golang:1.20.3'


### PR DESCRIPTION
**What this PR does / why we need it**:
Add CVE categorization to etcd-backup-restore within the gardener context.

**Which issue(s) this PR fixes**:
Fixes partially https://github.com/gardener/etcd-druid/issues/633

**Special notes for your reviewer**:
/invite @ashwani2k 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Add CVE categorization for etcd-backup-restore.
```
