### PR TITLE
Make embedded etcd lean during restoration to avoid any restoration failure

### DIFF
--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -60,7 +60,7 @@ const (
 	etcdConnectionTimeout                                 = 30 * time.Second
 	etcdCompactTimeout                                    = 2 * time.Minute
 	etcdDefragTimeout                                     = 5 * time.Minute
-	periodicallyMakeEtcdLeanAfterDeltaSnapApplied         = 10
+	periodicallyMakeEtcdLeanDeltaSnapshotInterval         = 10
 	thresholdPercentageForDBSizeAlarm             float64 = 80.0 / 100.0
 )
 
@@ -646,7 +646,7 @@ func (r *Restorer) applySnaps(clientKV client.KVCloser, clientMaintenance client
 
 					numberOfDeltaSnapApplied++
 
-					if numberOfDeltaSnapApplied%periodicallyMakeEtcdLeanAfterDeltaSnapApplied == 0 || prevAttemptToMakeEtcdLeanFailed {
+					if numberOfDeltaSnapApplied%periodicallyMakeEtcdLeanDeltaSnapshotInterval == 0 || prevAttemptToMakeEtcdLeanFailed {
 						r.logger.Info("making an embedded etcd lean and check for db size alarm")
 						if err := r.MakeEtcdLeanAndCheckAlarm(int64(remainingSnaps[currSnapIndex].LastRevision), endPoints, embeddedEtcdQuotaBytes, dbSizeAlarmCh, dbSizeAlarmDisarmCh, clientKV, clientMaintenance); err != nil {
 							r.logger.Errorf("unable to make embedded etcd lean: %v", err)

--- a/pkg/snapshot/restorer/restorer_test.go
+++ b/pkg/snapshot/restorer/restorer_test.go
@@ -642,7 +642,7 @@ var _ = Describe("Running Restorer", func() {
 			ckv     *mockfactory.MockKVCloser
 
 			dummyRevisionNo             = int64(1111)
-			dummyEtcdEndpoints          = []string{"http://127.0.0.1:9999"}
+			dummyEtcdEndpoints          = []string{"http://127.0.0.1:9999", "http://127.0.0.1:9900"}
 			dummyEmbeddedEtcdQuotaBytes = float64(100) // 100B
 		)
 		BeforeEach(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
It has been observed that sometimes during big restoration, `Embedded Etcd database space exceeds` causing the restoration failure.
This PR makes an embedded etcd lean during restoration to avoid any failure due to `etcd database space exceeds`.
To make embedded etcd lean:
- backup-restore will periodically run compaction on embedded etcd.
- backup-restore will keep a check on database size, and if it crosses certain threshold, backup-restore trigger defragmentation.


**Which issue(s) this PR fixes**:
Fixes #636 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Fix a restoration failure which can occurs due to an etcd database space exceeds during restoration.
```
