### PR TITLE
Updated the .reuse/dep5 file.

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -29,6 +29,10 @@ Files: pkg/snapstore/gcs/adapters.go
 Copyright: 2018 Google LLC
 License: Apache-2.0
 
+Files: pkg/snapshot/restorer/restorer.go
+Copyright: 2018 The etcd Authors
+License: Apache-2.0
+
 # --- vendor folder dependencies ---
 Files: vendor/github.com/google/gnostic/*
 Copyright: 2024 github.com/google/gnostic contributors.


### PR DESCRIPTION
**What this PR does / why we need it**:
AFAIR, some part of code in restorer file was copied from upstream etcd. Hence updating the `.reuse/dep5` file


**Which issue(s) this PR fixes**:
Addressing this comment:  https://github.com/gardener/etcd-backup-restore/pull/714#issuecomment-1963340490

**Special notes for your reviewer**:
@shreyas-s-rao 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
None
```
