### PR TITLE
Add etcd team to component descriptor

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -4,9 +4,9 @@ etcd-backup-restore:
       trait_depends:
       - publish
       repos:
-        - name: 'landscape_repo'
-          path: 'kubernetes-dev/landscape-dev-garden'
-          branch: 'master'
+      - name: 'landscape_repo'
+        path: 'kubernetes-dev/landscape-dev-garden'
+        branch: 'master'
       image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/testmachinery-run:stable
       execute:
       - tm-tests-playground
@@ -20,8 +20,7 @@ etcd-backup-restore:
   base_definition:
     traits:
       version:
-        preprocess:
-          'inject-commit-hash'
+        preprocess: 'inject-commit-hash'
         inject_effective_version: true
       component_descriptor:
         ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
@@ -48,6 +47,10 @@ etcd-backup-restore:
                 confidentiality_requirement: 'high'
                 integrity_requirement: 'high'
                 availability_requirement: 'high'
+            - name: 'cloud.gardener.cnudie/responsibles'
+              value:
+              - type: 'githubTeam'
+                teamname: 'gardener/etcd-druid-maintainers'
     steps:
       check:
         image: 'golang:1.20.3'
@@ -65,7 +68,7 @@ etcd-backup-restore:
         draft_release: ~
         component_descriptor:
           ocm_repository_mappings:
-            - repository: europe-docker.pkg.dev/gardener-project/releases
+          - repository: europe-docker.pkg.dev/gardener-project/releases
     pull-request:
       traits:
         pull-request: ~


### PR DESCRIPTION
/area delivery
/kind enhancement

**What this PR does / why we need it**:
This PR adds the `gardener/etcd-druid-maintainers` team as responsibilities to the component descriptor, similar to https://github.com/gardener/etcd-druid/pull/758.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
