### PR TITLE
Enhancing `etcd-backup-restore` to support `Azurite` - the Azure Blob Storage emulator

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
@@ -17,6 +17,12 @@ data:
 {{- else if eq .Values.backup.storageProvider "ABS" }}
   storageAccount: {{ .Values.backup.abs.storageAccount | b64enc }}
   storageKey : {{ .Values.backup.abs.storageKey | b64enc }}
+  {{- if .Values.backup.abs.enableAzurite }}
+  enableAzurite: {{ .Values.backup.abs.enableAzurite | b64enc}}
+  {{- end }}
+  {{- if .Values.backup.abs.storageAPIEndpoint }}
+  storageAPIEndpoint: {{ .Values.backup.abs.storageAPIEndpoint | b64enc}}
+  {{- end }}
 {{- else if eq .Values.backup.storageProvider "GCS" }}
   serviceaccount.json : {{ .Values.backup.gcs.serviceAccountJson | b64enc }}
   {{- if .Values.backup.gcs.storageAPIEndpoint }}

--- a/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
@@ -17,8 +17,8 @@ data:
 {{- else if eq .Values.backup.storageProvider "ABS" }}
   storageAccount: {{ .Values.backup.abs.storageAccount | b64enc }}
   storageKey : {{ .Values.backup.abs.storageKey | b64enc }}
-  {{- if .Values.backup.abs.enableAzurite }}
-  enableAzurite: {{ .Values.backup.abs.enableAzurite | b64enc}}
+  {{- if .Values.backup.abs.emulatorEnabled }}
+  emulatorEnabled: {{ .Values.backup.abs.emulatorEnabled | b64enc}}
   {{- end }}
   {{- if .Values.backup.abs.storageAPIEndpoint }}
   storageAPIEndpoint: {{ .Values.backup.abs.storageAPIEndpoint | b64enc}}

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -191,6 +191,20 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-etcd-backup
               key: "storageKey"
+  {{- if .Values.backup.abs.enableAzurite }}
+        - name: "AZURE_ENABLE_STORAGE_EMULATOR"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-etcd-backup
+              key: "enableAzurite"
+  {{- end }}
+  {{- if .Values.backup.abs.storageAPIEndpoint }}
+        - name: "AZURE_STORAGE_API_ENDPOINT"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-etcd-backup
+              key: "storageAPIEndpoint"
+  {{- end }}
 {{- else if eq .Values.backup.storageProvider "GCS" }}
         - name: "GOOGLE_APPLICATION_CREDENTIALS"
           value: "/root/.gcp/serviceaccount.json"

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -191,12 +191,12 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-etcd-backup
               key: "storageKey"
-  {{- if .Values.backup.abs.enableAzurite }}
-        - name: "AZURE_ENABLE_STORAGE_EMULATOR"
+  {{- if .Values.backup.abs.emulatorEnabled }}
+        - name: "EMULATOR_ENABLED"
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-etcd-backup
-              key: "enableAzurite"
+              key: "emulatorEnabled"
   {{- end }}
   {{- if .Values.backup.abs.storageAPIEndpoint }}
         - name: "AZURE_STORAGE_API_ENDPOINT"

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -94,6 +94,8 @@ backup:
   # abs:
   #   storageAccount: storage-account-with-object-storage-privileges
   #   storageKey: storage-key-with-object-storage-privileges
+  #   enableAzurite: boolean-float-to-enable-e2e-tests-to-use-azure-emulator # optional
+  #   storageAPIEndpoint: endpoint-override-for-storage-api # if enableAzurite is true
   # swift:
   #   authURL: identity-server-url
   #   domainName: domain-name

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -94,8 +94,8 @@ backup:
   # abs:
   #   storageAccount: storage-account-with-object-storage-privileges
   #   storageKey: storage-key-with-object-storage-privileges
-  #   enableAzurite: boolean-float-to-enable-e2e-tests-to-use-azure-emulator # optional
-  #   storageAPIEndpoint: endpoint-override-for-storage-api # if enableAzurite is true
+  #   emulatorEnabled: boolean-float-to-enable-e2e-tests-to-use-azure-emulator # optional
+  #   storageAPIEndpoint: endpoint-override-for-storage-api # if emulatorEnabled is true
   # swift:
   #   authURL: identity-server-url
   #   domainName: domain-name

--- a/example/storage-provider-secrets/00-azure-blob-storage-secret.yaml
+++ b/example/storage-provider-secrets/00-azure-blob-storage-secret.yaml
@@ -7,7 +7,7 @@ type: Opaque
 data: 
   storageAccount: YWRtaW4= # admin
   storageKey: YWRtaW4= # admin
-  # enableAzurite: dHJ1ZQ== # true (optional)
+  # emulatorEnabled: dHJ1ZQ== # true (optional)
   # storageAPIEndpoint: aHR0cDovL2F6dXJpdGUtc2VydmljZToxMDAwMA== # http://azurite-service:10000 (optional)
 
 #### OR ####

--- a/example/storage-provider-secrets/00-azure-blob-storage-secret.yaml
+++ b/example/storage-provider-secrets/00-azure-blob-storage-secret.yaml
@@ -7,6 +7,8 @@ type: Opaque
 data: 
   storageAccount: YWRtaW4= # admin
   storageKey: YWRtaW4= # admin
+  # enableAzurite: dHJ1ZQ== # true (optional)
+  # storageAPIEndpoint: aHR0cDovL2F6dXJpdGUtc2VydmljZToxMDAwMA== # http://azurite-service:10000 (optional)
 
 #### OR ####
 

--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -58,7 +58,7 @@ type absCredentials struct {
 	StorageAccount string `json:"storageAccount"`
 }
 
-// NewABSSnapStore create new ABSSnapStore from shared configuration with specified bucket
+// NewABSSnapStore creates a new ABSSnapStore using a shared configuration and a specified bucket
 func NewABSSnapStore(config *brtypes.SnapstoreConfig) (*ABSSnapStore, error) {
 	storageAccount, storageKey, err := getCredentials(getEnvPrefixString(config.IsSource))
 	if err != nil {
@@ -75,7 +75,7 @@ func NewABSSnapStore(config *brtypes.SnapstoreConfig) (*ABSSnapStore, error) {
 			TryTimeout: downloadTimeout,
 		}})
 
-	blobURL, err := constructBlobServiceURL(storageAccount, credentials)
+	blobURL, err := ConstructBlobServiceURL(credentials)
 	if err != nil {
 		return nil, err
 	}
@@ -86,8 +86,9 @@ func NewABSSnapStore(config *brtypes.SnapstoreConfig) (*ABSSnapStore, error) {
 	return GetABSSnapstoreFromClient(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads, config.MinChunkSize, &containerURL)
 }
 
-func constructBlobServiceURL(storageAccount string, credentials *azblob.SharedKeyCredential) (*url.URL, error) {
-	defaultURL, err := url.Parse(fmt.Sprintf("https://%s.%s", storageAccount, brtypes.AzureBlobStorageHostName))
+// ConstructBlobServiceURL constructs the Blob Service URL based on whether the Azurite Emulator is enabled or not
+func ConstructBlobServiceURL(credentials *azblob.SharedKeyCredential) (*url.URL, error) {
+	defaultURL, err := url.Parse(fmt.Sprintf("https://%s.%s", credentials.AccountName(), brtypes.AzureBlobStorageHostName))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse default service URL: %v", err)
 	}

--- a/pkg/snapstore/snapstore.go
+++ b/pkg/snapstore/snapstore.go
@@ -32,8 +32,8 @@ const (
 	backupVersionV1 = "v1"
 	backupVersionV2 = "v2"
 
-	// environment variable which indicates the usage of a storage emulator like Azurite, fake-gcs-server
-	envEmulatorEnabled = "EMULATOR_ENABLED"
+	// EnvEmulatorEnabled is the environment variable which indicates the usage of a storage emulator like Azurite, fake-gcs-server
+	EnvEmulatorEnabled = "EMULATOR_ENABLED"
 )
 
 type chunk struct {

--- a/pkg/snapstore/snapstore.go
+++ b/pkg/snapstore/snapstore.go
@@ -31,6 +31,9 @@ const (
 
 	backupVersionV1 = "v1"
 	backupVersionV2 = "v2"
+
+	// environment variable which indicates the usage of a storage emulator like Azurite, fake-gcs-server
+	envEmulatorEnabled = "EMULATOR_ENABLED"
 )
 
 type chunk struct {

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -469,22 +469,22 @@ var _ = Describe("Blob Service URL construction for Azure", func() {
 		credentials, err = azblob.NewSharedKeyCredential(storageAccount, storageKey)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
-	Context("when the environment variable \"EMULATOR_ENABLED\" is not set", func() {
+	Context(fmt.Sprintf("when the environment variable %q is not set", EnvEmulatorEnabled), func() {
 		It("should return the default blob service URL", func() {
 			blobServiceURL, err := ConstructBlobServiceURL(credentials)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(blobServiceURL.String()).Should(Equal(fmt.Sprintf("https://%s.%s", credentials.AccountName(), brtypes.AzureBlobStorageHostName)))
 		})
 	})
-	Context("when the environment variable \"EMULATOR_ENABLED\" is set", func() {
+	Context(fmt.Sprintf("when the environment variable %q is set", EnvEmulatorEnabled), func() {
 		Context("to values which are not \"true\"", func() {
 			It("should error when the environment variable is not \"true\" or \"false\"", func() {
-				GinkgoT().Setenv("EMULATOR_ENABLED", "")
+				GinkgoT().Setenv(EnvEmulatorEnabled, "")
 				_, err := ConstructBlobServiceURL(credentials)
 				Expect(err).Should(HaveOccurred())
 			})
 			It("should return the default blob service URL when the environment variable is set to \"false\"", func() {
-				GinkgoT().Setenv("EMULATOR_ENABLED", "false")
+				GinkgoT().Setenv(EnvEmulatorEnabled, "false")
 				blobServiceURL, err := ConstructBlobServiceURL(credentials)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(blobServiceURL.String()).Should(Equal(fmt.Sprintf("https://%s.%s", credentials.AccountName(), brtypes.AzureBlobStorageHostName)))
@@ -493,14 +493,14 @@ var _ = Describe("Blob Service URL construction for Azure", func() {
 		Context("to \"true\"", func() {
 			const endpoint string = "http://localhost:12345"
 			BeforeEach(func() {
-				GinkgoT().Setenv("EMULATOR_ENABLED", "true")
+				GinkgoT().Setenv(EnvEmulatorEnabled, "true")
 			})
-			It("should error when the \"AZURE_STORAGE_API_ENDPOINT\" environment variable is not set", func() {
+			It(fmt.Sprintf("should error when the %q environment variable is not set", AzuriteEndpoint), func() {
 				_, err := ConstructBlobServiceURL(credentials)
 				Expect(err).Should(HaveOccurred())
 			})
-			It(fmt.Sprintf("should return the Azurite blob service URL when the \"AZURE_STORAGE_API_ENDPOINT\" environment variable is set to \"%s\"", endpoint), func() {
-				GinkgoT().Setenv("AZURE_STORAGE_API_ENDPOINT", endpoint)
+			It(fmt.Sprintf("should return the Azurite blob service URL when the %q environment variable is set to %q", AzuriteEndpoint, endpoint), func() {
+				GinkgoT().Setenv(AzuriteEndpoint, endpoint)
 				blobServiceURL, err := ConstructBlobServiceURL(credentials)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(blobServiceURL.String()).Should(Equal(fmt.Sprintf("%s/%s", endpoint, credentials.AccountName())))

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-storage-blob-go/azblob"
 	. "github.com/gardener/etcd-backup-restore/pkg/snapstore"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 	fake "github.com/gophercloud/gophercloud/testhelper/client"
@@ -457,6 +458,55 @@ var _ = Describe("Dynamic access credential rotation test for each provider", fu
 			})
 		})
 	}
+})
+
+var _ = Describe("Blob Service URL construction for Azure", func() {
+	var credentials *azblob.SharedKeyCredential
+	BeforeEach(func() {
+		var err error
+		// test strings
+		storageAccount, storageKey := "testAccountName", "dGVzdEFjY291bnRLZXk="
+		credentials, err = azblob.NewSharedKeyCredential(storageAccount, storageKey)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+	Context("when the environment variable \"EMULATOR_ENABLED\" is not set", func() {
+		It("should return the default blob service URL", func() {
+			blobServiceURL, err := ConstructBlobServiceURL(credentials)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(blobServiceURL.String()).Should(Equal(fmt.Sprintf("https://%s.%s", credentials.AccountName(), brtypes.AzureBlobStorageHostName)))
+		})
+	})
+	Context("when the environment variable \"EMULATOR_ENABLED\" is set", func() {
+		Context("to values which are not \"true\"", func() {
+			It("should error when the environment variable is not \"true\" or \"false\"", func() {
+				GinkgoT().Setenv("EMULATOR_ENABLED", "")
+				_, err := ConstructBlobServiceURL(credentials)
+				Expect(err).Should(HaveOccurred())
+			})
+			It("should return the default blob service URL when the environment variable is set to \"false\"", func() {
+				GinkgoT().Setenv("EMULATOR_ENABLED", "false")
+				blobServiceURL, err := ConstructBlobServiceURL(credentials)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(blobServiceURL.String()).Should(Equal(fmt.Sprintf("https://%s.%s", credentials.AccountName(), brtypes.AzureBlobStorageHostName)))
+			})
+		})
+		Context("to \"true\"", func() {
+			const endpoint string = "http://localhost:12345"
+			BeforeEach(func() {
+				GinkgoT().Setenv("EMULATOR_ENABLED", "true")
+			})
+			It("should error when the \"AZURE_STORAGE_API_ENDPOINT\" environment variable is not set", func() {
+				_, err := ConstructBlobServiceURL(credentials)
+				Expect(err).Should(HaveOccurred())
+			})
+			It(fmt.Sprintf("should return the Azurite blob service URL when the \"AZURE_STORAGE_API_ENDPOINT\" environment variable is set to \"%s\"", endpoint), func() {
+				GinkgoT().Setenv("AZURE_STORAGE_API_ENDPOINT", endpoint)
+				blobServiceURL, err := ConstructBlobServiceURL(credentials)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(blobServiceURL.String()).Should(Equal(fmt.Sprintf("%s/%s", endpoint, credentials.AccountName())))
+			})
+		})
+	})
 })
 
 // createCredentialFilesInDirectory creates access credential files in the


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes to make `etcd-backup-restore` work with [`Azurite`](https://github.com/Azure/Azurite#introduction) - the Azure Blob Storage emulator to enable easier local development and testing.

Two new environment variables are introduced to make use of `Azurite` with `etcd-backup-restore`:
- `EMULATOR_ENABLED` - indicates whether `Azurite` is being used instead of ABS infrastructure. Takes boolean values, and hence can be set to `true` or `false`.
- `AZURE_STORAGE_API_ENDPOINT` - stores the endpoint at which `Azurite` is hosted. For example, if `Azurite` is hosted at `http://localhost:10000`, `AZURE_STORAGE_API_ENDPOINT` is set to this address. `etcd-backup-restore` reacts to the presence of this environment variable and sets the endpoint for `Azurite` accordingly if and only if the `EMULATOR_ENABLED` is set to `true`. This environment variable currently can not be used to set a custom endpoint for ABS, and can only be made use of to use `Azurite`.

**Which issue(s) this PR fixes**:
Fixes #698 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Added support to use Azurite, which emulates Azure Blob Storage for local development and testing - which can be enabled by setting the `EMULATOR_ENABLED` and  `AZURITE_STORAGE_API_ENDPOINT` environment variables.
```
