### PR TITLE
Adds sleep command at the end of compaction (cherry-pick for rel-v0.24)

### DIFF
--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -89,10 +89,11 @@ var _ = Describe("Running Compactor", func() {
 				PeerURLs:    peerUrls,
 			}
 			compactorConfig = &brtypes.CompactorConfig{
-				NeedDefragmentation: needDefragmentation,
-				SnapshotTimeout:     wrappers.Duration{Duration: snapshotTimeout},
-				DefragTimeout:       wrappers.Duration{Duration: defragTimeout},
-				EnabledLeaseRenewal: false,
+				NeedDefragmentation:       needDefragmentation,
+				SnapshotTimeout:           wrappers.Duration{Duration: snapshotTimeout},
+				DefragTimeout:             wrappers.Duration{Duration: defragTimeout},
+				EnabledLeaseRenewal:       false,
+				MetricsScrapeWaitDuration: wrappers.Duration{Duration: 0},
 			}
 			compactOptions = &brtypes.CompactOptions{
 				RestoreOptions:  restoreOpts,

--- a/pkg/types/compactor.go
+++ b/pkg/types/compactor.go
@@ -27,6 +27,8 @@ const (
 	defaultDefragTimeout time.Duration = 8 * time.Minute
 	// defaultSnapshotTimeout defines default timeout duration for taking compacted FullSnapshot.
 	defaultSnapshotTimeout time.Duration = 30 * time.Minute
+	//defaultMetricsScrapeWaitDuration defines default duration to wait for after compaction is completed, to allow Prometheus metrics to be scraped
+	defaultMetricsScrapeWaitDuration time.Duration = 0 * time.Second
 )
 
 // CompactOptions holds all configurable options of compact.
@@ -43,17 +45,20 @@ type CompactorConfig struct {
 	FullSnapshotLeaseName  string            `json:"fullSnapshotLeaseName,omitempty"`
 	DeltaSnapshotLeaseName string            `json:"deltaSnapshotLeaseName,omitempty"`
 	EnabledLeaseRenewal    bool              `json:"enabledLeaseRenewal"`
+	// see https://github.com/gardener/etcd-druid/issues/648
+	MetricsScrapeWaitDuration wrappers.Duration `json:"metricsScrapeWaitDuration,omitempty"`
 }
 
 // NewCompactorConfig returns the CompactorConfig.
 func NewCompactorConfig() *CompactorConfig {
 	return &CompactorConfig{
-		NeedDefragmentation:    true,
-		SnapshotTimeout:        wrappers.Duration{Duration: defaultSnapshotTimeout},
-		DefragTimeout:          wrappers.Duration{Duration: defaultDefragTimeout},
-		FullSnapshotLeaseName:  DefaultFullSnapshotLeaseName,
-		DeltaSnapshotLeaseName: DefaultDeltaSnapshotLeaseName,
-		EnabledLeaseRenewal:    DefaultSnapshotLeaseRenewalEnabled,
+		NeedDefragmentation:       true,
+		SnapshotTimeout:           wrappers.Duration{Duration: defaultSnapshotTimeout},
+		DefragTimeout:             wrappers.Duration{Duration: defaultDefragTimeout},
+		FullSnapshotLeaseName:     DefaultFullSnapshotLeaseName,
+		DeltaSnapshotLeaseName:    DefaultDeltaSnapshotLeaseName,
+		EnabledLeaseRenewal:       DefaultSnapshotLeaseRenewalEnabled,
+		MetricsScrapeWaitDuration: wrappers.Duration{Duration: defaultMetricsScrapeWaitDuration},
 	}
 }
 
@@ -65,6 +70,7 @@ func (c *CompactorConfig) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.FullSnapshotLeaseName, "full-snapshot-lease-name", c.FullSnapshotLeaseName, "full snapshot lease name")
 	fs.StringVar(&c.DeltaSnapshotLeaseName, "delta-snapshot-lease-name", c.DeltaSnapshotLeaseName, "delta snapshot lease name")
 	fs.BoolVar(&c.EnabledLeaseRenewal, "enable-snapshot-lease-renewal", c.EnabledLeaseRenewal, "Allows compactor to renew the full snapshot lease when successfully compacted snapshot is uploaded")
+	fs.DurationVar(&c.MetricsScrapeWaitDuration.Duration, "metrics-scrape-wait-duration", c.MetricsScrapeWaitDuration.Duration, "The duration to wait for after compaction is completed, to allow Prometheus metrics to be scraped")
 }
 
 // Validate validates the config.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cherry-pick commits from the following PR:
1. #660

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Introduce flag `metrics-scrape-wait-duration` to `etcdbrctl compact` command, that specifies a wait duration at the end of a snapshot compaction, to allow Prometheus to scrape metrics related to compaction before the `etcdbrctl` process exits.
```
