### PR TITLE
Modify URL parsing for `advertise-urls` used by `etcd` sidecar

### DIFF
--- a/pkg/member/member_control_test.go
+++ b/pkg/member/member_control_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Membercontrol", func() {
     quota-backend-bytes: 1073741824
     listen-client-urls: http://0.0.0.0:2379
     advertise-client-urls: http://0.0.0.0:2379
-    initial-advertise-peer-urls: http@etcd-main-peer@default@2380
+    initial-advertise-peer-urls: http://etcd-main-peer.default:2380
     initial-cluster: etcd1=http://0.0.0.0:2380
     initial-cluster-token: new
     initial-cluster-state: new

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -541,12 +541,23 @@ func ReadConfigFileAsMap(path string) (map[string]interface{}, error) {
 
 // ParsePeerURL forms a PeerURL, given podName by parsing the initial-advertise-peer-urls
 func ParsePeerURL(initialAdvertisePeerURLs, podName string) (string, error) {
-	tokens := strings.Split(initialAdvertisePeerURLs, "@")
-	if len(tokens) < 4 {
-		return "", fmt.Errorf("invalid peer URL : %s", initialAdvertisePeerURLs)
+	tokens := strings.Split(initialAdvertisePeerURLs, "://")
+	if len(tokens) < 2 {
+		return "", fmt.Errorf("invalid URL format : %s", initialAdvertisePeerURLs)
 	}
-	domaiName := fmt.Sprintf("%s.%s.%s", tokens[1], tokens[2], "svc")
-	return fmt.Sprintf("%s://%s.%s:%s", tokens[0], podName, domaiName, tokens[3]), nil
+	protocol := tokens[0]
+	tokens = strings.Split(tokens[1], ".")
+	if len(tokens) < 2 {
+		return "", fmt.Errorf("invalid URL format : %s", initialAdvertisePeerURLs)
+	}
+	svcName := tokens[0]
+	tokens = strings.Split(tokens[1], ":")
+	if len(tokens) < 2 {
+		return "", fmt.Errorf("invalid URL format : %s", initialAdvertisePeerURLs)
+	}
+	namespace, peerPort := tokens[0], tokens[1]
+	domaiName := fmt.Sprintf("%s.%s.%s", svcName, namespace, "svc")
+	return fmt.Sprintf("%s://%s.%s:%s", protocol, podName, domaiName, peerPort), nil
 }
 
 // IsPeerURLTLSEnabled checks whether the peer address is TLS enabled or not.

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -608,14 +608,14 @@ var _ = Describe("Miscellaneous Tests", func() {
 
 		Context("parse peer url", func() {
 			It("parsing well-defined initial-advertise-peer-urls", func() {
-				initialAdPeerURL = "https@etcd-events-peer@shoot--dev--test@2380"
+				initialAdPeerURL = "https://etcd-events-peer.shoot--dev--test:2380"
 				peerURL, err := ParsePeerURL(initialAdPeerURL, podName)
 				Expect(err).To(BeNil())
 				Expect(peerURL).To(Equal("https://etcd-test-pod-0.etcd-events-peer.shoot--dev--test.svc:2380"))
 			})
 
 			It("parsing malformed initial-advertise-peer-urls", func() {
-				initialAdPeerURL = "https@etcd-events-peer@shoot--dev--test"
+				initialAdPeerURL = "https://etcd-events-peer.shoot--dev--test"
 				_, err := ParsePeerURL(initialAdPeerURL, podName)
 				Expect(err).ToNot(BeNil())
 			})
@@ -724,7 +724,7 @@ var _ = Describe("Miscellaneous Tests", func() {
 		Context("with non-TLS enabled peer url", func() {
 			BeforeEach(func() {
 				etcdConfigYaml := `name: etcd1
-initial-advertise-peer-urls: http@etcd-main-peer@default@2380
+initial-advertise-peer-urls: http://etcd-main-peer.default:2380
 initial-cluster: etcd1=http://0.0.0.0:2380`
 				err := os.WriteFile(outfile, []byte(etcdConfigYaml), 0755)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -740,7 +740,7 @@ initial-cluster: etcd1=http://0.0.0.0:2380`
 		Context("with TLS enabled peer url", func() {
 			BeforeEach(func() {
 				etcdConfigYaml := `name: etcd1
-initial-advertise-peer-urls: https@etcd-main-peer@default@2380
+initial-advertise-peer-urls: https://etcd-main-peer.default:2380
 initial-cluster: etcd1=https://0.0.0.0:2380`
 				err := os.WriteFile(outfile, []byte(etcdConfigYaml), 0755)
 				Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/server/httpAPI.go
+++ b/pkg/server/httpAPI.go
@@ -439,7 +439,7 @@ func (h *HTTPHandler) serveConfig(rw http.ResponseWriter, req *http.Request) {
 	config["name"] = podName
 
 	initAdPeerURL := config["initial-advertise-peer-urls"]
-	protocol, svcName, namespace, peerPort, err := parsePeerURL(fmt.Sprint(initAdPeerURL))
+	protocol, svcName, namespace, peerPort, err := ParseAdvertiseURL(fmt.Sprint(initAdPeerURL))
 	if err != nil {
 		h.Logger.Warnf("Unable to determine service name, namespace, peer port from advertise peer urls : %v", err)
 		rw.WriteHeader(http.StatusInternalServerError)
@@ -449,7 +449,7 @@ func (h *HTTPHandler) serveConfig(rw http.ResponseWriter, req *http.Request) {
 	config["initial-advertise-peer-urls"] = fmt.Sprintf("%s://%s.%s:%s", protocol, podName, domaiName, peerPort)
 
 	advClientURL := config["advertise-client-urls"]
-	protocol, svcName, namespace, clientPort, err := parseAdvClientURL(fmt.Sprint(advClientURL))
+	protocol, svcName, namespace, clientPort, err := ParseAdvertiseURL(fmt.Sprint(advClientURL))
 	if err != nil {
 		h.Logger.Warnf("Unable to determine service name, namespace, peer port from advertise client url : %v", err)
 		rw.WriteHeader(http.StatusInternalServerError)
@@ -578,20 +578,24 @@ func getInitialCluster(ctx context.Context, initialCluster string, etcdConn brty
 	return initialCluster
 }
 
-func parsePeerURL(peerURL string) (string, string, string, string, error) {
-	tokens := strings.Split(peerURL, "@")
-	if len(tokens) < 4 {
-		return "", "", "", "", fmt.Errorf("total length of tokens is less than four")
+// ParseAdvertiseURL parses the advertise URL and returns the protocol, service name, namespace and port.
+func ParseAdvertiseURL(url string) (string, string, string, string, error) {
+	tokens := strings.Split(url, "://")
+	if len(tokens) < 2 {
+		return "", "", "", "", fmt.Errorf("invalid URL format : %s", url)
 	}
-	return tokens[0], tokens[1], tokens[2], tokens[3], nil
-}
-
-func parseAdvClientURL(advClientURL string) (string, string, string, string, error) {
-	tokens := strings.Split(advClientURL, "@")
-	if len(tokens) < 4 {
-		return "", "", "", "", fmt.Errorf("total length of tokens is less than four")
+	protocol := tokens[0]
+	tokens = strings.Split(tokens[1], ".")
+	if len(tokens) < 2 {
+		return "", "", "", "", fmt.Errorf("invalid URL format : %s", url)
 	}
-	return tokens[0], tokens[1], tokens[2], tokens[3], nil
+	svcName := tokens[0]
+	tokens = strings.Split(tokens[1], ":")
+	if len(tokens) < 2 {
+		return "", "", "", "", fmt.Errorf("invalid URL format : %s", url)
+	}
+	namespace, port := tokens[0], tokens[1]
+	return protocol, svcName, namespace, port, nil
 }
 
 // delegateReqToLeader forwards the incoming http/https request to BackupLeader.

--- a/test/e2e/integration/cloud_backup_test.go
+++ b/test/e2e/integration/cloud_backup_test.go
@@ -139,7 +139,7 @@ enable-v2: false
 quota-backend-bytes: 1073741824
 listen-client-urls: http://0.0.0.0:2379
 advertise-client-urls: http://0.0.0.0:2379
-initial-advertise-peer-urls: http@etcd-main-peer@default@2380
+initial-advertise-peer-urls: http://etcd-main-peer.default:2380
 initial-cluster: etcd1=http://0.0.0.0:2380
 initial-cluster-token: new
 initial-cluster-state: new


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR modifies the parsing logic for the `etcd configmap` parameters `initial-advertise-peer-urls` and `advertise-client-urls` as the druid PR [#771](https://github.com/gardener/etcd-druid/pull/771) now uses proper URLs for these flags instead of `@` as separator currently being used. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Enhances parsing logic for Etcd ConfigMap parameters `initial-advertise-peer-urls` and `advertise-client-urls` to support proper URL formatting
```
