### PR TITLE
[FakeGCS] Add a new field `emulatorEnabled` in gcp secret & configure Gcloud client for GCS Emulator

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
@@ -28,6 +28,9 @@ data:
   {{- if .Values.backup.gcs.storageAPIEndpoint }}
   storageAPIEndpoint: {{ .Values.backup.gcs.storageAPIEndpoint | b64enc}}
   {{- end }}
+  {{- if .Values.backup.gcs.emulatorEnabled }}
+  emulatorEnabled: {{ .Values.backup.gcs.emulatorEnabled | b64enc}}
+  {{- end }}
 {{- else if eq .Values.backup.storageProvider "Swift" }}
   authURL: {{ .Values.backup.swift.authURL | b64enc }}
   domainName: {{ .Values.backup.swift.domainName | b64enc }}

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -365,3 +365,4 @@ spec:
       resources:
         requests:
           storage: {{ .Values.storageCapacity }}
+          

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -218,6 +218,13 @@ spec:
               key: "storageAPIEndpoint"
               optional: true
   {{- end }}
+  {{- if .Values.backup.gcs.emulatorEnabled }}
+        - name: "GOOGLE_EMULATOR_ENABLED"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-etcd-backup
+              key: "emulatorEnabled"
+  {{- end }}
 {{- else if eq .Values.backup.storageProvider "Swift" }}
         - name: "OS_AUTH_URL"
           valueFrom:

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -192,7 +192,7 @@ spec:
               name: {{ .Release.Name }}-etcd-backup
               key: "storageKey"
   {{- if .Values.backup.abs.emulatorEnabled }}
-        - name: "EMULATOR_ENABLED"
+        - name: "AZURE_EMULATOR_ENABLED"
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-etcd-backup
@@ -224,6 +224,7 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-etcd-backup
               key: "emulatorEnabled"
+              optional: true
   {{- end }}
 {{- else if eq .Values.backup.storageProvider "Swift" }}
         - name: "OS_AUTH_URL"

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -91,6 +91,7 @@ backup:
   # gcs:
   #   serviceAccountJson: service-account-json-with-object-storage-privileges
   #   storageAPIEndpoint: endpoint-override-for-storage-api # optional
+  #   emulatorEnabled: boolean-flag-to-configure-etcdbr-to-use-gcs-emulator # optional
   # abs:
   #   storageAccount: storage-account-with-object-storage-privileges
   #   storageKey: storage-key-with-object-storage-privileges

--- a/example/storage-provider-secrets/04-google-cloud-storage-secret.yaml
+++ b/example/storage-provider-secrets/04-google-cloud-storage-secret.yaml
@@ -6,4 +6,5 @@ metadata:
 type: Opaque
 data:
   serviceaccount.json: ...
-#  storageAPIEndpoint: # http[s]://host[:port]/storage/v1/
+#  storageAPIEndpoint: aHR0cFtzXTovL2hvc3RbOnBvcnRdL3N0b3JhZ2UvdjEv # http[s]://host[:port]/storage/v1/
+#  emulatorEnabled: dHJ1ZQ== # true (optional)

--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -80,27 +80,27 @@ func NewABSSnapStore(config *brtypes.SnapstoreConfig) (*ABSSnapStore, error) {
 // ConstructBlobServiceURL constructs the Blob Service URL based on the activation status of the Azurite Emulator.
 // It checks the environment variables for emulator configuration and constructs the URL accordingly.
 // The function expects two environment variables:
-// - EMULATOR_ENABLED: Indicates whether the Azurite Emulator is enabled (expects "true" or "false").
+// - AZURE_EMULATOR_ENABLED: Indicates whether the Azurite Emulator is enabled (expects "true" or "false").
 // - AZURE_STORAGE_API_ENDPOINT: Specifies the Azurite Emulator endpoint when the emulator is enabled.
 func ConstructBlobServiceURL(credentials *azblob.SharedKeyCredential) (*url.URL, error) {
 	defaultURL, err := url.Parse(fmt.Sprintf("https://%s.%s", credentials.AccountName(), brtypes.AzureBlobStorageHostName))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse default service URL: %w", err)
 	}
-	emulatorEnabled, ok := os.LookupEnv(EnvEmulatorEnabled)
+	emulatorEnabled, ok := os.LookupEnv(EnvAzureEmulatorEnabled)
 	if !ok {
 		return defaultURL, nil
 	}
 	isEmulator, err := strconv.ParseBool(emulatorEnabled)
 	if err != nil {
-		return nil, fmt.Errorf("invalid value for %s: %s, error: %w", EnvEmulatorEnabled, emulatorEnabled, err)
+		return nil, fmt.Errorf("invalid value for %s: %s, error: %w", EnvAzureEmulatorEnabled, emulatorEnabled, err)
 	}
 	if !isEmulator {
 		return defaultURL, nil
 	}
 	endpoint, ok := os.LookupEnv(AzuriteEndpoint)
 	if !ok {
-		return nil, fmt.Errorf("%s environment variable not set while %s is true", AzuriteEndpoint, EnvEmulatorEnabled)
+		return nil, fmt.Errorf("%s environment variable not set while %s is true", AzuriteEndpoint, EnvAzureEmulatorEnabled)
 	}
 	// Application protocol (http or https) is determined by the user of the Azurite, not by this function.
 	return url.Parse(fmt.Sprintf("%s/%s", endpoint, credentials.AccountName()))

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -111,7 +111,7 @@ func NewGCSSnapStoreFromClient(bucket, prefix, tempDir string, maxParallelChunkU
 
 // isEmulatorEnabled checks if the fake GCS emulator is enabled
 func isEmulatorEnabled() bool {
-	isFakeGCSEnabled, ok := os.LookupEnv(EnvGcsEmulatorEnabled)
+	isFakeGCSEnabled, ok := os.LookupEnv(EnvGCSEmulatorEnabled)
 	if !ok {
 		return false
 	}

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -30,7 +30,6 @@ const (
 	envStoreCredentials       = "GOOGLE_APPLICATION_CREDENTIALS"
 	envStorageAPIEndpoint     = "GOOGLE_STORAGE_API_ENDPOINT"
 	envSourceStoreCredentials = "SOURCE_GOOGLE_APPLICATION_CREDENTIALS"
-	envEmulatorEnabled        = "GOOGLE_EMULATOR_ENABLED"
 )
 
 // GCSSnapStore is snapstore with GCS object store as backend.
@@ -112,7 +111,7 @@ func NewGCSSnapStoreFromClient(bucket, prefix, tempDir string, maxParallelChunkU
 
 // isEmulatorEnabled checks if the fake GCS emulator is enabled
 func isEmulatorEnabled() bool {
-	isFakeGCSEnabled, ok := os.LookupEnv(envEmulatorEnabled)
+	isFakeGCSEnabled, ok := os.LookupEnv(EnvGcsEmulatorEnabled)
 	if !ok {
 		return false
 	}

--- a/pkg/snapstore/snapshot.go
+++ b/pkg/snapstore/snapshot.go
@@ -116,6 +116,10 @@ func ParseSnapshot(snapPath string) (*brtypes.Snapshot, error) {
 	//parse creation time as well as parse the Snapshot compression suffix
 	lastNameToken := strings.Split(tokens[3], "/")
 	timeWithSnapSuffix := strings.Split(lastNameToken[0], ".")
+	// Check & remove if the last token is a chunk directory. The chunkDirSuffix is set by only GCS snapstore when using a emulator for testing.
+	if fmt.Sprintf(".%s", timeWithSnapSuffix[len(timeWithSnapSuffix)-1]) == brtypes.ChunkDirSuffix {
+		timeWithSnapSuffix = timeWithSnapSuffix[:len(timeWithSnapSuffix)-1]
+	}
 	if len(timeWithSnapSuffix) >= 2 {
 		if "."+timeWithSnapSuffix[1] != brtypes.FinalSuffix {
 			s.CompressionSuffix = "." + timeWithSnapSuffix[1]

--- a/pkg/snapstore/snapstore.go
+++ b/pkg/snapstore/snapstore.go
@@ -23,8 +23,8 @@ const (
 	backupVersionV2 = "v2"
 	// EnvAzureEmulatorEnabled is the environment variable which indicates whether the Azurite emulator is enabled
 	EnvAzureEmulatorEnabled = "AZURE_EMULATOR_ENABLED"
-	// EnvGcsEmulatorEnabled is the environment variable which indicates whether the GCS emulator is enabled
-	EnvGcsEmulatorEnabled = "GOOGLE_EMULATOR_ENABLED"
+	// EnvGCSEmulatorEnabled is the environment variable which indicates whether the GCS emulator is enabled
+	EnvGCSEmulatorEnabled = "GOOGLE_EMULATOR_ENABLED"
 )
 
 type chunk struct {

--- a/pkg/snapstore/snapstore.go
+++ b/pkg/snapstore/snapstore.go
@@ -21,9 +21,10 @@ const (
 
 	backupVersionV1 = "v1"
 	backupVersionV2 = "v2"
-
-	// EnvEmulatorEnabled is the environment variable which indicates the usage of a storage emulator like Azurite, fake-gcs-server
-	EnvEmulatorEnabled = "EMULATOR_ENABLED"
+	// EnvAzureEmulatorEnabled is the environment variable which indicates whether the Azurite emulator is enabled
+	EnvAzureEmulatorEnabled = "AZURE_EMULATOR_ENABLED"
+	// EnvGcsEmulatorEnabled is the environment variable which indicates whether the GCS emulator is enabled
+	EnvGcsEmulatorEnabled = "GOOGLE_EMULATOR_ENABLED"
 )
 
 type chunk struct {

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 				objectCountPerSnapshot: 1,
 			},
 			"GCS": {
-				SnapStore: NewGCSSnapStoreFromClient(bucket, prefixV2, "/tmp", 5, brtypes.MinChunkSize, &mockGCSClient{
+				SnapStore: NewGCSSnapStoreFromClient(bucket, prefixV2, "/tmp", 5, brtypes.MinChunkSize, "", &mockGCSClient{
 					objects: objectMap,
 					prefix:  prefixV2,
 				}),
@@ -518,22 +518,22 @@ var _ = Describe("Blob Service URL construction for Azure", func() {
 		credentials, err = azblob.NewSharedKeyCredential(storageAccount, storageKey)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
-	Context(fmt.Sprintf("when the environment variable %q is not set", EnvEmulatorEnabled), func() {
+	Context(fmt.Sprintf("when the environment variable %q is not set", EnvAzureEmulatorEnabled), func() {
 		It("should return the default blob service URL", func() {
 			blobServiceURL, err := ConstructBlobServiceURL(credentials)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(blobServiceURL.String()).Should(Equal(fmt.Sprintf("https://%s.%s", credentials.AccountName(), brtypes.AzureBlobStorageHostName)))
 		})
 	})
-	Context(fmt.Sprintf("when the environment variable %q is set", EnvEmulatorEnabled), func() {
+	Context(fmt.Sprintf("when the environment variable %q is set", EnvAzureEmulatorEnabled), func() {
 		Context("to values which are not \"true\"", func() {
 			It("should error when the environment variable is not \"true\" or \"false\"", func() {
-				GinkgoT().Setenv(EnvEmulatorEnabled, "")
+				GinkgoT().Setenv(EnvAzureEmulatorEnabled, "")
 				_, err := ConstructBlobServiceURL(credentials)
 				Expect(err).Should(HaveOccurred())
 			})
 			It("should return the default blob service URL when the environment variable is set to \"false\"", func() {
-				GinkgoT().Setenv(EnvEmulatorEnabled, "false")
+				GinkgoT().Setenv(EnvAzureEmulatorEnabled, "false")
 				blobServiceURL, err := ConstructBlobServiceURL(credentials)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(blobServiceURL.String()).Should(Equal(fmt.Sprintf("https://%s.%s", credentials.AccountName(), brtypes.AzureBlobStorageHostName)))
@@ -542,7 +542,7 @@ var _ = Describe("Blob Service URL construction for Azure", func() {
 		Context("to \"true\"", func() {
 			const endpoint string = "http://localhost:12345"
 			BeforeEach(func() {
-				GinkgoT().Setenv(EnvEmulatorEnabled, "true")
+				GinkgoT().Setenv(EnvAzureEmulatorEnabled, "true")
 			})
 			It(fmt.Sprintf("should error when the %q environment variable is not set", AzuriteEndpoint), func() {
 				_, err := ConstructBlobServiceURL(credentials)

--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -48,6 +48,10 @@ const (
 	// FinalSuffix is the suffix appended to the names of final snapshots.
 	FinalSuffix = ".final"
 
+	// ChunkDirSuffix is the suffix appended to the name of chunk snapshot folder when using fakegcs emulator for testing.
+	// Refer to this github issue for more details: https://github.com/fsouza/fake-gcs-server/issues/1434
+	ChunkDirSuffix = ".chunk"
+
 	backupFormatVersion = "v2"
 
 	// MinChunkSize is set to 5Mib since it is lower chunk size limit for AWS.


### PR DESCRIPTION
**What this PR does / why we need it**:

* Add a new field `emulatorEnabled` in gcp secret
* configure Google cloud client for GCS Emulator when `emulatorEnabled` is `true`

This is helpful to run `etcdbr` tests locally and on pipelines without actually using the real infra. This can also be used by [Etcd-druid](https://github.com/gardener/etcd-druid) to use GCS Emulator [fake-gcs-server](https://github.com/fsouza/fake-gcs-server) for running e2e-tests.

For these, Google cloud client in `backup-restore` has to be configured to connect to the Emulator. 

This PR enables that in either of the two ways 
1) `GOOGLE_EMULATOR_ENABLED` env var is set when running `etcdbr` as a process using `etcdbrctl` 
2) `emulatorEnabled` field in the gcp secret is set to `true` via helm chart

**Which issue(s) this PR fixes**:
Fixes #696 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Added support for using fake-gcs-server for all etcdbr functionalities. To enable: Either 
1) Set `GOOGLE_EMULATOR_ENABLED` environment variable when running `etcdbrctl` command OR 
2) Set `emulatorEnabled: true` in GCP backup secret when deploying via Helm chart.
```
