### PR TITLE
Making etcd-backup-restore restart tolerant in between of scaling-up a cluster.

### DIFF
--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -54,7 +54,7 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 	logger := e.Logger.WithField("actor", "initializer")
 	metrics.CurrentClusterSize.With(prometheus.Labels{}).Set(float64(e.Validator.OriginalClusterSize))
 	start := time.Now()
-	memberHearbeatPresent := false
+	memberHeartbeatPresent := false
 	ctx := context.Background()
 	var err error
 
@@ -75,7 +75,7 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 		m := member.NewMemberControl(e.Config.EtcdConnectionConfig)
 
 		// check heartbeat of etcd member
-		if memberHearbeatPresent, err = m.WasMemberInCluster(ctx, clientSet); memberHearbeatPresent {
+		if memberHeartbeatPresent, err = m.WasMemberInCluster(ctx, clientSet); memberHeartbeatPresent {
 			logger.Info("member found to be already a part of the cluster")
 			logger.Info("skipping the scale-up check")
 		} else {
@@ -125,7 +125,7 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 	metrics.ValidationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Observe(time.Since(start).Seconds())
 
 	if dataDirStatus != validator.DataDirectoryValid {
-		if dataDirStatus == validator.DataDirStatusInvalidInMultiNode || (e.Validator.OriginalClusterSize > 1 && dataDirStatus == validator.DataDirectoryCorrupt) || (e.Validator.OriginalClusterSize > 1 && memberHearbeatPresent) {
+		if dataDirStatus == validator.DataDirStatusInvalidInMultiNode || (e.Validator.OriginalClusterSize > 1 && dataDirStatus == validator.DataDirectoryCorrupt) || (e.Validator.OriginalClusterSize > 1 && memberHeartbeatPresent) {
 			start := time.Now()
 			if err := e.restoreInMultiNode(ctx); err != nil {
 				metrics.RestorationDurationSeconds.With(prometheus.Labels{metrics.LabelRestorationKind: metrics.ValueRestoreSingleMemberInMultiNode, metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -75,13 +75,10 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 		m := member.NewMemberControl(e.Config.EtcdConnectionConfig)
 
 		// check heartbeat of etcd member
-		if memberHeartbeatPresent, err = m.WasMemberInCluster(ctx, clientSet); memberHeartbeatPresent {
+		if memberHeartbeatPresent = m.WasMemberInCluster(ctx, clientSet); memberHeartbeatPresent {
 			logger.Info("member found to be already a part of the cluster")
 			logger.Info("skipping the scale-up check")
 		} else {
-			if err != nil {
-				logger.Errorf("unable to check heartbeat of etcd member: %v", err)
-			}
 			logger.Info("member heartbeat is not present")
 			logger.Info("backup-restore will start the scale-up check")
 			isScaleup, err := m.IsClusterScaledUp(ctx, clientSet)

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -54,7 +54,7 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 	logger := e.Logger.WithField("actor", "initializer")
 	metrics.CurrentClusterSize.With(prometheus.Labels{}).Set(float64(e.Validator.OriginalClusterSize))
 	start := time.Now()
-	isEtcdMemberPresent := false
+	memberHearbeatPresent := false
 	ctx := context.Background()
 	var err error
 
@@ -71,20 +71,30 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 		if err != nil {
 			logger.Fatalf("failed to create clientset, %v", err)
 		}
+
 		m := member.NewMemberControl(e.Config.EtcdConnectionConfig)
-		isScaleup, err := m.IsClusterScaledUp(ctx, clientSet)
-		if err != nil {
-			logger.Errorf("scale-up not detected: %v", err)
-		} else if isScaleup {
-			logger.Info("Etcd cluster scale-up is detected")
-			// Add a learner(non-voting member) to a etcd cluster with retry
-			// If backup-restore is unable to add a learner in a cluster
-			// restart the `initialization` by exiting the backup-restore.
-			if err := member.AddLearnerWithRetry(ctx, m, addLearnerAttempts, e.Config.RestoreOptions.Config.DataDir); err != nil {
-				logger.Fatalf("unable to add a learner in a cluster: %v", err)
+
+		// check heartbeat of etcd member
+		if memberHearbeatPresent, err = m.WasMemberInCluster(ctx, clientSet); memberHearbeatPresent {
+			logger.Info("member found to be already a part of the cluster")
+			logger.Info("skipping the scale-up check")
+		} else {
+			logger.Info("member heartbeat is not present")
+			logger.Info("backup-restore will start the scale-up check")
+			isScaleup, err := m.IsClusterScaledUp(ctx, clientSet)
+			if err != nil {
+				logger.Errorf("scale-up not detected: %v", err)
+			} else if isScaleup {
+				logger.Info("Etcd cluster scale-up is detected")
+				// Add a learner(non-voting member) to a etcd cluster with retry
+				// If backup-restore is unable to add a learner in a cluster
+				// restart the `initialization` by exiting the backup-restore.
+				if err := member.AddLearnerWithRetry(ctx, m, addLearnerAttempts, e.Config.RestoreOptions.Config.DataDir); err != nil {
+					logger.Fatalf("unable to add a learner in a cluster: %v", err)
+				}
+				// return here after adding learner(non-voting member) as no restoration or validation required.
+				return nil
 			}
-			// return here after adding learner(non-voting member) as no restoration or validation required.
-			return nil
 		}
 	}
 
@@ -112,7 +122,7 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 	metrics.ValidationDurationSeconds.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Observe(time.Since(start).Seconds())
 
 	if dataDirStatus != validator.DataDirectoryValid {
-		if dataDirStatus == validator.DataDirStatusInvalidInMultiNode || (e.Validator.OriginalClusterSize > 1 && dataDirStatus == validator.DataDirectoryCorrupt) || (e.Validator.OriginalClusterSize > 1 && isEtcdMemberPresent) {
+		if dataDirStatus == validator.DataDirStatusInvalidInMultiNode || (e.Validator.OriginalClusterSize > 1 && dataDirStatus == validator.DataDirectoryCorrupt) || (e.Validator.OriginalClusterSize > 1 && memberHearbeatPresent) {
 			start := time.Now()
 			if err := e.restoreInMultiNode(ctx); err != nil {
 				metrics.RestorationDurationSeconds.With(prometheus.Labels{metrics.LabelRestorationKind: metrics.ValueRestoreSingleMemberInMultiNode, metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Observe(time.Since(start).Seconds())

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -79,6 +79,9 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 			logger.Info("member found to be already a part of the cluster")
 			logger.Info("skipping the scale-up check")
 		} else {
+			if err != nil {
+				logger.Errorf("unable to check heartbeat of etcd member: %v", err)
+			}
 			logger.Info("member heartbeat is not present")
 			logger.Info("backup-restore will start the scale-up check")
 			isScaleup, err := m.IsClusterScaledUp(ctx, clientSet)

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -363,7 +363,7 @@ func (m *memberControl) WasMemberInCluster(ctx context.Context, clientSet client
 		Namespace: m.podNamespace,
 		Name:      m.podName,
 	}, memberLease); err != nil {
-		return false, fmt.Errorf("couldn't able to fetch member lease: %v", err)
+		return false, fmt.Errorf("couldn't fetch member lease while checking if the member was part of the cluster: %v", err)
 	}
 
 	if memberLease.Spec.HolderIdentity == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes an `etcd-backup-restore` restart tolerant while scaling-up a etcd cluster.
This fixes the `permanent quorum loss` problem when any pod member restartes in between scaling-up of an etcd cluster.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/etcd-druid/issues/641

**Special notes for your reviewer**:

**Release note**:
```noteworthy operator
Making etcd-backup-restore restart tolerant while scaling-up an etcd cluster.
```
