### PR TITLE
Update testmachinery image location

### DIFF
--- a/.test-defs/IntegrationTest.yaml
+++ b/.test-defs/IntegrationTest.yaml
@@ -12,4 +12,4 @@ spec:
   args:
   - >-
     .ci/integration_test tm
-  image: eu.gcr.io/gardener-project/gardener/testmachinery/base-step:0.205.0
+  image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/base-step:stable


### PR DESCRIPTION
**What this PR does / why we need it**:
With gardener/test-infra#479, testmachinery images are published to a new location.

I'm not sure, if there was a reason to use a specific version. But I would suggest to use the `stable` tag going forward.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
