### PR TITLE
Set appropriate SSE Customer Key and MD5 in `S3SnapStore.uploadPart()` for SSE-C

### DIFF
--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -459,8 +459,8 @@ func (s *S3SnapStore) uploadPart(snap *brtypes.Snapshot, file *os.File, uploadID
 	if s.sseCustomerKey != "" {
 		// Customer managed Server Side Encryption
 		uploadPartInput.SSECustomerAlgorithm = aws.String(s.sseCustomerAlgorithm)
-		uploadPartInput.SSECustomerKey = aws.String(s.sseCustomerAlgorithm)
-		uploadPartInput.SSECustomerKeyMD5 = aws.String(s.sseCustomerAlgorithm)
+		uploadPartInput.SSECustomerKey = aws.String(s.sseCustomerKey)
+		uploadPartInput.SSECustomerKeyMD5 = aws.String(s.sseCustomerKeyMD5)
 	}
 
 	uploadPartOutput, err := s.client.UploadPartWithContext(ctx, uploadPartInput)


### PR DESCRIPTION
**What this PR does / why we need it**:
This is mostly a typo bug from the previous sse [PR](https://github.com/gardener/etcd-backup-restore/pull/719)