### PR TITLE
Fix a full snapshot lease renewal decision

### DIFF
--- a/pkg/health/heartbeat/heartbeat.go
+++ b/pkg/health/heartbeat/heartbeat.go
@@ -185,7 +185,7 @@ func UpdateFullSnapshotLease(ctx context.Context, logger *logrus.Entry, fullSnap
 			if err != nil {
 				return err
 			}
-			if rev >= fullSnapshot.LastRevision {
+			if rev > fullSnapshot.LastRevision {
 				return nil
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

The recently merged PR #711 had introduced a small change in wrongly deciding that If there's no revision change for full snapshot lease, then don't renew it. But the opposite was originally introduced in PR #410 as a deliberate change so that even if there are no events in the last 24h ( which leads to the current full snapshot having the same revision as previous ) we still want to renew the full snapshot lease because it helps in not marking the full snapshot health check as failed although it was not actually a failure but a case of `skipping the full snapshot` ( May happen in idle dev shoot clusters in landscapes )

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
