### PR TITLE
Add unit tests for chunk deletion by garbage collector

### DIFF
--- a/pkg/snapshot/snapshotter/garbagecollector.go
+++ b/pkg/snapshot/snapshotter/garbagecollector.go
@@ -208,7 +208,7 @@ func (ssr *Snapshotter) GarbageCollectChunks(snapList brtypes.SnapList) (int, br
 			continue
 		}
 		// Skip the chunk deletion if it's corresponding full/delta snapshot is not uploaded yet
-		if ssr.prevSnapshot.LastRevision == 0 || snap.StartRevision > ssr.prevSnapshot.LastRevision {
+		if ssr.PrevSnapshot.LastRevision == 0 || snap.StartRevision > ssr.PrevSnapshot.LastRevision {
 			continue
 		}
 		// delete the chunk object

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -815,6 +815,7 @@ var _ = Describe("Snapshotter", func() {
 						deletedCount, snapList := ssr.GarbageCollectChunks(list)
 						Expect(deletedCount).To(BeZero())
 						Expect(len(snapList)).To(Equal(3))
+						Expect(list).To(Equal(snapList))
 
 						chunkCount, compositeCount, err := getObjectCount(store)
 						Expect(err).NotTo(HaveOccurred())

--- a/pkg/snapstore/local_snapstore.go
+++ b/pkg/snapstore/local_snapstore.go
@@ -58,6 +58,13 @@ func (s *LocalSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
 	if err != nil && !os.IsExist(err) {
 		return err
 	}
+	if snap.IsChunk {
+		tok := strings.Split(snap.SnapName, "/")
+		err = os.MkdirAll(path.Join(s.prefix, snap.SnapDir, tok[0]), 0700)
+		if err != nil && !os.IsExist(err) {
+			return err
+		}
+	}
 	f, err := os.Create(path.Join(s.prefix, snap.SnapDir, snap.SnapName))
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds unit tests for chunk deletion by GC to make sure that GC only removes chunks and doesn't mess up with non-chunk objects in the store. And that the chunk deletion doesn't affect the general flow of operations in backup-restore.

**Which issue(s) this PR fixes**:
Fixes #684

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add unit tests for chunk deletion
```
