### PR TITLE
Fix statefulset to treat provider config env vars as optional

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -197,6 +197,7 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-etcd-backup
               key: "emulatorEnabled"
+              optional: true
   {{- end }}
   {{- if .Values.backup.abs.storageAPIEndpoint }}
         - name: "AZURE_STORAGE_API_ENDPOINT"
@@ -204,6 +205,7 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-etcd-backup
               key: "storageAPIEndpoint"
+              optional: true
   {{- end }}
 {{- else if eq .Values.backup.storageProvider "GCS" }}
         - name: "GOOGLE_APPLICATION_CREDENTIALS"
@@ -214,6 +216,7 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-etcd-backup
               key: "storageAPIEndpoint"
+              optional: true
   {{- end }}
 {{- else if eq .Values.backup.storageProvider "Swift" }}
         - name: "OS_AUTH_URL"
@@ -284,6 +287,7 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-etcd-backup
               key: "disableSsl"
+              optional: true
   {{- end }}
   {{- if .Values.backup.ecs.insecureSkipVerify }}
         - name: "ECS_INSECURE_SKIP_VERIFY"
@@ -291,6 +295,7 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-etcd-backup
               key: "insecureSkipVerify"
+              optional: true
   {{- end }}
 {{- end }}
         volumeMounts:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix statefulset to treat provider config env vars as optional. This allows users to not define certain non-mandatory fields in the provider secrets, which the statefulset can then ignore, instead of forcing the fields to be present in the provider secrets. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @renormalize @anveshreddy18 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
