### PR TITLE
[rel-v0.24] Optimize dynamic loading of IaaS Credentials using credential file timestamps

### DIFF
--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -155,6 +155,16 @@ EOF
 [default]
 region = $3
 EOF
+  temp_dir=$(mktemp -d)
+  credentials_file="${temp_dir}/credentials.json"
+  cat <<EOF >"${credentials_file}"
+{
+  "accessKeyID": "$1",
+  "secretAccessKey": "$2",
+  "region": "$3"
+}
+EOF
+  export AWS_APPLICATION_CREDENTIALS_JSON="${credentials_file}"
 }
 
 function create_aws_secret() {

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"cloud.google.com/go/storage"
 	stiface "github.com/gardener/etcd-backup-restore/pkg/snapstore/gcs"
@@ -269,24 +270,16 @@ func (s *GCSSnapStore) Delete(snap brtypes.Snapshot) error {
 	return s.client.Bucket(s.bucket).Object(objectName).Delete(context.TODO())
 }
 
-// GCSSnapStoreHash calculates and returns the hash of GCS snapstore secret.
-func GCSSnapStoreHash(config *brtypes.SnapstoreConfig) (string, error) {
-	if _, isSet := os.LookupEnv(envStoreCredentials); isSet {
-		if file := os.Getenv(envStoreCredentials); file != "" {
-			credjson, err := readGCSCredentialsFile(file)
-			if err != nil {
-				return "", fmt.Errorf("error getting credentials from %v ", file)
-			}
-			return getHash(credjson), nil
+// GetGCSCredentialsLastModifiedTime returns the latest modification timestamp of the GCS credential file
+func GetGCSCredentialsLastModifiedTime() (time.Time, error) {
+	if filename, isSet := os.LookupEnv(envStoreCredentials); isSet {
+		credentialFiles := []string{filename}
+		gcsTimeStamp, err := getLatestCredentialsModifiedTime(credentialFiles)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("failed to fetch file information of the GCS JSON credential file %v with error: %v", filename, err)
 		}
+		return gcsTimeStamp, nil
 	}
-	return "", nil
-}
 
-func readGCSCredentialsFile(filename string) ([]byte, error) {
-	b, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-	return b, nil
+	return time.Time{}, fmt.Errorf("no environment variable set for the GCS credential file")
 }

--- a/pkg/snapstore/utils.go
+++ b/pkg/snapstore/utils.go
@@ -15,7 +15,6 @@
 package snapstore
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"os"
 	"path"
@@ -171,36 +170,46 @@ func adaptPrefix(snap *brtypes.Snapshot, snapstorePrefix string) string {
 	return snapstorePrefix
 }
 
-// GetSnapstoreSecretHash returns the hash of object store secrets hash
-func GetSnapstoreSecretHash(config *brtypes.SnapstoreConfig) (string, error) {
-	switch config.Provider {
+// GetSnapstoreSecretModifiedTime returns the latest modification timestamp of the access credential files.
+// Returns an error if fetching the timestamp of the access credential files fails.
+func GetSnapstoreSecretModifiedTime(snapstoreProvider string) (time.Time, error) {
+	switch snapstoreProvider {
 	case brtypes.SnapstoreProviderLocal:
-		return "", nil
+		return time.Time{}, nil
 	case brtypes.SnapstoreProviderS3:
-		return S3SnapStoreHash(config)
+		return GetS3CredentialsLastModifiedTime()
 	case brtypes.SnapstoreProviderABS:
-		return ABSSnapStoreHash(config)
+		return GetABSCredentialsLastModifiedTime()
 	case brtypes.SnapstoreProviderGCS:
-		return GCSSnapStoreHash(config)
+		return GetGCSCredentialsLastModifiedTime()
 	case brtypes.SnapstoreProviderSwift:
-		return SwiftSnapStoreHash(config)
+		return GetSwiftCredentialsLastModifiedTime()
 	case brtypes.SnapstoreProviderOSS:
-		return OSSSnapStoreHash(config)
+		return GetOSSCredentialsLastModifiedTime()
 	case brtypes.SnapstoreProviderOCS:
-		return OCSSnapStoreHash(config)
+		return GetOCSCredentialsLastModifiedTime()
 	default:
-		return "", nil
+		return time.Time{}, nil
 	}
 }
 
-func getHash(data interface{}) string {
-	switch dat := data.(type) {
-	case string:
-		sha := sha256.Sum256([]byte(dat))
-		return fmt.Sprintf("%x", sha)
-	case []byte:
-		sha := sha256.Sum256(dat)
-		return fmt.Sprintf("%x", sha)
+// getLatestCredentialsModifiedTime returns the latest file modification time from a list of files
+func getLatestCredentialsModifiedTime(credentialFiles []string) (time.Time, error) {
+	var latestModifiedTime time.Time
+
+	for _, filename := range credentialFiles {
+		// os.Stat instead of file.Info because the file is symlinked
+		fileInfo, err := os.Stat(filename)
+		if err != nil {
+			return time.Time{}, err
+		}
+		if fileInfo.IsDir() {
+			return time.Time{}, fmt.Errorf("a directory %s found in place of a credential file", fileInfo.Name())
+		}
+		fileModifiedTime := fileInfo.ModTime()
+		if latestModifiedTime.Before(fileModifiedTime) {
+			latestModifiedTime = fileModifiedTime
+		}
 	}
-	return ""
+	return latestModifiedTime, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick of #670

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Dynamic loading of IaaS credentials is now optimized to make use of file system information instead of calculating a hash of the credentials to detect changes.
```
