### PR TITLE
Do not check SSR State when Snapshotter should be stopped

### DIFF
--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -330,7 +330,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 
 // runEtcdProbeLoopWithSnapshotter runs the etcd probe loop
 // for the case when backup-restore becomes leading sidecar.
-func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Context, handler *HTTPHandler, ssr *snapshotter.Snapshotter, ss brtypes.SnapStore, ssrStopCh chan struct{}, ackCh chan struct{}) {
+func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Context, handler *HTTPHandler, ssr *snapshotter.Snapshotter, ss brtypes.SnapStore, ssrStopCh <-chan struct{}, ackCh chan<- struct{}) {
 	var (
 		err                       error
 		initialDeltaSnapshotTaken bool
@@ -513,7 +513,7 @@ func handleAckState(handler *HTTPHandler, ackCh chan struct{}) {
 }
 
 // handleSsrStopRequest responds to handlers request and stop interrupt.
-func handleSsrStopRequest(ctx context.Context, handler *HTTPHandler, ssr *snapshotter.Snapshotter, ackCh, ssrStopCh chan struct{}, logger *logrus.Entry) {
+func handleSsrStopRequest(ctx context.Context, handler *HTTPHandler, ssr *snapshotter.Snapshotter, ackCh chan<- struct{}, ssrStopCh chan<- struct{}, logger *logrus.Entry) {
 	logger.Info("Starting the handleSsrStopRequest handler...")
 	for {
 		var ok bool

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -523,15 +523,9 @@ func handleSsrStopRequest(ctx context.Context, handler *HTTPHandler, ssr *snapsh
 			logger.Infof("handleSsrStopRequest: %v", ctx.Err())
 		}
 
-		ssr.SsrStateMutex.Lock()
-		if ssr.SsrState == brtypes.SnapshotterActive {
-			ssr.SsrStateMutex.Unlock()
-			close(ssrStopCh)
-		} else {
-			ssr.SsrState = brtypes.SnapshotterInactive
-			ssr.SsrStateMutex.Unlock()
-			ackCh <- emptyStruct
-		}
+		ackCh <- emptyStruct
+		close(ssrStopCh)
+
 		if !ok {
 			logger.Info("Stopping handleSsrStopRequest handler...")
 			return

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -526,7 +526,7 @@ func handleSsrStopRequest(ctx context.Context, handler *HTTPHandler, ssr *snapsh
 		ssr.SsrStateMutex.Lock()
 		if ssr.SsrState == brtypes.SnapshotterActive {
 			ssr.SsrStateMutex.Unlock()
-			ssrStopCh <- emptyStruct
+			close(ssrStopCh)
 		} else {
 			ssr.SsrState = brtypes.SnapshotterInactive
 			ssr.SsrStateMutex.Unlock()


### PR DESCRIPTION
**What this PR does / why we need it**:

As reported in #676 we sometimes see that multiple snapshotters can be running at one time in a cluster. 

I believe that the reason for this is that the snapshotter is not set to active state until an initial delta snapshot or a fullsnapshot has been taken. If a leadership election takes place while the snapshot is being taken and the current leader loses that election, then handleSsrRequest does not send on the ssrStopCh. This in turn causes ssr.snapshotEventHandler to never return and snapshots would continue to be taken.

Secondly I'm propsing a change to close the `ssrStopCh` rather than sending on it. This is to make it clear to the reader that the channel is no longer being used at this point. 

Lastly the function signature changes are simply adding further type annotations to the channels passed to functions to help readers understand where channels are being read from/sent to. 


**Which issue(s) this PR fixes**:
Fixes #676 

**Special notes for your reviewer**:

The reason why the ssrState was being checked is not apparent to me so I'd be delighted to be told why this might be an awful idea. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Do not rely on the snapshotter state when stopping the snapshotter. The snapshotter will now always be closed when a member goes from being the leader to any other state. 
```
