### PR TITLE
[rel-v0.24] Add support for overriding storage API endpoint for GCS

### DIFF
--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -114,7 +114,7 @@ function setup_etcdbrctl(){
 
 function setup_awscli() {
     echo "Installing awscli..."
-    pip3 install awscli
+    pip3 install --break-system-packages awscli
     echo "Successfully installed awscli."
 }
 

--- a/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
@@ -19,6 +19,9 @@ data:
   storageKey : {{ .Values.backup.abs.storageKey | b64enc }}
 {{- else if eq .Values.backup.storageProvider "GCS" }}
   serviceaccount.json : {{ .Values.backup.gcs.serviceAccountJson | b64enc }}
+  {{- if .Values.backup.gcs.storageAPIEndpoint }}
+  storageAPIEndpoint: {{ .Values.backup.gcs.storageAPIEndpoint | b64enc}}
+  {{- end }}
 {{- else if eq .Values.backup.storageProvider "Swift" }}
   authURL: {{ .Values.backup.swift.authURL | b64enc }}
   domainName: {{ .Values.backup.swift.domainName | b64enc }}

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -194,6 +194,13 @@ spec:
 {{- else if eq .Values.backup.storageProvider "GCS" }}
         - name: "GOOGLE_APPLICATION_CREDENTIALS"
           value: "/root/.gcp/serviceaccount.json"
+  {{- if .Values.backup.gcs.storageAPIEndpoint }}
+        - name: "GOOGLE_STORAGE_API_ENDPOINT"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-etcd-backup
+              key: "storageAPIEndpoint"
+  {{- end }}
 {{- else if eq .Values.backup.storageProvider "Swift" }}
         - name: "OS_AUTH_URL"
           valueFrom:
@@ -221,10 +228,10 @@ spec:
               name: {{ .Release.Name }}-etcd-backup
               key: "tenantName"
         - name: "OS_REGION_NAME"
-            valueFrom:
-              secretKeyRef:
-                name: { { .Release.Name } }-etcd-backup
-                key: "regionName"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-etcd-backup
+              key: "regionName"
 {{- else if eq .Values.backup.storageProvider "OSS" }}
         - name: "ALICLOUD_ENDPOINT"
           valueFrom:

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -90,6 +90,7 @@ backup:
   #   accessKeyID: access-key-id-with-route53-privileges
   # gcs:
   #   serviceAccountJson: service-account-json-with-object-storage-privileges
+  #   storageAPIEndpoint: endpoint-override-for-storage-api # optional
   # abs:
   #   storageAccount: storage-account-with-object-storage-privileges
   #   storageKey: storage-key-with-object-storage-privileges

--- a/doc/usage/getting_started.md
+++ b/doc/usage/getting_started.md
@@ -14,18 +14,19 @@ The procedure to provide credentials to access the cloud provider object store v
 ### Various ways to pass Credentials:
 
 * For `AWS S3`: 
-   1. The secret file should be provided and it's file path should be made available as environment variables: `AWS_APPLICATION_CREDENTIALS` or `AWS_APPLICATION_CREDENTIALS_JSON`.
-   2. For `S3-compatible providers` such as MinIO, `endpoint`, `s3ForcePathStyle`, `insecureSkipVerify` and `trustedCaCert`, can also be made available in a above file to configure the S3 client to communicate to a non-AWS provider.
+  1. The secret file should be provided, and the file path should be made available as environment variables: `AWS_APPLICATION_CREDENTIALS` or `AWS_APPLICATION_CREDENTIALS_JSON`.
+  2. For `S3-compatible providers` such as MinIO, `endpoint`, `s3ForcePathStyle`, `insecureSkipVerify` and `trustedCaCert`, can also be made available in a above file to configure the S3 client to communicate to a non-AWS provider.
 
 * For  `Google Cloud Storage`: 
-   1. The service account json file should be provided in the `~/.gcp` as a `service-account-file.json` file.
-   2. The service account json file should be provided and it's file path should be made available as environment variable: `GOOGLE_APPLICATION_CREDENTIALS`
+  1. The service account json file should be provided in the `~/.gcp` as a `service-account-file.json` file.
+  2. The service account json file should be provided, and the file path should be made available as environment variable `GOOGLE_APPLICATION_CREDENTIALS`.
+  3. If using a storage API [endpoint override](https://pkg.go.dev/cloud.google.com/go#hdr-Endpoint_Override), such as a [regional endpoint](https://cloud.google.com/storage/docs/regional-endpoints) or a local GCS emulator endpoint, then the endpoint must be made available via environment variable `GOOGLE_STORAGE_API_ENDPOINT`, in the format `http[s]://host[:port]/storage/v1/`.
 
 * For `Azure Blob storage`:
-   1. The secret file should be provided and it's file path should be made available as environment variables: `AZURE_APPLICATION_CREDENTIALS` or `AZURE_APPLICATION_CREDENTIALS_JSON`.
+  1. The secret file should be provided, and the file path should be made available as environment variables: `AZURE_APPLICATION_CREDENTIALS` or `AZURE_APPLICATION_CREDENTIALS_JSON`.
 
 * For `Openstack Swift`:
-  1. The secret file should be provided and file path should be made available as environment variables: `OPENSTACK_APPLICATION_CREDENTIALS` or `OPENSTACK_APPLICATION_CREDENTIALS_JSON`.
+  1. The secret file should be provided, and the file path should be made available as environment variables: `OPENSTACK_APPLICATION_CREDENTIALS` or `OPENSTACK_APPLICATION_CREDENTIALS_JSON`.
 
 * For `Alicloud OSS`:
   1. The secret file should be provided and file path should be made available as environment variables: `ALICLOUD_APPLICATION_CREDENTIALS` or `ALICLOUD_APPLICATION_CREDENTIALS_JSON`.
@@ -34,7 +35,7 @@ The procedure to provide credentials to access the cloud provider object store v
   1. `ECS_ENDPOINT`, `ECS_ACCESS_KEY_ID`, `ECS_SECRET_ACCESS_KEY` should be made available as environment variables. For development purposes, the environment variables `ECS_DISABLE_SSL` and `ECS_INSECURE_SKIP_VERIFY` can also be set to "true" or "false".
 
 * For `Openshift Container Storage (OCS)`:
-  1. The secret file should be provided and file path should be made available as environment variables: `OPENSHIFT_APPLICATION_CREDENTIALS` or `OPENSHIFT_APPLICATION_CREDENTIALS_JSON`.
+  1. The secret file should be provided, and the file path should be made available as environment variables: `OPENSHIFT_APPLICATION_CREDENTIALS` or `OPENSHIFT_APPLICATION_CREDENTIALS_JSON`.
   For development purposes, the environment variables `OCS_DISABLE_SSL` and `OCS_INSECURE_SKIP_VERIFY` can also be set to "true" or "false".
 
 

--- a/example/storage-provider-secrets/04-google-cloud-storage-secret.yaml
+++ b/example/storage-provider-secrets/04-google-cloud-storage-secret.yaml
@@ -6,3 +6,4 @@ metadata:
 type: Opaque
 data:
   serviceaccount.json: ...
+# storageAPIEndpoint: # http[s]://host[:port]/storage/v1/


### PR DESCRIPTION
/area backup
/platform gcp
/kind enhancement

**What this PR does / why we need it**:
Cherry-pick of #691 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @ishan16696 @anveshreddy18 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Add support for overriding storage API endpoint for provider GCS, by setting environment variable `GOOGLE_STORAGE_API_ENDPOINT`, with the value in the format `http[s]://host[:port]/storage/v1/`. ⚠️ Note: GCS storage API endpoint will not be overridden for `copy` subcommand, since backup buckets may reside in different regions.
```
