### PR TITLE
Fix awscli installation for integration test

### DIFF
--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -114,7 +114,7 @@ function setup_etcdbrctl(){
 
 function setup_awscli() {
     echo "Installing awscli..."
-    pip3 install awscli
+    pip3 install --break-system-packages awscli
     echo "Successfully installed awscli."
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix awscli installation for integration test, similar to https://github.com/gardener/test-infra/pull/480/commits/8fc1fb7f32b39aba7ddb74317cdd8dae17a8b572 (when building the testmachinery image itself).

**Which issue(s) this PR fixes**:
Fixes following error from integration test:
```
Installing awscli...
error: externally-managed-environment

× This environment is externally managed
╰─> 
    The system-wide python installation should be maintained using the system
    package manager (apk) only.
    
    If the package in question is not packaged already (and hence installable via
    "apk add py3-somepackage"), please consider installing it inside a virtual
    environment, e.g.:
    
    python3 -m venv /path/to/venv
    . /path/to/venv/bin/activate
    pip install mypackage
    
    To exit the virtual environment, run:
    
    deactivate
    
    The virtual environment is not deleted, and can be re-entered by re-sourcing
    the activate file.
    
    To automatically manage virtual environments, consider using pipx (from the
    pipx package).

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

**Special notes for your reviewer**:
/invite @ishan16696 
The integration test for this PR will fail, but once it's merged to master, the head-update job should pass. Tested locally and confirmed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
