### PR TITLE
Add support for overriding storage API endpoint for GCS

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
@@ -19,6 +19,9 @@ data:
   storageKey : {{ .Values.backup.abs.storageKey | b64enc }}
 {{- else if eq .Values.backup.storageProvider "GCS" }}
   serviceaccount.json : {{ .Values.backup.gcs.serviceAccountJson | b64enc }}
+  {{- if .Values.backup.gcs.storageAPIEndpoint }}
+  storageAPIEndpoint: {{ .Values.backup.gcs.storageAPIEndpoint | b64enc}}
+  {{- end }}
 {{- else if eq .Values.backup.storageProvider "Swift" }}
   authURL: {{ .Values.backup.swift.authURL | b64enc }}
   domainName: {{ .Values.backup.swift.domainName | b64enc }}

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -194,6 +194,13 @@ spec:
 {{- else if eq .Values.backup.storageProvider "GCS" }}
         - name: "GOOGLE_APPLICATION_CREDENTIALS"
           value: "/root/.gcp/serviceaccount.json"
+  {{- if .Values.backup.gcs.storageAPIEndpoint }}
+        - name: "GOOGLE_STORAGE_API_ENDPOINT"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-etcd-backup
+              key: "storageAPIEndpoint"
+  {{- end }}
 {{- else if eq .Values.backup.storageProvider "Swift" }}
         - name: "OS_AUTH_URL"
           valueFrom:
@@ -221,10 +228,10 @@ spec:
               name: {{ .Release.Name }}-etcd-backup
               key: "tenantName"
         - name: "OS_REGION_NAME"
-            valueFrom:
-              secretKeyRef:
-                name: { { .Release.Name } }-etcd-backup
-                key: "regionName"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-etcd-backup
+              key: "regionName"
 {{- else if eq .Values.backup.storageProvider "OSS" }}
         - name: "ALICLOUD_ENDPOINT"
           valueFrom:

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -90,6 +90,7 @@ backup:
   #   accessKeyID: access-key-id-with-route53-privileges
   # gcs:
   #   serviceAccountJson: service-account-json-with-object-storage-privileges
+  #   storageAPIEndpoint: endpoint-override-for-storage-api # optional
   # abs:
   #   storageAccount: storage-account-with-object-storage-privileges
   #   storageKey: storage-key-with-object-storage-privileges

--- a/docs/deployment/getting_started.md
+++ b/docs/deployment/getting_started.md
@@ -14,27 +14,28 @@ The procedure to provide credentials to access the cloud provider object store v
 ### Various ways to pass Credentials:
 
 * For `AWS S3`: 
-   1. The secret file should be provided and it's file path should be made available as environment variables: `AWS_APPLICATION_CREDENTIALS` or `AWS_APPLICATION_CREDENTIALS_JSON`.
+   1. The secret file should be provided, and the file path should be made available as environment variables: `AWS_APPLICATION_CREDENTIALS` or `AWS_APPLICATION_CREDENTIALS_JSON`.
    2. For `S3-compatible providers` such as MinIO, `endpoint`, `s3ForcePathStyle`, `insecureSkipVerify` and `trustedCaCert`, can also be made available in a above file to configure the S3 client to communicate to a non-AWS provider.
 
 * For  `Google Cloud Storage`: 
    1. The service account json file should be provided in the `~/.gcp` as a `service-account-file.json` file.
-   2. The service account json file should be provided and it's file path should be made available as environment variable: `GOOGLE_APPLICATION_CREDENTIALS`
+   2. The service account json file should be provided, and the file path should be made available as environment variable `GOOGLE_APPLICATION_CREDENTIALS`.
+   3. If using a storage API [endpoint override](https://pkg.go.dev/cloud.google.com/go#hdr-Endpoint_Override), such as a [regional endpoint](https://cloud.google.com/storage/docs/regional-endpoints) or a local GCS emulator endpoint, then the endpoint must be made available via environment variable `GOOGLE_STORAGE_API_ENDPOINT`, in the format `http[s]://host[:port]/storage/v1/`.
 
 * For `Azure Blob storage`:
-   1. The secret file should be provided and it's file path should be made available as environment variables: `AZURE_APPLICATION_CREDENTIALS` or `AZURE_APPLICATION_CREDENTIALS_JSON`.
+   1. The secret file should be provided, and the file path should be made available as environment variables: `AZURE_APPLICATION_CREDENTIALS` or `AZURE_APPLICATION_CREDENTIALS_JSON`.
 
 * For `Openstack Swift`:
-  1. The secret file should be provided and file path should be made available as environment variables: `OPENSTACK_APPLICATION_CREDENTIALS` or `OPENSTACK_APPLICATION_CREDENTIALS_JSON`.
+  1. The secret file should be provided, and the file path should be made available as environment variables: `OPENSTACK_APPLICATION_CREDENTIALS` or `OPENSTACK_APPLICATION_CREDENTIALS_JSON`.
 
 * For `Alicloud OSS`:
-  1. The secret file should be provided and file path should be made available as environment variables: `ALICLOUD_APPLICATION_CREDENTIALS` or `ALICLOUD_APPLICATION_CREDENTIALS_JSON`.
+  1. The secret file should be provided, and the file path should be made available as environment variables: `ALICLOUD_APPLICATION_CREDENTIALS` or `ALICLOUD_APPLICATION_CREDENTIALS_JSON`.
 
 * For `Dell EMC ECS`:
   1. `ECS_ENDPOINT`, `ECS_ACCESS_KEY_ID`, `ECS_SECRET_ACCESS_KEY` should be made available as environment variables. For development purposes, the environment variables `ECS_DISABLE_SSL` and `ECS_INSECURE_SKIP_VERIFY` can also be set to "true" or "false".
 
 * For `Openshift Container Storage (OCS)`:
-  1. The secret file should be provided and file path should be made available as environment variables: `OPENSHIFT_APPLICATION_CREDENTIALS` or `OPENSHIFT_APPLICATION_CREDENTIALS_JSON`.
+  1. The secret file should be provided, and the file path should be made available as environment variables: `OPENSHIFT_APPLICATION_CREDENTIALS` or `OPENSHIFT_APPLICATION_CREDENTIALS_JSON`.
   For development purposes, the environment variables `OCS_DISABLE_SSL` and `OCS_INSECURE_SKIP_VERIFY` can also be set to "true" or "false".
 
 

--- a/example/storage-provider-secrets/04-google-cloud-storage-secret.yaml
+++ b/example/storage-provider-secrets/04-google-cloud-storage-secret.yaml
@@ -6,3 +6,4 @@ metadata:
 type: Opaque
 data:
   serviceaccount.json: ...
+#  storageAPIEndpoint: # http[s]://host[:port]/storage/v1/

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -36,9 +36,9 @@ import (
 )
 
 const (
-	storeCredentials       = "GOOGLE_APPLICATION_CREDENTIALS"
-	storageAPIEndpoint     = "GOOGLE_STORAGE_API_ENDPOINT"
-	sourceStoreCredentials = "SOURCE_GOOGLE_APPLICATION_CREDENTIALS"
+	envStoreCredentials       = "GOOGLE_APPLICATION_CREDENTIALS"
+	envStorageAPIEndpoint     = "GOOGLE_STORAGE_API_ENDPOINT"
+	envSourceStoreCredentials = "SOURCE_GOOGLE_APPLICATION_CREDENTIALS"
 )
 
 // GCSSnapStore is snapstore with GCS object store as backend.
@@ -62,17 +62,17 @@ func NewGCSSnapStore(config *brtypes.SnapstoreConfig) (*GCSSnapStore, error) {
 	ctx := context.TODO()
 	var opts []option.ClientOption // no need to explicitly set store credentials here since the Google SDK picks it up from the standard environment variable
 
-	if _, ok := os.LookupEnv(sourceStoreCredentials); !ok { // do not set endpoint override when copying backups between buckets, since the buckets may reside on different regions
-		endpoint := strings.TrimSpace(os.Getenv(storageAPIEndpoint))
+	if _, ok := os.LookupEnv(envSourceStoreCredentials); !ok { // do not set endpoint override when copying backups between buckets, since the buckets may reside on different regions
+		endpoint := strings.TrimSpace(os.Getenv(envStorageAPIEndpoint))
 		if endpoint != "" {
 			opts = append(opts, option.WithEndpoint(endpoint))
 		}
 	}
 
 	if config.IsSource {
-		filename := os.Getenv(sourceStoreCredentials)
+		filename := os.Getenv(envSourceStoreCredentials)
 		if filename == "" {
-			return nil, fmt.Errorf("environment variable %s is not set", sourceStoreCredentials)
+			return nil, fmt.Errorf("environment variable %s is not set", envSourceStoreCredentials)
 		}
 		opts = append(opts, option.WithCredentialsFile(filename))
 	}
@@ -272,7 +272,7 @@ func (s *GCSSnapStore) Delete(snap brtypes.Snapshot) error {
 
 // GetGCSCredentialsLastModifiedTime returns the latest modification timestamp of the GCS credential file
 func GetGCSCredentialsLastModifiedTime() (time.Time, error) {
-	if filename, isSet := os.LookupEnv(storeCredentials); isSet {
+	if filename, isSet := os.LookupEnv(envStoreCredentials); isSet {
 		credentialFiles := []string{filename}
 		gcsTimeStamp, err := getLatestCredentialsModifiedTime(credentialFiles)
 		if err != nil {


### PR DESCRIPTION
/area backup
/platform gcp
/kind enhancement

**What this PR does / why we need it**:
Add support for overriding storage API endpoint for Google GCS provider. This allows users to specify their own storage API [endpoint override](https://pkg.go.dev/cloud.google.com/go#hdr-Endpoint_Override), such as a [regional endpoint](https://cloud.google.com/storage/docs/regional-endpoints), or even a local GCS emulator endpoint. Users need to set environment variable `GOOGLE_STORAGE_API_ENDPOINT`, with the value in the format `http[s]://host[:port]/storage/v1/`.

**Which issue(s) this PR fixes**:
Fixes #690 

**Special notes for your reviewer**:
/cc @dguendisch @anveshreddy18 
/invite @ishan16696 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Add support for overriding storage API endpoint for provider GCS, by setting environment variable `GOOGLE_STORAGE_API_ENDPOINT`, with the value in the format `http[s]://host[:port]/storage/v1/`. ⚠️ Note: GC storage API endpoint will not be overridden for `copy` subcommand, since backup buckets may reside in different regions.
```
