### PR TITLE
[Cherrypick #673] Enhancement: Implement Chunk Deletion for Multi-part Uploaded Files on GCP and Openstack Cloud Providers

### DIFF
--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -144,12 +144,12 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 				objectMap[path.Join(prefixV1, snap2.SnapDir, snap2.SnapName)] = &expectedVal2
 
 				logrus.Infof("Running mock tests for %s when only v1 is present", key)
-				// List snap1 and snap3
+				// List snap1 and snap2
 				snapList, err := snapStore.List()
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(snapList.Len()).To(Equal(2))
 				Expect(snapList[0].SnapName).To(Equal(snap2.SnapName))
-				// Fetch snap3
+				// Fetch snap2
 				rc, err := snapStore.Fetch(*snapList[1])
 				Expect(err).ShouldNot(HaveOccurred())
 				defer rc.Close()
@@ -164,12 +164,13 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 				snapList, err = snapStore.List()
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(snapList.Len()).To(Equal(prevLen - 1))
-				// Save snapshot
+				// reset the objectMap
 				resetObjectMap()
 				dummyData := make([]byte, 6*1024*1024)
+				// Save a new snapshot 'snap3'
 				err = snapStore.Save(snap3, io.NopCloser(bytes.NewReader(dummyData)))
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(len(objectMap)).Should(BeNumerically(">", 0))
+				Expect(len(objectMap)).Should(BeNumerically(">=", 1))
 			}
 		})
 	})
@@ -217,19 +218,20 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 				err = snapStore.Delete(*snapList[2])
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(len(objectMap)).To(Equal(prevLen - 1))
-
-				// Save snapshot
+				// reset the objectMap
 				resetObjectMap()
+				// Save a new snapshot 'snap1'
 				dummyData := make([]byte, 6*1024*1024)
 				err = snapStore.Save(snap1, io.NopCloser(bytes.NewReader(dummyData)))
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(len(objectMap)).Should(BeNumerically(">", 0))
+				Expect(len(objectMap)).Should(BeNumerically(">=", 1))
 
+				// Save another new snapshot 'snap4'
 				prevLen = len(objectMap)
 				dummyData = make([]byte, 6*1024*1024)
 				err = snapStore.Save(snap4, io.NopCloser(bytes.NewReader(dummyData)))
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(len(objectMap)).Should(BeNumerically(">", prevLen))
+				Expect(len(objectMap)).Should(BeNumerically(">=", prevLen+1))
 			}
 		})
 	})
@@ -248,6 +250,7 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(snapList.Len()).To(Equal(2))
 				Expect(snapList[0].SnapName).To(Equal(snap4.SnapName))
+				Expect(snapList[1].SnapName).To(Equal(snap5.SnapName))
 				// Fetch snap5
 				rc, err := snapStore.Fetch(*snapList[1])
 				Expect(err).ShouldNot(HaveOccurred())
@@ -263,12 +266,13 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 				snapList, err = snapStore.List()
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(snapList.Len()).To(Equal(prevLen - 1))
-				// Save snapshot
+				// Reset the objectMap
 				resetObjectMap()
+				// Save a new snapshot 'snap4'
 				dummyData := make([]byte, 6*1024*1024)
 				err = snapStore.Save(snap4, io.NopCloser(bytes.NewReader(dummyData)))
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(len(objectMap)).Should(BeNumerically(">", 0))
+				Expect(len(objectMap)).Should(BeNumerically(">=", 1))
 			}
 		})
 	})

--- a/pkg/snapstore/swift_snapstore_test.go
+++ b/pkg/snapstore/swift_snapstore_test.go
@@ -94,6 +94,9 @@ func handleCreateTextObject(w http.ResponseWriter, r *http.Request) {
 // handleDownloadObject creates an HTTP handler at `/testContainer/testObject` on the test handler mux that
 // responds with a `Download` response.
 func handleDownloadObject(w http.ResponseWriter, r *http.Request) {
+	objectMapMutex.Lock()
+	defer objectMapMutex.Unlock()
+
 	prefix := parseObjectNamefromURL(r.URL)
 	var contents []byte
 	for key, val := range objectMap {
@@ -109,8 +112,10 @@ func handleDownloadObject(w http.ResponseWriter, r *http.Request) {
 // handleListObjectNames creates an HTTP handler at `/testContainer` on the test handler mux that
 // responds with a `List` response when only object names are requested.
 func handleListObjectNames(w http.ResponseWriter, r *http.Request) {
-	marker := r.URL.Query().Get("marker")
+	objectMapMutex.Lock()
+	defer objectMapMutex.Unlock()
 
+	marker := r.URL.Query().Get("marker")
 	// To store the keys in slice in sorted order
 	var keys, contents []string
 	for k := range objectMap {
@@ -132,6 +137,8 @@ func handleListObjectNames(w http.ResponseWriter, r *http.Request) {
 // handleDeleteObject creates an HTTP handler at `/testContainer/testObject` on the test handler mux that
 // responds with a `Delete` response.
 func handleDeleteObject(w http.ResponseWriter, r *http.Request) {
+	objectMapMutex.Lock()
+	defer objectMapMutex.Unlock()
 	key := parseObjectNamefromURL(r.URL)
 	if _, ok := objectMap[key]; ok {
 		delete(objectMap, key)


### PR DESCRIPTION

**What this PR does / why we need it**:
Cherrypick of PR: https://github.com/gardener/etcd-backup-restore/pull/673

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Enhanced Garbage Collector to garbage collect the chunks for cloud providers like GCP and OpenStack which does not automatically delete snapshot chunks after the formation of a composite object.
```
