### PR TITLE
Adds sleep command at the end of compaction.

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -182,7 +182,21 @@ func (cp *Compactor) Compact(ctx context.Context, opts *brtypes.CompactOptions) 
 	}
 
 	// Add a sleep command so that prometheus can collect necessary metrics related to the uploading of snapshots. see https://github.com/gardener/etcd-druid/issues/648
-	time.Sleep(opts.SleepTimeout.Duration)
+	err = SleepWithContext(ctx, opts.SleepFor.Duration)
+	if err != nil {
+		cp.logger.Warnf("Could not sleep for specified duration: %v", err)
+	}
 
 	return snapshot, nil
+}
+
+func SleepWithContext(ctx context.Context, sleepFor time.Duration) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(sleepFor):
+			return nil
+		}
+	}
 }

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -182,7 +182,7 @@ func (cp *Compactor) Compact(ctx context.Context, opts *brtypes.CompactOptions) 
 	}
 
 	// Add a sleep command so that prometheus can collect necessary metrics related to the uploading of snapshots. see https://github.com/gardener/etcd-druid/issues/648
-	err = SleepWithContext(ctx, opts.SleepFor.Duration)
+	err = sleepWithContext(ctx, opts.SleepForScrape.Duration)
 	if err != nil {
 		cp.logger.Warnf("Could not sleep for specified duration: %v", err)
 	}
@@ -190,7 +190,7 @@ func (cp *Compactor) Compact(ctx context.Context, opts *brtypes.CompactOptions) 
 	return snapshot, nil
 }
 
-func SleepWithContext(ctx context.Context, sleepFor time.Duration) error {
+func sleepWithContext(ctx context.Context, sleepFor time.Duration) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -182,7 +182,7 @@ func (cp *Compactor) Compact(ctx context.Context, opts *brtypes.CompactOptions) 
 	}
 
 	// Add a sleep command so that prometheus can collect necessary metrics related to the uploading of snapshots. see https://github.com/gardener/etcd-druid/issues/648
-	err = sleepWithContext(ctx, opts.SleepForScrape.Duration)
+	err = sleepWithContext(ctx, opts.MetricsScrapeWaitDuration.Duration)
 	if err != nil {
 		cp.logger.Warnf("Could not sleep for specified duration: %v", err)
 	}

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -181,5 +181,8 @@ func (cp *Compactor) Compact(ctx context.Context, opts *brtypes.CompactOptions) 
 		cancel()
 	}
 
+	// Add a sleep command so that prometheus can collect necessary metrics related to the uploading of snapshots. see https://github.com/gardener/etcd-druid/issues/648
+	time.Sleep(opts.SleepTimeout.Duration)
+
 	return snapshot, nil
 }

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -39,8 +39,8 @@ var _ = Describe("Running Compactor", func() {
 		embeddedEtcdQuotaBytes int64  = 8 * 1024 * 1024 * 1024
 		snapshotTimeout               = 30 * time.Second
 		defragTimeout                 = 30 * time.Second
-		// keep SleepFor low so that tests are faster
-		sleepFor            = 10 * time.Nanosecond
+		// keep SleepForScrape low so that tests are faster
+		sleepForScrape      = 10 * time.Nanosecond
 		needDefragmentation = true
 	)
 
@@ -95,7 +95,7 @@ var _ = Describe("Running Compactor", func() {
 				SnapshotTimeout:     wrappers.Duration{Duration: snapshotTimeout},
 				DefragTimeout:       wrappers.Duration{Duration: defragTimeout},
 				EnabledLeaseRenewal: false,
-				SleepFor:            wrappers.Duration{Duration: sleepFor},
+				SleepForScrape:      wrappers.Duration{Duration: sleepForScrape},
 			}
 			compactOptions = &brtypes.CompactOptions{
 				RestoreOptions:  restoreOpts,

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -39,9 +39,7 @@ var _ = Describe("Running Compactor", func() {
 		embeddedEtcdQuotaBytes int64  = 8 * 1024 * 1024 * 1024
 		snapshotTimeout               = 30 * time.Second
 		defragTimeout                 = 30 * time.Second
-		// keep SleepForScrape 0 so that tests are faster
-		sleepForScrape      = 0 * time.Second
-		needDefragmentation = true
+		needDefragmentation           = true
 	)
 
 	BeforeEach(func() {
@@ -91,11 +89,11 @@ var _ = Describe("Running Compactor", func() {
 				PeerURLs:    peerUrls,
 			}
 			compactorConfig = &brtypes.CompactorConfig{
-				NeedDefragmentation: needDefragmentation,
-				SnapshotTimeout:     wrappers.Duration{Duration: snapshotTimeout},
-				DefragTimeout:       wrappers.Duration{Duration: defragTimeout},
-				EnabledLeaseRenewal: false,
-				SleepForScrape:      wrappers.Duration{Duration: sleepForScrape},
+				NeedDefragmentation:       needDefragmentation,
+				SnapshotTimeout:           wrappers.Duration{Duration: snapshotTimeout},
+				DefragTimeout:             wrappers.Duration{Duration: defragTimeout},
+				EnabledLeaseRenewal:       false,
+				MetricsScrapeWaitDuration: wrappers.Duration{Duration: 0},
 			}
 			compactOptions = &brtypes.CompactOptions{
 				RestoreOptions:  restoreOpts,

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -39,8 +39,8 @@ var _ = Describe("Running Compactor", func() {
 		embeddedEtcdQuotaBytes int64  = 8 * 1024 * 1024 * 1024
 		snapshotTimeout               = 30 * time.Second
 		defragTimeout                 = 30 * time.Second
-		// keep SleepForScrape low so that tests are faster
-		sleepForScrape      = 10 * time.Nanosecond
+		// keep SleepForScrape 0 so that tests are faster
+		sleepForScrape      = 0 * time.Second
 		needDefragmentation = true
 	)
 

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -39,7 +39,9 @@ var _ = Describe("Running Compactor", func() {
 		embeddedEtcdQuotaBytes int64  = 8 * 1024 * 1024 * 1024
 		snapshotTimeout               = 30 * time.Second
 		defragTimeout                 = 30 * time.Second
-		needDefragmentation           = true
+		// keep sleepTimeout low so that tests are faster
+		sleepTimeout        = 10 * time.Nanosecond
+		needDefragmentation = true
 	)
 
 	BeforeEach(func() {
@@ -93,6 +95,7 @@ var _ = Describe("Running Compactor", func() {
 				SnapshotTimeout:     wrappers.Duration{Duration: snapshotTimeout},
 				DefragTimeout:       wrappers.Duration{Duration: defragTimeout},
 				EnabledLeaseRenewal: false,
+				SleepTimeout:        wrappers.Duration{Duration: sleepTimeout},
 			}
 			compactOptions = &brtypes.CompactOptions{
 				RestoreOptions:  restoreOpts,

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -39,8 +39,8 @@ var _ = Describe("Running Compactor", func() {
 		embeddedEtcdQuotaBytes int64  = 8 * 1024 * 1024 * 1024
 		snapshotTimeout               = 30 * time.Second
 		defragTimeout                 = 30 * time.Second
-		// keep sleepTimeout low so that tests are faster
-		sleepTimeout        = 10 * time.Nanosecond
+		// keep SleepFor low so that tests are faster
+		sleepFor            = 10 * time.Nanosecond
 		needDefragmentation = true
 	)
 
@@ -95,7 +95,7 @@ var _ = Describe("Running Compactor", func() {
 				SnapshotTimeout:     wrappers.Duration{Duration: snapshotTimeout},
 				DefragTimeout:       wrappers.Duration{Duration: defragTimeout},
 				EnabledLeaseRenewal: false,
-				SleepTimeout:        wrappers.Duration{Duration: sleepTimeout},
+				SleepFor:            wrappers.Duration{Duration: sleepFor},
 			}
 			compactOptions = &brtypes.CompactOptions{
 				RestoreOptions:  restoreOpts,

--- a/pkg/types/compactor.go
+++ b/pkg/types/compactor.go
@@ -27,8 +27,8 @@ const (
 	defaultDefragTimeout time.Duration = 8 * time.Minute
 	// defaultSnapshotTimeout defines default timeout duration for taking compacted FullSnapshot.
 	defaultSnapshotTimeout time.Duration = 30 * time.Minute
-	//defaultSleepTimeoutInSeconds defines default timeout for sleep command in compaction
-	defaultSleepTimeout time.Duration = 60 * time.Second
+	//defaultSleepForInSeconds defines default timeout for sleep command in compaction
+	defaultSleepFor time.Duration = 60 * time.Second
 )
 
 // CompactOptions holds all configurable options of compact.
@@ -46,7 +46,7 @@ type CompactorConfig struct {
 	DeltaSnapshotLeaseName string            `json:"deltaSnapshotLeaseName,omitempty"`
 	EnabledLeaseRenewal    bool              `json:"enabledLeaseRenewal"`
 	// see https://github.com/gardener/etcd-druid/issues/648
-	SleepTimeout wrappers.Duration `json:"sleepTimeout,omitempty"`
+	SleepFor wrappers.Duration `json:"sleepFor,omitempty"`
 }
 
 // NewCompactorConfig returns the CompactorConfig.
@@ -58,7 +58,7 @@ func NewCompactorConfig() *CompactorConfig {
 		FullSnapshotLeaseName:  DefaultFullSnapshotLeaseName,
 		DeltaSnapshotLeaseName: DefaultDeltaSnapshotLeaseName,
 		EnabledLeaseRenewal:    DefaultSnapshotLeaseRenewalEnabled,
-		SleepTimeout:           wrappers.Duration{Duration: defaultSleepTimeout},
+		SleepFor:               wrappers.Duration{Duration: defaultSleepFor},
 	}
 }
 
@@ -70,7 +70,7 @@ func (c *CompactorConfig) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.FullSnapshotLeaseName, "full-snapshot-lease-name", c.FullSnapshotLeaseName, "full snapshot lease name")
 	fs.StringVar(&c.DeltaSnapshotLeaseName, "delta-snapshot-lease-name", c.DeltaSnapshotLeaseName, "delta snapshot lease name")
 	fs.BoolVar(&c.EnabledLeaseRenewal, "enable-snapshot-lease-renewal", c.EnabledLeaseRenewal, "Allows compactor to renew the full snapshot lease when successfully compacted snapshot is uploaded")
-	fs.DurationVar(&c.SleepTimeout.Duration, "sleep-timeout-in-seconds", c.SleepTimeout.Duration, "Timeout for sleep command after the snapshot upload is over")
+	fs.DurationVar(&c.SleepFor.Duration, "sleep-timeout-in-seconds", c.SleepFor.Duration, "Timeout for sleep command after the snapshot upload is over")
 }
 
 // Validate validates the config.

--- a/pkg/types/compactor.go
+++ b/pkg/types/compactor.go
@@ -28,7 +28,7 @@ const (
 	// defaultSnapshotTimeout defines default timeout duration for taking compacted FullSnapshot.
 	defaultSnapshotTimeout time.Duration = 30 * time.Minute
 	//defaultSleepForScrapeInSeconds defines default timeout for sleep command in compaction
-	defaultSleepForScrape time.Duration = 60 * time.Second
+	defaultSleepForScrape time.Duration = 0 * time.Second
 )
 
 // CompactOptions holds all configurable options of compact.

--- a/pkg/types/compactor.go
+++ b/pkg/types/compactor.go
@@ -27,8 +27,8 @@ const (
 	defaultDefragTimeout time.Duration = 8 * time.Minute
 	// defaultSnapshotTimeout defines default timeout duration for taking compacted FullSnapshot.
 	defaultSnapshotTimeout time.Duration = 30 * time.Minute
-	//defaultSleepForInSeconds defines default timeout for sleep command in compaction
-	defaultSleepFor time.Duration = 60 * time.Second
+	//defaultSleepForScrapeInSeconds defines default timeout for sleep command in compaction
+	defaultSleepForScrape time.Duration = 60 * time.Second
 )
 
 // CompactOptions holds all configurable options of compact.
@@ -46,7 +46,7 @@ type CompactorConfig struct {
 	DeltaSnapshotLeaseName string            `json:"deltaSnapshotLeaseName,omitempty"`
 	EnabledLeaseRenewal    bool              `json:"enabledLeaseRenewal"`
 	// see https://github.com/gardener/etcd-druid/issues/648
-	SleepFor wrappers.Duration `json:"sleepFor,omitempty"`
+	SleepForScrape wrappers.Duration `json:"sleepForScrape,omitempty"`
 }
 
 // NewCompactorConfig returns the CompactorConfig.
@@ -58,7 +58,7 @@ func NewCompactorConfig() *CompactorConfig {
 		FullSnapshotLeaseName:  DefaultFullSnapshotLeaseName,
 		DeltaSnapshotLeaseName: DefaultDeltaSnapshotLeaseName,
 		EnabledLeaseRenewal:    DefaultSnapshotLeaseRenewalEnabled,
-		SleepFor:               wrappers.Duration{Duration: defaultSleepFor},
+		SleepForScrape:         wrappers.Duration{Duration: defaultSleepForScrape},
 	}
 }
 
@@ -70,7 +70,7 @@ func (c *CompactorConfig) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.FullSnapshotLeaseName, "full-snapshot-lease-name", c.FullSnapshotLeaseName, "full snapshot lease name")
 	fs.StringVar(&c.DeltaSnapshotLeaseName, "delta-snapshot-lease-name", c.DeltaSnapshotLeaseName, "delta snapshot lease name")
 	fs.BoolVar(&c.EnabledLeaseRenewal, "enable-snapshot-lease-renewal", c.EnabledLeaseRenewal, "Allows compactor to renew the full snapshot lease when successfully compacted snapshot is uploaded")
-	fs.DurationVar(&c.SleepFor.Duration, "sleep-timeout-in-seconds", c.SleepFor.Duration, "Timeout for sleep command after the snapshot upload is over")
+	fs.DurationVar(&c.SleepForScrape.Duration, "sleep-for-scrape", c.SleepForScrape.Duration, "Sleep duration after compaction is completed")
 }
 
 // Validate validates the config.

--- a/pkg/types/compactor.go
+++ b/pkg/types/compactor.go
@@ -27,6 +27,8 @@ const (
 	defaultDefragTimeout time.Duration = 8 * time.Minute
 	// defaultSnapshotTimeout defines default timeout duration for taking compacted FullSnapshot.
 	defaultSnapshotTimeout time.Duration = 30 * time.Minute
+	//defaultSleepTimeoutInSeconds defines default timeout for sleep command in compaction
+	defaultSleepTimeout time.Duration = 60 * time.Second
 )
 
 // CompactOptions holds all configurable options of compact.
@@ -43,6 +45,8 @@ type CompactorConfig struct {
 	FullSnapshotLeaseName  string            `json:"fullSnapshotLeaseName,omitempty"`
 	DeltaSnapshotLeaseName string            `json:"deltaSnapshotLeaseName,omitempty"`
 	EnabledLeaseRenewal    bool              `json:"enabledLeaseRenewal"`
+	// see https://github.com/gardener/etcd-druid/issues/648
+	SleepTimeout wrappers.Duration `json:"sleepTimeout,omitempty"`
 }
 
 // NewCompactorConfig returns the CompactorConfig.
@@ -54,6 +58,7 @@ func NewCompactorConfig() *CompactorConfig {
 		FullSnapshotLeaseName:  DefaultFullSnapshotLeaseName,
 		DeltaSnapshotLeaseName: DefaultDeltaSnapshotLeaseName,
 		EnabledLeaseRenewal:    DefaultSnapshotLeaseRenewalEnabled,
+		SleepTimeout:           wrappers.Duration{Duration: defaultSleepTimeout},
 	}
 }
 
@@ -65,6 +70,7 @@ func (c *CompactorConfig) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.FullSnapshotLeaseName, "full-snapshot-lease-name", c.FullSnapshotLeaseName, "full snapshot lease name")
 	fs.StringVar(&c.DeltaSnapshotLeaseName, "delta-snapshot-lease-name", c.DeltaSnapshotLeaseName, "delta snapshot lease name")
 	fs.BoolVar(&c.EnabledLeaseRenewal, "enable-snapshot-lease-renewal", c.EnabledLeaseRenewal, "Allows compactor to renew the full snapshot lease when successfully compacted snapshot is uploaded")
+	fs.DurationVar(&c.SleepTimeout.Duration, "sleep-timeout-in-seconds", c.SleepTimeout.Duration, "Timeout for sleep command after the snapshot upload is over")
 }
 
 // Validate validates the config.

--- a/pkg/types/compactor.go
+++ b/pkg/types/compactor.go
@@ -27,8 +27,8 @@ const (
 	defaultDefragTimeout time.Duration = 8 * time.Minute
 	// defaultSnapshotTimeout defines default timeout duration for taking compacted FullSnapshot.
 	defaultSnapshotTimeout time.Duration = 30 * time.Minute
-	//defaultSleepForScrapeInSeconds defines default timeout for sleep command in compaction
-	defaultSleepForScrape time.Duration = 0 * time.Second
+	//defaultMetricsScrapeWaitDuration defines default duration to wait for after compaction is completed, to allow Prometheus metrics to be scraped
+	defaultMetricsScrapeWaitDuration time.Duration = 0 * time.Second
 )
 
 // CompactOptions holds all configurable options of compact.
@@ -46,19 +46,19 @@ type CompactorConfig struct {
 	DeltaSnapshotLeaseName string            `json:"deltaSnapshotLeaseName,omitempty"`
 	EnabledLeaseRenewal    bool              `json:"enabledLeaseRenewal"`
 	// see https://github.com/gardener/etcd-druid/issues/648
-	SleepForScrape wrappers.Duration `json:"sleepForScrape,omitempty"`
+	MetricsScrapeWaitDuration wrappers.Duration `json:"metricsScrapeWaitDuration,omitempty"`
 }
 
 // NewCompactorConfig returns the CompactorConfig.
 func NewCompactorConfig() *CompactorConfig {
 	return &CompactorConfig{
-		NeedDefragmentation:    true,
-		SnapshotTimeout:        wrappers.Duration{Duration: defaultSnapshotTimeout},
-		DefragTimeout:          wrappers.Duration{Duration: defaultDefragTimeout},
-		FullSnapshotLeaseName:  DefaultFullSnapshotLeaseName,
-		DeltaSnapshotLeaseName: DefaultDeltaSnapshotLeaseName,
-		EnabledLeaseRenewal:    DefaultSnapshotLeaseRenewalEnabled,
-		SleepForScrape:         wrappers.Duration{Duration: defaultSleepForScrape},
+		NeedDefragmentation:       true,
+		SnapshotTimeout:           wrappers.Duration{Duration: defaultSnapshotTimeout},
+		DefragTimeout:             wrappers.Duration{Duration: defaultDefragTimeout},
+		FullSnapshotLeaseName:     DefaultFullSnapshotLeaseName,
+		DeltaSnapshotLeaseName:    DefaultDeltaSnapshotLeaseName,
+		EnabledLeaseRenewal:       DefaultSnapshotLeaseRenewalEnabled,
+		MetricsScrapeWaitDuration: wrappers.Duration{Duration: defaultMetricsScrapeWaitDuration},
 	}
 }
 
@@ -70,7 +70,7 @@ func (c *CompactorConfig) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.FullSnapshotLeaseName, "full-snapshot-lease-name", c.FullSnapshotLeaseName, "full snapshot lease name")
 	fs.StringVar(&c.DeltaSnapshotLeaseName, "delta-snapshot-lease-name", c.DeltaSnapshotLeaseName, "delta snapshot lease name")
 	fs.BoolVar(&c.EnabledLeaseRenewal, "enable-snapshot-lease-renewal", c.EnabledLeaseRenewal, "Allows compactor to renew the full snapshot lease when successfully compacted snapshot is uploaded")
-	fs.DurationVar(&c.SleepForScrape.Duration, "sleep-for-scrape", c.SleepForScrape.Duration, "Sleep duration after compaction is completed")
+	fs.DurationVar(&c.MetricsScrapeWaitDuration.Duration, "metrics-scrape-wait-duration", c.MetricsScrapeWaitDuration.Duration, "The duration to wait for after compaction is completed, to allow Prometheus metrics to be scraped")
 }
 
 // Validate validates the config.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a provision of sleep duration  after the `Compact` function done with uploading snapshot. This sleep duration is needed as prometheus is required to collect necessary metrics for network activity after a fast full snapshot upload. The sleep duration is supplied as flag to `etcdbrctl compact` command and set to 0 by default. But the flag can be configured by any agent, who is using `etcdbrctl`, to set any duration value like 60s, 2m etc. `60s` value of sleep duration is enough to allow sufficient time for Prometheus to scrape network related metrics after a fast full snapshot upload.

**Which issue(s) this PR fixes**:
Fixes #
https://github.com/gardener/etcd-druid/pull/648

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Introduce flag `metrics-scrape-wait-duration` to `etcdbrctl compact` command, that specifies a wait duration at the end of a snapshot compaction, to allow Prometheus to scrape metrics related to compaction before the `etcdbrctl` process exits.
```
