### PR TITLE
Fix regression in chunk deletion for openstack provider

### DIFF
--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 				prefix:           prefixV2,
 				multiPartUploads: map[string]*[][]byte{},
 			}),
-			"swift": NewSwiftSnapstoreFromClient(bucket, prefixV2, "/tmp", 5, brtypes.MinChunkSize, fake.ServiceClient()),
+			"swift": NewSwiftSnapstoreFromClient(bucket, prefixV2, "/tmp", 5, brtypes.MinChunkSize, fake.ServiceClient(), false),
 			"ABS":   newFakeABSSnapstore(),
 			"GCS": NewGCSSnapStoreFromClient(bucket, prefixV2, "/tmp", 5, brtypes.MinChunkSize, &mockGCSClient{
 				objects: objectMap,

--- a/pkg/snapstore/swift_snapstore.go
+++ b/pkg/snapstore/swift_snapstore.go
@@ -523,14 +523,13 @@ func (s *SwiftSnapStore) Delete(snap brtypes.Snapshot) error {
 			chunkObjectNames = append(chunkObjectNames, path.Join(chunk.Prefix, chunk.SnapDir, chunk.SnapName))
 		}
 
-		chunkObjectsDeleteResult := objects.BulkDelete(s.client, s.bucket, chunkObjectNames)
-		if chunkObjectsDeleteResult.Err != nil {
+		if chunkObjectsDeleteResult := objects.BulkDelete(s.client, s.bucket, chunkObjectNames); chunkObjectsDeleteResult.Err != nil {
 			return chunkObjectsDeleteResult.Err
 		}
 	}
 
-	manifestObjectDeleteResult := objects.Delete(s.client, s.bucket, path.Join(snap.Prefix, snap.SnapDir, snap.SnapName), nil)
-	return manifestObjectDeleteResult.Err
+	// delete manifest object
+	return objects.Delete(s.client, s.bucket, path.Join(snap.Prefix, snap.SnapDir, snap.SnapName), nil).Err
 }
 
 // GetSwiftCredentialsLastModifiedTime returns the latest modification timestamp of the Swift credential file(s)

--- a/pkg/snapstore/swift_snapstore.go
+++ b/pkg/snapstore/swift_snapstore.go
@@ -330,22 +330,23 @@ func (s *SwiftSnapStore) Fetch(snap brtypes.Snapshot) (io.ReadCloser, error) {
 	return resp.Body, resp.Err
 }
 
-// Save will write the snapshot to store
+// Save will write the snapshot to store, as a DLO (dynamic large object), as described
+// in https://docs.openstack.org/swift/latest/overview_large_objects.html
 func (s *SwiftSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
 	// Save it locally
-	tmpfile, err := os.CreateTemp(s.tempDir, tmpBackupFilePrefix)
+	tempFile, err := os.CreateTemp(s.tempDir, tmpBackupFilePrefix)
 	if err != nil {
 		rc.Close()
 		return fmt.Errorf("failed to create snapshot tempfile: %v", err)
 	}
 	defer func() {
-		tmpfile.Close()
-		os.Remove(tmpfile.Name())
+		tempFile.Close()
+		os.Remove(tempFile.Name())
 	}()
-	size, err := io.Copy(tmpfile, rc)
+	size, err := io.Copy(tempFile, rc)
 	rc.Close()
 	if err != nil {
-		return fmt.Errorf("failed to save snapshot to tmpfile: %v", err)
+		return fmt.Errorf("failed to save snapshot to tempFile: %v", err)
 	}
 
 	var (
@@ -365,7 +366,7 @@ func (s *SwiftSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
 
 	for i := uint(0); i < s.maxParallelChunkUploads; i++ {
 		wg.Add(1)
-		go s.chunkUploader(&wg, cancelCh, &snap, tmpfile, chunkUploadCh, resCh)
+		go s.chunkUploader(&wg, cancelCh, &snap, tempFile, chunkUploadCh, resCh)
 	}
 
 	logrus.Infof("Uploading snapshot of size: %d, chunkSize: %d, noOfChunks: %d", size, chunkSize, noOfChunks)
@@ -483,13 +484,47 @@ func (s *SwiftSnapStore) List() (brtypes.SnapList, error) {
 
 	sort.Sort(snapList)
 	return snapList, nil
-
 }
 
-// Delete should delete the snapshot file from store
+func (s *SwiftSnapStore) getSnapshotChunks(snapshot brtypes.Snapshot) (brtypes.SnapList, error) {
+	snaps, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var chunkList brtypes.SnapList
+	for _, snap := range snaps {
+		if snap.IsChunk {
+			chunkParentSnapPath, _ := path.Split(path.Join(snap.Prefix, snap.SnapDir, snap.SnapName))
+			if strings.TrimSuffix(chunkParentSnapPath, "/") == path.Join(snapshot.Prefix, snapshot.SnapDir, snapshot.SnapName) {
+				chunkList = append(chunkList, snap)
+			}
+		}
+	}
+	return chunkList, nil
+}
+
+// Delete deletes the objects related to the DLO (dynamic large object) from the store.
+// This includes the manifest object as well as the segment objects, as
+// described in https://docs.openstack.org/swift/latest/overview_large_objects.html
 func (s *SwiftSnapStore) Delete(snap brtypes.Snapshot) error {
-	result := objects.Delete(s.client, s.bucket, path.Join(snap.Prefix, snap.SnapDir, snap.SnapName), nil)
-	return result.Err
+	chunks, err := s.getSnapshotChunks(snap)
+	if err != nil {
+		return err
+	}
+
+	var chunkObjectNames []string
+	for _, chunk := range chunks {
+		chunkObjectNames = append(chunkObjectNames, path.Join(chunk.Prefix, chunk.SnapDir, chunk.SnapName))
+	}
+
+	manifestObjectDeleteResult := objects.Delete(s.client, s.bucket, path.Join(snap.Prefix, snap.SnapDir, snap.SnapName), nil)
+	if manifestObjectDeleteResult.Err != nil {
+		return manifestObjectDeleteResult.Err
+	}
+
+	chunkObjectsDeleteResult := objects.BulkDelete(s.client, s.bucket, chunkObjectNames)
+	return chunkObjectsDeleteResult.Err
 }
 
 // GetSwiftCredentialsLastModifiedTime returns the latest modification timestamp of the Swift credential file(s)

--- a/pkg/snapstore/swift_snapstore.go
+++ b/pkg/snapstore/swift_snapstore.go
@@ -518,14 +518,17 @@ func (s *SwiftSnapStore) Delete(snap brtypes.Snapshot) error {
 			return err
 		}
 
-		var chunkObjectNames []string
-		for _, chunk := range chunks {
-			chunkObjectNames = append(chunkObjectNames, path.Join(chunk.Prefix, chunk.SnapDir, chunk.SnapName))
+		if len(chunks) > 0 {
+			var chunkObjectNames []string
+			for _, chunk := range chunks {
+				chunkObjectNames = append(chunkObjectNames, path.Join(chunk.Prefix, chunk.SnapDir, chunk.SnapName))
+			}
+
+			if chunkObjectsDeleteResult := objects.BulkDelete(s.client, s.bucket, chunkObjectNames); chunkObjectsDeleteResult.Err != nil {
+				return chunkObjectsDeleteResult.Err
+			}
 		}
 
-		if chunkObjectsDeleteResult := objects.BulkDelete(s.client, s.bucket, chunkObjectNames); chunkObjectsDeleteResult.Err != nil {
-			return chunkObjectsDeleteResult.Err
-		}
 	}
 
 	// delete manifest object


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a recent regression in chunk deletion behavior for Openstack Swift snapshots. Additionally, remove backward compatibility tests between `v1` and `v2` for garbage collection, since `v1` is no longer supported. Support for `v1` backup directory structure in other parts of the code should be gradually removed as well, but not in this PR, to avoid scope spill.

**Which issue(s) this PR fixes**:
Fixes #702

**Special notes for your reviewer**:
/cc @plkokanov 
/invite @ishan16696 @anveshreddy18 @seshachalam-yv 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A regression in chunk deletion behavior for openstack provider has now been fixed.
```
