### PR TITLE
[rel-v0.24] Switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/performance_regression_test
+++ b/.ci/performance_regression_test
@@ -43,11 +43,11 @@ fi
 
 ETCD_VERSION=${ETCD_VERSION:-"v3.4.13-bootstrap-1"}
 if [ "$ETCD_VERSION" != "" ]; then
-  ETCD_IMAGE=${ETCD_IMAGE:-"eu.gcr.io/gardener-project/gardener/etcd:$ETCD_VERSION"}
+  ETCD_IMAGE=${ETCD_IMAGE:-"europe-docker.pkg.dev/gardener-project/public/gardener/etcd:$ETCD_VERSION"}
 fi
 
 if [ "$ETCDBR_VERSION" != "" ]; then
-  ETCDBR_IMAGE=${ETCDBR_IMAGE:-"eu.gcr.io/gardener-project/gardener/etcdbrctl:$ETCDBR_VERSION"}
+  ETCDBR_IMAGE=${ETCDBR_IMAGE:-"europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl:$ETCDBR_VERSION"}
 fi
 
 if [ -r "$PERF_TEST_KUBECONFIG" ]; then

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,7 +7,7 @@ etcd-backup-restore:
         - name: 'landscape_repo'
           path: 'kubernetes-dev/landscape-dev-garden'
           branch: 'master'
-      image: eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable
+      image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/testmachinery-run:stable
       execute:
       - tm-tests-playground
       - --flavor-tm-chart=etcd
@@ -17,14 +17,14 @@ etcd-backup-restore:
       - --testrun-prefix=playground
       - --set=projectNamespace=garden-it
 
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         oci-builder: docker-buildx
         platforms:
@@ -32,8 +32,7 @@ etcd-backup-restore:
         - linux/arm64
         dockerimages:
           etcdbrctl:
-            registry: 'gcr-readwrite'
-            image: 'eu.gcr.io/gardener-project/gardener/etcdbrctl'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/etcdbrctl
             dockerfile: 'build/Dockerfile'
             inputs:
               repos:
@@ -55,7 +54,7 @@ etcd-backup-restore:
       unit_test:
         image: 'golang:1.20.3'
       integration_test:
-        image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'
+        image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/base-step:stable
       build:
         image: 'golang:1.20.3'
         output_dir: 'binary'
@@ -63,8 +62,10 @@ etcd-backup-restore:
   jobs:
     head-update:
       traits:
-        component_descriptor: ~
         draft_release: ~
+        component_descriptor:
+          ocm_repository_mappings:
+          - repository: europe-docker.pkg.dev/gardener-project/releases
     pull-request:
       traits:
         pull-request: ~
@@ -72,6 +73,12 @@ etcd-backup-restore:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            etcdbrctl:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/etcdbrctl
         release:
           nextversion: 'bump_minor'
         slack:
@@ -80,4 +87,3 @@ etcd-backup-restore:
             internal_scp_workspace:
               channel_name: 'C0177NLL8V9' # gardener-etcd
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~

--- a/.test-defs/IntegrationTest.yaml
+++ b/.test-defs/IntegrationTest.yaml
@@ -12,4 +12,4 @@ spec:
   args:
   - >-
     .ci/integration_test tm
-  image: eu.gcr.io/gardener-project/gardener/testmachinery/base-step:0.205.0
+  image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/base-step:stable

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 VERSION             ?= $(shell cat VERSION)
-REGISTRY            ?= eu.gcr.io/gardener-project/gardener
-IMAGE_REPOSITORY    := $(REGISTRY)/etcdbrctl
+REGISTRY            ?= europe-docker.pkg.dev/gardener-project/public
+IMAGE_REPOSITORY    := $(REGISTRY)/gardener/etcdbrctl
 IMAGE_TAG           := $(VERSION)
 BUILD_DIR           := build
 BIN_DIR             := bin

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -1,13 +1,13 @@
 images:
   # etcd image to use
   etcd:
-    repository: eu.gcr.io/gardener-project/gardener/etcd
-    tag: v3.4.13-bootstrap-1
+    repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd
+    tag: v3.4.26-3
     pullPolicy: IfNotPresent
   # etcd-backup-restore image to use
   etcdBackupRestore:
-    repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-    tag: v0.12.1
+    repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
+    tag: v0.24.7
     pullPolicy: IfNotPresent
 
 resources:

--- a/doc/usage/getting_started.md
+++ b/doc/usage/getting_started.md
@@ -1,6 +1,6 @@
 # Getting started
 
-Currently we don't publish the binary build with the release, but it is pretty straight forward to build it by following the steps mentioned [here](../development/local_setup.md#build). But we do publish the docker image with each release, please check the [release page](https://github.com/gardener/etcd-backup-restore/releases) for the same. Currently, release docker images are pushed to `eu.gcr.io/gardener-project/gardener/etcdbrctl` to container registry.
+Currently we don't publish the binary build with the release, but it is pretty straight forward to build it by following the steps mentioned [here](../development/local_setup.md#build). But we do publish the docker image with each release, please check the [release page](https://github.com/gardener/etcd-backup-restore/releases) for the same. Currently, release docker images are pushed to `europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl` to container registry.
 
 ## Usage
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick of #688 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @ccwienk 
/cc @ishan16696 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.
```
