### PR TITLE
Skip scale-up checks for first member of etcd cluster.

### DIFF
--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/gardener/etcd-backup-restore/pkg/errors"
@@ -57,8 +58,14 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 	ctx := context.Background()
 	var err error
 
-	//Etcd cluster scale-up case
-	if miscellaneous.IsMultiNode(logger) {
+	podName, err := miscellaneous.GetEnvVarOrError("POD_NAME")
+	if err != nil {
+		logger.Fatalf("Error reading POD_NAME env var : %v", err)
+	}
+
+	// Etcd cluster scale-up case
+	// Note: first member of etcd cluster can never be part of scale-up case.
+	if miscellaneous.IsMultiNode(logger) && !strings.HasSuffix(podName, "0") {
 		clientSet, err := miscellaneous.GetKubernetesClientSetOrError()
 		if err != nil {
 			logger.Fatalf("failed to create clientset, %v", err)

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -65,6 +65,7 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 
 	// Etcd cluster scale-up case
 	// Note: first member of etcd cluster can never be part of scale-up case.
+	// TODO: consider removing this special check for first cluster member when backup-restore can check presence of any member in cluster.
 	if miscellaneous.IsMultiNode(logger) && !strings.HasSuffix(podName, "0") {
 		clientSet, err := miscellaneous.GetKubernetesClientSetOrError()
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables the first member to skips the scale-up checks as first member of etcd cluster can never be part of scale-up(`1->3 replicas`). please check this: https://github.com/gardener/etcd-backup-restore/issues/646#issuecomment-1635716166


**Which issue(s) this PR fixes**:
Fixes #646 

**Special notes for your reviewer**:

**Release note**:
```improvement operator
While scaling up a non-HA etcd cluster to HA skipping the scale-up checks for first member of etcd cluster as first member can never be a part of scale-up scenarios.
```
