### PR TITLE
Optimize dynamic loading of IaaS Credentials using credential file timestamps

### DIFF
--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -155,6 +155,16 @@ EOF
 [default]
 region = $3
 EOF
+  temp_dir=$(mktemp -d)
+  credentials_file="${temp_dir}/credentials.json"
+  cat <<EOF >"${credentials_file}"
+{
+  "accessKeyID": "$1",
+  "secretAccessKey": "$2",
+  "region": "$3"
+}
+EOF
+  export AWS_APPLICATION_CREDENTIALS_JSON="${credentials_file}"
 }
 
 function create_aws_secret() {

--- a/.ci/unit_test
+++ b/.ci/unit_test
@@ -48,7 +48,7 @@ test_with_coverage() {
 ################################################################################
 
 # To run a specific package, run TEST_PACKAGES=<PATH_TO_PACKAGE> make test
-TEST_PACKAGES="${TEST_PACKAGES:-"cmd pkg"}"
+TEST_PACKAGES="${TEST_PACKAGES:-"pkg/snapstore"}"
 
 RUN_NEGATIVE="${RUN_NEGATIVE:-"true"}"
 

--- a/.ci/unit_test
+++ b/.ci/unit_test
@@ -48,7 +48,7 @@ test_with_coverage() {
 ################################################################################
 
 # To run a specific package, run TEST_PACKAGES=<PATH_TO_PACKAGE> make test
-TEST_PACKAGES="${TEST_PACKAGES:-"pkg/snapstore"}"
+TEST_PACKAGES="${TEST_PACKAGES:-"cmd pkg"}"
 
 RUN_NEGATIVE="${RUN_NEGATIVE:-"true"}"
 

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -332,7 +332,7 @@ var _ = Describe("Dynamic access credential rotation for each provider", func() 
 				It("Should return error", func() {
 					newSecretModifiedTime, err := GetSnapstoreSecretModifiedTime(providerToSnapstoreProviderMap[provider])
 					Expect(err).Should(HaveOccurred())
-					Expect(newSecretModifiedTime.IsZero()).Should(Equal(true))
+					Expect(newSecretModifiedTime.IsZero()).Should(BeTrue())
 				})
 			})
 			Describe("Environment variable set, points to a directory", func() {
@@ -343,7 +343,7 @@ var _ = Describe("Dynamic access credential rotation for each provider", func() 
 					It("Should return error", func() {
 						newSecretModifiedTime, err := GetSnapstoreSecretModifiedTime(providerToSnapstoreProviderMap[provider])
 						Expect(err).Should(HaveOccurred())
-						Expect(newSecretModifiedTime.IsZero()).Should(Equal(true))
+						Expect(newSecretModifiedTime.IsZero()).Should(BeTrue())
 					})
 				})
 				Describe("Directory exists", func() {
@@ -356,7 +356,7 @@ var _ = Describe("Dynamic access credential rotation for each provider", func() 
 						It("Should return error", func() {
 							newSecretModifiedTime, err := GetSnapstoreSecretModifiedTime(providerToSnapstoreProviderMap[provider])
 							Expect(err).Should(HaveOccurred())
-							Expect(newSecretModifiedTime.IsZero()).Should(Equal(true))
+							Expect(newSecretModifiedTime.IsZero()).Should(BeTrue())
 						})
 					})
 					// test with each particular credential file missing
@@ -372,12 +372,13 @@ var _ = Describe("Dynamic access credential rotation for each provider", func() 
 									}
 									credentialFullPaths = append(credentialFullPaths, filepath.Join(credentialDirectory, credentialFileNames[i]))
 								}
-								createCredentialFiles(credentialFullPaths)
+								lastCreationTimeForFile := createCredentialFiles(credentialFullPaths)
+								Expect(lastCreationTimeForFile.IsZero()).ShouldNot(BeTrue())
 							})
 							It("Should return error", func() {
 								newSecretModifiedTime, err := GetSnapstoreSecretModifiedTime(providerToSnapstoreProviderMap[provider])
 								Expect(err).Should(HaveOccurred())
-								Expect(newSecretModifiedTime.IsZero()).Should(Equal(true))
+								Expect(newSecretModifiedTime.IsZero()).Should(BeTrue())
 							})
 						})
 					}
@@ -389,12 +390,13 @@ var _ = Describe("Dynamic access credential rotation for each provider", func() 
 								credentialFileFullPaths = append(credentialFileFullPaths, filepath.Join(credentialDirectory, credentialFileNames[i]))
 							}
 							lastCreationTimeForFile = createCredentialFiles(credentialFileFullPaths)
+							Expect(lastCreationTimeForFile.IsZero()).ShouldNot(BeTrue())
 						})
 						Context("Files not modified", func() {
 							It("Should return creation timestamp", func() {
 								newSecretModifiedTime, err := GetSnapstoreSecretModifiedTime(providerToSnapstoreProviderMap[provider])
 								Expect(err).ShouldNot(HaveOccurred())
-								Expect(newSecretModifiedTime.Equal(lastCreationTimeForFile)).Should(Equal(true))
+								Expect(newSecretModifiedTime.Equal(lastCreationTimeForFile)).Should(BeTrue())
 							})
 						})
 						// test with each particular credential file modified
@@ -404,9 +406,7 @@ var _ = Describe("Dynamic access credential rotation for each provider", func() 
 								BeforeEach(func() {
 									fmt.Println("Testing for the provider:", providerToSnapstoreProviderMap[provider])
 									bytesRead, err := os.ReadFile(credentialFileFullPaths[fileModifiedIndex])
-									if err != nil {
-										fmt.Println("Error while reading the unmodified credential file:", err)
-									}
+									Expect(err).ShouldNot(HaveOccurred())
 									fmt.Printf("The original contents of the file are: \"%s\"\n", string(bytesRead))
 									err = modifyCredentialFile(fileModifiedIndex, credentialFileFullPaths)
 									Expect(err).ShouldNot(HaveOccurred())
@@ -418,11 +418,9 @@ var _ = Describe("Dynamic access credential rotation for each provider", func() 
 									fmt.Println("Modification time for the credential file:\t", newSecretModifiedTime)
 									// printing contents of the file
 									bytesRead, err := os.ReadFile(credentialFileFullPaths[fileModifiedIndex])
-									if err != nil {
-										fmt.Println("Error while reading the modified credential file:", err)
-									}
+									Expect(err).ShouldNot(HaveOccurred())
 									fmt.Printf("The new contents of the file are: \"%s\"\n", string(bytesRead))
-									Expect(newSecretModifiedTime.After(lastCreationTimeForFile)).Should(Equal(true))
+									Expect(newSecretModifiedTime.After(lastCreationTimeForFile)).Should(BeTrue())
 								})
 							})
 						}
@@ -436,7 +434,6 @@ var _ = Describe("Dynamic access credential rotation for each provider", func() 
 					os.Unsetenv(provider)
 				})
 			})
-
 		})
 	}
 	// Credentials in JSON
@@ -448,7 +445,7 @@ var _ = Describe("Dynamic access credential rotation for each provider", func() 
 				It("Should return error", func() {
 					newSecretModifiedTime, err := GetSnapstoreSecretModifiedTime(snapstoreProvider)
 					Expect(err).Should(HaveOccurred())
-					Expect(newSecretModifiedTime.IsZero()).Should(Equal(true))
+					Expect(newSecretModifiedTime.IsZero()).Should(BeTrue())
 				})
 			})
 			Describe("Environment variable set, points to a file", func() {
@@ -459,7 +456,7 @@ var _ = Describe("Dynamic access credential rotation for each provider", func() 
 					It("Should return error", func() {
 						newSecretModifiedTime, err := GetSnapstoreSecretModifiedTime(snapstoreProvider)
 						Expect(err).Should(HaveOccurred())
-						Expect(newSecretModifiedTime.IsZero()).Should(Equal(true))
+						Expect(newSecretModifiedTime.IsZero()).Should(BeTrue())
 					})
 				})
 				Describe("File exists", func() {
@@ -470,24 +467,23 @@ var _ = Describe("Dynamic access credential rotation for each provider", func() 
 						Expect(err).ShouldNot(HaveOccurred())
 						credentialFileFullPaths = append(credentialFileFullPaths, filepath.Join(credentialDirectory, "credentials.json"))
 						lastCreationTimeForFile = createCredentialFiles(credentialFileFullPaths)
+						Expect(lastCreationTimeForFile.IsZero()).ShouldNot(BeTrue())
 						os.Setenv(provider, credentialFileFullPaths[0])
-						Expect(credentialFileFullPaths[0]).NotTo(Equal(""))
+						Expect(credentialFileFullPaths[0]).NotTo(BeEmpty())
 					})
 					Context("File not modified", func() {
 						It("Should return the creation timestamp", func() {
 							newSecretModifiedTime, err := GetSnapstoreSecretModifiedTime(snapstoreProvider)
 							Expect(err).ShouldNot(HaveOccurred())
-							Expect(newSecretModifiedTime.Equal(lastCreationTimeForFile)).Should(Equal(true))
+							Expect(newSecretModifiedTime.Equal(lastCreationTimeForFile)).Should(BeTrue())
 						})
 					})
 					Context("File modified", func() {
 						BeforeEach(func() {
 							fmt.Println("Testing for the provider (JSON):", snapstoreProvider)
 							bytesRead, err := os.ReadFile(credentialFileFullPaths[0])
-							if err != nil {
-								fmt.Println("Error while reading the unmodified JSON credential file:", err)
-							}
-							fmt.Printf("The original contents of the JSON file are:\"%s\"\n", string(bytesRead))
+							Expect(err).ShouldNot(HaveOccurred())
+							fmt.Printf("The original contents of the JSON file are: \"%s\"\n", string(bytesRead))
 							err = modifyCredentialFile(0, credentialFileFullPaths)
 							Expect(err).ShouldNot(HaveOccurred())
 						})
@@ -498,11 +494,9 @@ var _ = Describe("Dynamic access credential rotation for each provider", func() 
 							fmt.Println("Modification time for the JSON credential file:\t", newSecretModifiedTime)
 							// printing contents of the file:
 							bytes, err := os.ReadFile(credentialFileFullPaths[0])
-							if err != nil {
-								fmt.Println("Error while reading the modified JSON credential file:", err)
-							}
+							Expect(err).ShouldNot(HaveOccurred())
 							fmt.Printf("The new contents of the JSON file are: \"%s\"\n", string(bytes))
-							Expect(newSecretModifiedTime.After(lastCreationTimeForFile)).Should(Equal(true))
+							Expect(newSecretModifiedTime.After(lastCreationTimeForFile)).Should(BeTrue())
 						})
 					})
 					AfterEach(func() {
@@ -532,11 +526,11 @@ func createCredentialFiles(filenames []string) time.Time {
 	}
 	// the last file created at the end has the latest creation time (modification time)
 	lastFile, err := os.Open(filenames[len(filenames)-1])
-	defer lastFile.Close()
 	if err != nil {
 		fmt.Println("Error while opening the last created credential file:", err)
 		return time.Time{}
 	}
+	defer lastFile.Close()
 	lastFileInfo, err := lastFile.Stat()
 	if err != nil {
 		fmt.Println("Error while fetching information of the last created credential file:", err)
@@ -550,11 +544,7 @@ func modifyCredentialFile(fileIndex int, credentialFileFullPaths []string) error
 	// sleep before the file is modified, file modification timestamp does not change otherwise on concourse
 	time.Sleep(time.Millisecond * 100)
 	err := os.WriteFile(credentialFileFullPaths[fileIndex], []byte("MODIFIED CONTENT"), os.ModePerm)
-	if err != nil {
-		fmt.Println("Error while modifying the credential file: ", err)
-	}
-	fmt.Println("Modified the file! ", credentialFileFullPaths[fileIndex])
-	return nil
+	return err
 }
 
 func parseObjectNamefromURL(u *url.URL) string {

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -321,7 +321,44 @@ var (
 	}
 )
 
-var _ = FDescribe("Dynamic access credential rotation for each provider", func() {
+var _ = FDescribe("Testing the file modification time for a file", func() {
+	It("The file should return a new modification time", func() {
+		filename := "temporary"
+
+		err := os.WriteFile(filename, []byte("INITIAL CONTENT"), os.ModePerm)
+		Expect(err).ShouldNot(HaveOccurred())
+		file, err := os.Open(filename)
+		Expect(err).ShouldNot(HaveOccurred())
+		fileInfo, err := file.Stat()
+		Expect(err).ShouldNot(HaveOccurred())
+		timeCreation := fileInfo.ModTime()
+		err = file.Close()
+		Expect(err).ShouldNot(HaveOccurred())
+		fmt.Println("The file was created at:", timeCreation)
+		bytesRead, err := os.ReadFile(filename)
+		Expect(err).ShouldNot(HaveOccurred())
+		fmt.Println("The file contents are:", string(bytesRead))
+
+		err = os.WriteFile(filename, []byte("FINAL CONTENT"), os.ModePerm)
+		Expect(err).ShouldNot(HaveOccurred())
+		file, err = os.Open(filename)
+		Expect(err).ShouldNot(HaveOccurred())
+		fileInfo, err = file.Stat()
+		Expect(err).ShouldNot(HaveOccurred())
+		timeModification := fileInfo.ModTime()
+		err = file.Close()
+		Expect(err).ShouldNot(HaveOccurred())
+		fmt.Println("The file was modified at:", timeModification)
+		bytesRead, err = os.ReadFile(filename)
+		Expect(err).ShouldNot(HaveOccurred())
+		fmt.Println("The file contents are:", string(bytesRead))
+
+		Expect(timeModification.After(timeCreation)).Should(Equal(true))
+		os.Remove(filename)
+	})
+})
+
+var _ = Describe("Dynamic access credential rotation for each provider", func() {
 	// Credentials in a directory
 	for providerIndex, provider := range providers {
 		// the value is to be used in the closure capture

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -321,44 +321,7 @@ var (
 	}
 )
 
-var _ = FDescribe("Testing the file modification time for a file", func() {
-	It("The file should return a new modification time", func() {
-		filename := "temporary"
-
-		err := os.WriteFile(filename, []byte("INITIAL CONTENT"), os.ModePerm)
-		Expect(err).ShouldNot(HaveOccurred())
-		file, err := os.Open(filename)
-		Expect(err).ShouldNot(HaveOccurred())
-		fileInfo, err := file.Stat()
-		Expect(err).ShouldNot(HaveOccurred())
-		timeCreation := fileInfo.ModTime()
-		err = file.Close()
-		Expect(err).ShouldNot(HaveOccurred())
-		fmt.Println("The file was created at:", timeCreation)
-		bytesRead, err := os.ReadFile(filename)
-		Expect(err).ShouldNot(HaveOccurred())
-		fmt.Println("The file contents are:", string(bytesRead))
-
-		err = os.WriteFile(filename, []byte("FINAL CONTENT"), os.ModePerm)
-		Expect(err).ShouldNot(HaveOccurred())
-		file, err = os.Open(filename)
-		Expect(err).ShouldNot(HaveOccurred())
-		fileInfo, err = file.Stat()
-		Expect(err).ShouldNot(HaveOccurred())
-		timeModification := fileInfo.ModTime()
-		err = file.Close()
-		Expect(err).ShouldNot(HaveOccurred())
-		fmt.Println("The file was modified at:", timeModification)
-		bytesRead, err = os.ReadFile(filename)
-		Expect(err).ShouldNot(HaveOccurred())
-		fmt.Println("The file contents are:", string(bytesRead))
-
-		Expect(timeModification.After(timeCreation)).Should(Equal(true))
-		os.Remove(filename)
-	})
-})
-
-var _ = Describe("Dynamic access credential rotation for each provider", func() {
+var _ = FDescribe("Dynamic access credential rotation for each provider", func() {
 	// Credentials in a directory
 	for providerIndex, provider := range providers {
 		// the value is to be used in the closure capture
@@ -589,6 +552,7 @@ func createCredentialFiles(filenames []string) time.Time {
 
 // modifies the credential file to change the modification timestamp
 func modifyCredentialFile(fileIndex int, credentialFileFullPaths []string) error {
+	time.Sleep(time.Millisecond * 100)
 	err := os.WriteFile(credentialFileFullPaths[fileIndex], []byte("MODIFIED CONTENT"), os.ModePerm)
 	if err != nil {
 		fmt.Println("Error while modifying the credential file: ", err)

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -15,7 +15,7 @@
 package snapstore_test
 
 import (
-	"bufio"
+	// "bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -421,10 +421,16 @@ var _ = FDescribe("Dynamic access credential rotation for each provider", func()
 									Expect(err).ShouldNot(HaveOccurred())
 								})
 								FIt("Should return modification timestamp", func() {
+									fileIndex := fileIndex
 									newSecretModifiedTime, err := GetSnapstoreSecretModifiedTime(providerToSnapstoreProviderMap[provider])
 									Expect(err).ShouldNot(HaveOccurred())
+									fileOpen, err := os.Open(credentialFullPaths[fileIndex])
+									Expect(err).ToNot(HaveOccurred())
+									statFile, err := fileOpen.Stat()
+									mod := statFile.ModTime()
 									fmt.Println("Creation time for the credential file:\t\t", lastCreationTimeForFile)
 									fmt.Println("Modification time for the credential file:\t", newSecretModifiedTime)
+									fmt.Println("Modification time through stat file:\t\t", mod)
 									// printing contents of the file:
 									bytes, err := os.ReadFile(credentialFullPaths[fileIndex])
 									if err != nil {
@@ -432,10 +438,10 @@ var _ = FDescribe("Dynamic access credential rotation for each provider", func()
 									}
 									// scanner := bufio.NewScanner(credentialFiles[0])
 									// scanner.Scan()
-									fmt.Println("The contents of the file in IT  434: ", string(bytes))
-									scanner := bufio.NewScanner(credentialFiles[fileIndex])
-									scanner.Scan()
-									fmt.Println("The contents of the file in IT through scanner are: ", scanner.Text())
+									fmt.Println("The contents of the file in IT 440: ", string(bytes))
+									// scanner := bufio.NewScanner(credentialFiles[fileIndex])
+									// scanner.Scan()
+									// fmt.Println("The contents of the file in IT through scanner are: ", scanner.Text())
 									Expect(newSecretModifiedTime.After(lastCreationTimeForFile)).Should(Equal(true))
 								})
 							})
@@ -493,7 +499,7 @@ var _ = FDescribe("Dynamic access credential rotation for each provider", func()
 						}
 						// scanner := bufio.NewScanner(credentialFiles[0])
 						// scanner.Scan()
-						fmt.Println("The contents of the JSON file in BeforeEach 493: ", string(bytes))
+						fmt.Println("The contents of the JSON file in BeforeEach 501: ", string(bytes))
 						// fmt.Println("the error while scannign was: ", scanner.Err())
 					})
 					Context("File not modified", func() {
@@ -515,18 +521,23 @@ var _ = FDescribe("Dynamic access credential rotation for each provider", func()
 						FIt("Should return the modification timestamp", func() {
 							newSecretModifiedTime, err := GetSnapstoreSecretModifiedTime(snapstoreProvider)
 							Expect(err).ShouldNot(HaveOccurred())
+							fileOpen, err := os.Open(credentialFullPath)
+							Expect(err).ToNot(HaveOccurred())
+							statFile, err := fileOpen.Stat()
+							mod := statFile.ModTime()
 							fmt.Println("Creation time for the credential file:\t\t", lastCreationTimeForFile)
 							fmt.Println("Modification time for the credential file:\t", newSecretModifiedTime)
+							fmt.Println("Modification time through stat file:\t\t", mod)
 							bytes, err := os.ReadFile(credentialFullPath)
 							if err != nil {
 								fmt.Println("Errored in reading!!", err)
 							}
-							fmt.Println("The contents of the JSON file in It 523: ", string(bytes))
+							fmt.Println("The contents of the JSON file in It 534: ", string(bytes))
 							// printing contents of the file:
 							// credentialFiles[0].Read()
-							scanner := bufio.NewScanner(credentialFiles[0])
-							scanner.Scan()
-							fmt.Println("The contents of the JSON file in It 528 (scanner) are: and the filename is: ", scanner.Text(), credentialFiles[0].Name(), credentialFiles[0])
+							// scanner := bufio.NewScanner(credentialFiles[0])
+							// scanner.Scan()
+							// fmt.Println("The contents of the JSON file in It 528 (scanner) are: and the filename is: ", scanner.Text(), credentialFiles[0].Name(), credentialFiles[0])
 							Expect(newSecretModifiedTime.After(lastCreationTimeForFile)).Should(Equal(true))
 						})
 					})
@@ -557,7 +568,6 @@ func createCredentialFiles(filenames []string) ([]*os.File, time.Time) {
 		// scanner := bufio.NewScanner(file)
 		// scanner.Scan()
 		// fmt.Println("The contents of the file (createCredentialFiles), scanner are: ", scanner.Text(), file)
-
 	}
 	lastFileInfo, err := credentialFiles[len(credentialFiles)-1].Stat()
 	if err != nil {

--- a/pkg/snapstore/utils.go
+++ b/pkg/snapstore/utils.go
@@ -211,6 +211,9 @@ func getLatestCredentialsModifiedTime(credentialFiles []string) (time.Time, erro
 		if err != nil {
 			return time.Time{}, err
 		}
+		if fileInfo.IsDir() {
+			return time.Time{}, fmt.Errorf("a directory %s found in place of a credential file", fileInfo.Name())
+		}
 		fileModifiedTime := fileInfo.ModTime()
 		if latestModifiedTime.Before(fileModifiedTime) {
 			latestModifiedTime = fileModifiedTime

--- a/pkg/snapstore/utils.go
+++ b/pkg/snapstore/utils.go
@@ -15,7 +15,6 @@
 package snapstore
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"os"
 	"path"
@@ -179,36 +178,43 @@ func adaptPrefix(snap *brtypes.Snapshot, snapstorePrefix string) string {
 	return snapstorePrefix
 }
 
-// GetSnapstoreSecretHash returns the hash of object store secrets hash
-func GetSnapstoreSecretHash(config *brtypes.SnapstoreConfig) (string, error) {
-	switch config.Provider {
+// GetSnapstoreSecretModifiedTime returns the latest modification timestamp of the access credential files.
+// Returns an error if fetching the timestamp of the access credential files fails.
+func GetSnapstoreSecretModifiedTime(snapstoreProvider string) (time.Time, error) {
+	switch snapstoreProvider {
 	case brtypes.SnapstoreProviderLocal:
-		return "", nil
+		return time.Time{}, nil
 	case brtypes.SnapstoreProviderS3:
-		return S3SnapStoreHash(config)
+		return GetS3CredentialsLastModifiedTime()
 	case brtypes.SnapstoreProviderABS:
-		return ABSSnapStoreHash(config)
+		return GetABSCredentialsLastModifiedTime()
 	case brtypes.SnapstoreProviderGCS:
-		return GCSSnapStoreHash(config)
+		return GetGCSCredentialsLastModifiedTime()
 	case brtypes.SnapstoreProviderSwift:
-		return SwiftSnapStoreHash(config)
+		return GetSwiftCredentialsLastModifiedTime()
 	case brtypes.SnapstoreProviderOSS:
-		return OSSSnapStoreHash(config)
+		return GetOSSCredentialsLastModifiedTime()
 	case brtypes.SnapstoreProviderOCS:
-		return OCSSnapStoreHash(config)
+		return GetOCSCredentialsLastModifiedTime()
 	default:
-		return "", nil
+		return time.Time{}, nil
 	}
 }
 
-func getHash(data interface{}) string {
-	switch dat := data.(type) {
-	case string:
-		sha := sha256.Sum256([]byte(dat))
-		return fmt.Sprintf("%x", sha)
-	case []byte:
-		sha := sha256.Sum256(dat)
-		return fmt.Sprintf("%x", sha)
+// getLatestCredentialsModifiedTime returns the latest file modification time from a list of files
+func getLatestCredentialsModifiedTime(credentialFiles []string) (time.Time, error) {
+	var latestModifiedTime time.Time
+
+	for _, filename := range credentialFiles {
+		// os.Stat instead of file.Info because the file is symlinked
+		fileInfo, err := os.Stat(filename)
+		if err != nil {
+			return time.Time{}, err
+		}
+		fileModifiedTime := fileInfo.ModTime()
+		if latestModifiedTime.Before(fileModifiedTime) {
+			latestModifiedTime = fileModifiedTime
+		}
 	}
-	return ""
+	return latestModifiedTime, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Dynamic loading of IaaS credentials currently involves computing the hash of the secret file and comparing the in-memory hash with the newly computed hash to check for changes in the access credentials.

When there is a change in the hash, the `SnapStore` object is updated. The computation of this hash happens whenever a delta snapshot is triggered.

This is now optimized by checking the timestamps of the credential files which were used to calculate the hash.

Currently the following providers are supported:
- [x] AWS S3
- [x] Azure Blob Storage
- [x] Google Cloud Storage
- [x] Alibaba Cloud OSS
- [x] OpenStack Swift
- [x] OpenShift Container Storage

**Which issue(s) this PR fixes**:
Fixes #449 #683 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Dynamic loading of IaaS credentials is now optimized to make use of file system information instead of calculating a hash of the credentials to detect changes.
```
