### PR TITLE
Add support to read JSON credential files present in a directory passed through the `<PROVIDER>_APPLICATION_CREDENTIALS` environment variable

### DIFF
--- a/docs/deployment/getting_started.md
+++ b/docs/deployment/getting_started.md
@@ -1,24 +1,26 @@
 # Getting started
 
-Currently we don't publish the binary build with the release, but it is pretty straight forward to build it by following the steps mentioned [here](../development/local_setup.md#build). But we do publish the docker image with each release, please check the [release page](https://github.com/gardener/etcd-backup-restore/releases) for the same. Currently, release docker images are pushed to `europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl` to container registry.
+The binary builds are not published with each release, but it is pretty straight forward to build it by following the steps mentioned [here](../development/local_setup.md#build). But we do publish the docker image with each release, please check the [release page](https://github.com/gardener/etcd-backup-restore/releases) for the same. Currently, release docker images are pushed to `europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl` to container registry.
 
 ## Usage
 
-You can follow the `help` flag on `etcdbrctl` command and its sub-commands to know the usage details. Some of the common use cases are mentioned below. Although examples below use `AWS S3` as storage provider, etcd-backup-restore supports AWS, GCS, Azure, Openstack swift and Alicloud OSS object store. It also supports local disk as storage provider for development purposes, but it is not recommended to use this in a production environment.
+You can follow the `help` flag on `etcdbrctl` command and its sub-commands to know the usage details. Some common use cases are mentioned below. Although examples below use `AWS S3` as storage provider, etcd-backup-restore supports AWS, GCS, Azure, OpenStack Swift, and AliCloud OSS object store. It also supports local disk as storage provider for development purposes, but it is not recommended to use this in a production environment.
 
 ### Cloud Provider Credentials
 
-The procedure to provide credentials to access the cloud provider object store varies for different providers, there are various ways to pass credentials([described below](#various-ways-to-pass-credentials)), you can choose either ways but we recommend you to pass credentials through a file.
+The procedure to provide credentials to access the cloud provider object store varies for different providers, there are various ways to pass credentials([described below](#various-ways-to-pass-credentials)), however, it is *highly* recommended passing each credential as an individual file in a directory.
 
+### Various ways to pass Credentials
 
-### Various ways to pass Credentials:
+> [!WARNING]
+> It is recommended to pass credentials as files in a directory. Please avoid passing credentials as a JSON file, since this feature is planned to be deprecated soon (in *v0.31.0*).
 
-* For `AWS S3`: 
+* For `AWS S3`:
    1. The secret file should be provided, and the file path should be made available as environment variables: `AWS_APPLICATION_CREDENTIALS` or `AWS_APPLICATION_CREDENTIALS_JSON`.
    2. For `S3-compatible providers` such as MinIO, `endpoint`, `s3ForcePathStyle`, `insecureSkipVerify` and `trustedCaCert`, can also be made available in a above file to configure the S3 client to communicate to a non-AWS provider.
    3. To enable Server-Side Encryption using Customer Managed Keys for `S3-compatible providers`, use `sseCustomerKey` and `sseCustomerAlgorithm` in the credentials file above. For example, `sseCustomerAlgorithm` could be set to `AES256`, and correspondingly the `sseCustomerKey` is set to a valid AES-256 key.
 
-* For  `Google Cloud Storage`: 
+* For `Google Cloud Storage`:
    1. The service account json file should be provided in the `~/.gcp` as a `service-account-file.json` file.
    2. The service account json file should be provided, and the file path should be made available as environment variable `GOOGLE_APPLICATION_CREDENTIALS`.
    3. If using a storage API [endpoint override](https://pkg.go.dev/cloud.google.com/go#hdr-Endpoint_Override), such as a [regional endpoint](https://cloud.google.com/storage/docs/regional-endpoints) or a local GCS emulator endpoint, then the endpoint must be made available via environment variable `GOOGLE_STORAGE_API_ENDPOINT`, in the format `http[s]://host[:port]/storage/v1/`.
@@ -39,12 +41,11 @@ The procedure to provide credentials to access the cloud provider object store v
   1. The secret file should be provided, and the file path should be made available as environment variables: `OPENSHIFT_APPLICATION_CREDENTIALS` or `OPENSHIFT_APPLICATION_CREDENTIALS_JSON`.
   For development purposes, the environment variables `OCS_DISABLE_SSL` and `OCS_INSECURE_SKIP_VERIFY` can also be set to "true" or "false".
 
-
 Check the [example of storage provider secrets](https://github.com/gardener/etcd-backup-restore/tree/master/example/storage-provider-secrets)
 
 ### Taking scheduled snapshot
 
-Sub-command `snapshot` takes scheduled backups, or `snapshots` of a running `etcd` cluster, which are pushed to one of the storage providers specified above (please note that `etcd` should already be running). One can apply standard cron format scheduling for regular backup of etcd. The cron schedule is used to take full backups. The delta snapshots are taken at regular intervals in the period in between full snapshots as indicated by the `delta-snapshot-period` flag. The default for the same is 20 seconds.
+Sub-command `snapshot` takes scheduled backups, or `snapshots` of a running `etcd` cluster, which are pushed to one of the storage providers specified above (please note that `etcd` should already be running). One can apply standard Cron format scheduling for regular backup of etcd. The Cron schedule is used to take full backups. The delta snapshots are taken at regular intervals in the period in between full snapshots as indicated by the `delta-snapshot-period` flag. The default for the same is 20 seconds.
 
 etcd-backup-restore has two garbage collection policies to clean up existing backups from the cloud bucket. The flag `garbage-collection-policy` is used to indicate the desired garbage collection policy.
 

--- a/docs/deployment/getting_started.md
+++ b/docs/deployment/getting_started.md
@@ -8,16 +8,13 @@ You can follow the `help` flag on `etcdbrctl` command and its sub-commands to kn
 
 ### Cloud Provider Credentials
 
-The procedure to provide credentials to access the cloud provider object store varies for different providers, there are various ways to pass credentials([described below](#various-ways-to-pass-credentials)), however, it is *highly* recommended passing each credential as an individual file in a directory.
+The procedure to provide credentials to access the cloud provider object store varies for different providers, the method to pass credentials for each provider is [described below](#passing-credentials).
 
-### Various ways to pass Credentials
-
-> [!WARNING]
-> It is recommended to pass credentials as files in a directory. Please avoid passing credentials as a JSON file, since this feature is planned to be deprecated soon (in *v0.31.0*).
+### Passing Credentials
 
 * For `AWS S3`:
-   1. The secret file should be provided, and the file path should be made available as environment variables: `AWS_APPLICATION_CREDENTIALS` or `AWS_APPLICATION_CREDENTIALS_JSON`.
-   2. For `S3-compatible providers` such as MinIO, `endpoint`, `s3ForcePathStyle`, `insecureSkipVerify` and `trustedCaCert`, can also be made available in a above file to configure the S3 client to communicate to a non-AWS provider.
+   1. The secret file should be provided, and the file path should be made available as an environment variable: `AWS_APPLICATION_CREDENTIALS`.
+   2. For `S3-compatible providers` such as MinIO, `endpoint`, `s3ForcePathStyle`, `insecureSkipVerify` and `trustedCaCert`, can also be made available in an above file to configure the S3 client to communicate to a non-AWS provider.
    3. To enable Server-Side Encryption using Customer Managed Keys for `S3-compatible providers`, use `sseCustomerKey` and `sseCustomerAlgorithm` in the credentials file above. For example, `sseCustomerAlgorithm` could be set to `AES256`, and correspondingly the `sseCustomerKey` is set to a valid AES-256 key.
 
 * For `Google Cloud Storage`:
@@ -26,19 +23,19 @@ The procedure to provide credentials to access the cloud provider object store v
    3. If using a storage API [endpoint override](https://pkg.go.dev/cloud.google.com/go#hdr-Endpoint_Override), such as a [regional endpoint](https://cloud.google.com/storage/docs/regional-endpoints) or a local GCS emulator endpoint, then the endpoint must be made available via environment variable `GOOGLE_STORAGE_API_ENDPOINT`, in the format `http[s]://host[:port]/storage/v1/`.
 
 * For `Azure Blob storage`:
-   1. The secret file should be provided, and the file path should be made available as environment variables: `AZURE_APPLICATION_CREDENTIALS` or `AZURE_APPLICATION_CREDENTIALS_JSON`.
+   1. The secret file should be provided, and the file path should be made available as an environment variable: `AZURE_APPLICATION_CREDENTIALS`.
 
 * For `Openstack Swift`:
-  1. The secret file should be provided, and the file path should be made available as environment variables: `OPENSTACK_APPLICATION_CREDENTIALS` or `OPENSTACK_APPLICATION_CREDENTIALS_JSON`.
+  1. The secret file should be provided, and the file path should be made available as an environment variable: `OPENSTACK_APPLICATION_CREDENTIALS`.
 
 * For `Alicloud OSS`:
-  1. The secret file should be provided, and the file path should be made available as environment variables: `ALICLOUD_APPLICATION_CREDENTIALS` or `ALICLOUD_APPLICATION_CREDENTIALS_JSON`.
+  1. The secret file should be provided, and the file path should be made available as an environment variable: `ALICLOUD_APPLICATION_CREDENTIALS`.
 
 * For `Dell EMC ECS`:
   1. `ECS_ENDPOINT`, `ECS_ACCESS_KEY_ID`, `ECS_SECRET_ACCESS_KEY` should be made available as environment variables. For development purposes, the environment variables `ECS_DISABLE_SSL` and `ECS_INSECURE_SKIP_VERIFY` can also be set to "true" or "false".
 
 * For `Openshift Container Storage (OCS)`:
-  1. The secret file should be provided, and the file path should be made available as environment variables: `OPENSHIFT_APPLICATION_CREDENTIALS` or `OPENSHIFT_APPLICATION_CREDENTIALS_JSON`.
+  1. The secret file should be provided, and the file path should be made available as an environment variable: `OPENSHIFT_APPLICATION_CREDENTIALS`.
   For development purposes, the environment variables `OCS_DISABLE_SSL` and `OCS_INSECURE_SKIP_VERIFY` can also be set to "true" or "false".
 
 Check the [example of storage provider secrets](https://github.com/gardener/etcd-backup-restore/tree/master/example/storage-provider-secrets)

--- a/docs/deployment/getting_started.md
+++ b/docs/deployment/getting_started.md
@@ -4,7 +4,7 @@ The binary builds are not published with each release, but it is pretty straight
 
 ## Usage
 
-You can follow the `help` flag on `etcdbrctl` command and its sub-commands to know the usage details. Some common use cases are mentioned below. Although examples below use `AWS S3` as storage provider, etcd-backup-restore supports AWS, GCS, Azure, OpenStack Swift, and AliCloud OSS object store. It also supports local disk as storage provider for development purposes, but it is not recommended to use this in a production environment.
+You can follow the `help` flag on `etcdbrctl` command and its sub-commands to know the usage details. Some common use cases are mentioned below. Although examples below use `AWS S3` as storage provider, etcd-backup-restore supports AWS S3, GCS, Azure Blob Storage, OpenStack Swift, and AliCloud OSS object store. It also supports local disk as storage provider for development purposes, but it is not recommended to use this in a production environment.
 
 ### Cloud Provider Credentials
 

--- a/example/storage-provider-secrets/00-azure-blob-storage-secret.yaml
+++ b/example/storage-provider-secrets/00-azure-blob-storage-secret.yaml
@@ -9,22 +9,3 @@ data:
   storageKey: YWRtaW4= # admin
   # emulatorEnabled: dHJ1ZQ== # true (optional)
   # storageAPIEndpoint: aHR0cDovL2F6dXJpdGUtc2VydmljZToxMDAwMA== # http://azurite-service:10000 (optional)
-
-#### OR ####
-
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: etcd-backup
-  namespace: example-json-azure
-type: Opaque
-stringData:
-  secret.json: |-
-    {
-    "storageAccount": "admin",
-    "storageKey": "admin"
-    } 
-
-
-

--- a/example/storage-provider-secrets/01-aws-s3-storage-secret.yaml
+++ b/example/storage-provider-secrets/01-aws-s3-storage-secret.yaml
@@ -12,30 +12,3 @@ data:
 # s3ForcePathStyle: # set to `true` for S3 compliant providers
 # insecureSkipVerify: # set to `true` for S3 private deployments to skip certificate check
 # trustedCaCert: # set a trusted Certificate authority for private deployments like minio
-
-#### OR ####
-
---- 
-apiVersion: v1
-kind: Secret
-metadata:
-  name: etcd-backup
-  namespace: example-json-aws
-type: Opaque
-stringData:
-  secret.json: |-
-    {
-    "accessKeyID": "eu-west-1",
-    "region": "admin",
-    "secretAccessKey": "admin"
-    } 
-# secret.json: |-
-#  {
-#  "accessKeyID": "eu-west-1",
-#  "region": "admin",
-#  "secretAccessKey": "admin",
-#  "endpoint": "https://example.com:9000",
-#  "s3ForcePathStyle": true,
-#  "insecureSkipVerify": true,
-#  "trustedCaCert": "-----BEGIN CERTIFICATE----\nMIIDAzCCAeugAwIBAgIBADANBgkqhkiG9w0BAQsFADAjMSEwHwYDVQQDDBhrM3Mt\nc2VydmVyLWNhQDE2NTc2MzQ0MDQwHhcNMjIwNzEyMTQwMDA0WhcNMzIwNzA5MTQw\n...\n-----END CERTIFICATE-----"
-#  }

--- a/example/storage-provider-secrets/02-openstack-swift-storage-secret.yaml
+++ b/example/storage-provider-secrets/02-openstack-swift-storage-secret.yaml
@@ -15,26 +15,6 @@ data:
 #### OR ####
 
 --- 
-apiVersion: v1
-kind: Secret
-metadata:
-  name: etcd-backup
-  namespace: example-json-swift
-type: Opaque
-stringData:
-  secret.json: |-
-    {
-    "authURL": "http://example.com/v3",
-    "domainName": "example.com",
-    "password": "password",
-    "region": "eu-nl-007",
-    "tenantName": "admin",
-    "username": "admin"
-    } 
-
-#### OR ####
-
---- 
 
 apiVersion: v1
 kind: Secret
@@ -50,26 +30,3 @@ data:
   applicationCredentialID:  YWRtaW4= # admin
   applicationCredentialName:  YWRtaW4= # admin
   applicationCredentialSecret:  c2VjcmV0 # secret
-
-
-#### OR ####
-
---- 
-
-apiVersion: v1
-kind: Secret
-metadata:
-  name: etcd-backup
-  namespace: example-json-swift
-type: Opaque
-stringData:
-  secret.json: |-
-    {
-    "authURL": "http://example.com/v3",
-    "domainName": "example.com",
-    "applicationCredentialID": "admin",
-    "applicationCredentialName": "admin",
-    "applicationCredentialSecret": "secret",
-    "region": "eu-nl-007",
-    "tenantName": "admin"
-    } 

--- a/example/storage-provider-secrets/03-ali-cloud-object-storage-secret.yaml
+++ b/example/storage-provider-secrets/03-ali-cloud-object-storage-secret.yaml
@@ -8,21 +8,3 @@ data:
   accessKeyID: YWRtaW4= # admin
   accessKeySecret: YWRtaW4= # admin
   storageEndpoint: aHR0cHM6Ly9vc3MtcmVnaW9uLmV4YW1wbGUuY29t # https://oss-region.example.com
-  
-### OR ###
-
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: etcd-backup
-  namespace: example-json-aliCloud
-type: Opaque
-stringData:
-  secret.json: |-
-    {
-      "accessKeyID": "admin",
-      "accessKeySecret": "admin",
-      "storageEndpoint": "https://oss-region.example.com"
-    } 
-

--- a/example/storage-provider-secrets/05-openshift-container-storage-secret.yaml
+++ b/example/storage-provider-secrets/05-openshift-container-storage-secret.yaml
@@ -9,22 +9,3 @@ data:
   secretAccessKey: YWRtaW4= # admin
   endpoint: aHR0cHM6Ly9vY3Mub3BlbnNoaWZ0Lm9yZw== # https://ocs.openshift.org
   region: cmVnaW9uMQ== #region1
-
-### OR ###
-
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: etcd-backup
-  namespace: example-json-ocs
-type: Opaque
-stringData:
-  secret.json: |-
-    {
-      "accessKeyID": "admin",
-      "secretAccessKey": "admin",
-      "endpoint": "https://ocs.openshift.org",
-      "region": "region1"
-    }
-

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -298,7 +298,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 				m := member.NewMemberControl(b.config.EtcdConnectionConfig)
 				if err := m.PromoteMember(ctx); err == nil {
 					logger.Info("Successfully promoted the learner to a voting member...")
-				} else if err != nil {
+				} else {
 					logger.Errorf("unable to promote the learner to a voting member: %v", err)
 				}
 			}
@@ -513,7 +513,7 @@ func handleAckState(handler *HTTPHandler, ackCh chan struct{}) {
 }
 
 // handleSsrStopRequest responds to handlers request and stop interrupt.
-func handleSsrStopRequest(ctx context.Context, handler *HTTPHandler, ssr *snapshotter.Snapshotter, ackCh chan<- struct{}, ssrStopCh chan<- struct{}, logger *logrus.Entry) {
+func handleSsrStopRequest(ctx context.Context, handler *HTTPHandler, _ *snapshotter.Snapshotter, ackCh chan<- struct{}, ssrStopCh chan<- struct{}, logger *logrus.Entry) {
 	logger.Info("Starting the handleSsrStopRequest handler...")
 	for {
 		var ok bool

--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -394,9 +394,9 @@ func GetABSCredentialsLastModifiedTime() (time.Time, error) {
 	// TODO: @renormalize Remove this extra handling in v0.31.0
 	// Check if a JSON file is present in the directory, if it is present -> the JSON file must be used for credentials.
 	if dir, isSet := os.LookupEnv(absCredentialDirectory); isSet {
-		modificationTimeStamp, err := getJSONCredentialModifiedTime(dir, "ABS")
+		modificationTimeStamp, err := getJSONCredentialModifiedTime(dir)
 		if err != nil {
-			return time.Time{}, err
+			return time.Time{}, fmt.Errorf("failed to fetch credential modification time for ABS with error: %w", err)
 		}
 		if !modificationTimeStamp.IsZero() {
 			return modificationTimeStamp, nil

--- a/pkg/snapstore/ocs_s3_snapstore.go
+++ b/pkg/snapstore/ocs_s3_snapstore.go
@@ -43,15 +43,32 @@ func getOCSAuthOptions(prefix string) (*ocsAuthOptions, error) {
 	if filename, isSet := os.LookupEnv(prefix + ocsCredentialJSONFile); isSet {
 		ao, err := readOCSCredentialsJSON(filename)
 		if err != nil {
-			return nil, fmt.Errorf("error getting credentials using %v file", filename)
+			return nil, fmt.Errorf("error getting credentials using %v file with error: %w", filename, err)
 		}
 		return ao, nil
+	}
+
+	// TODO: @renormalize Remove this extra handling in v0.31.0
+	// Check if a JSON file is present in the directory, if it is present -> the JSON file must be used for credentials.
+	if dir, isSet := os.LookupEnv(prefix + ocsCredentialDirectory); isSet {
+		jsonCredentialFile, err := findFileWithExtensionInDir(dir, ".json")
+		if err != nil {
+			return nil, fmt.Errorf("error while finding a JSON credential file in %v directory with error: %w", dir, err)
+		}
+		if jsonCredentialFile != "" {
+			ao, err := readOCSCredentialsJSON(jsonCredentialFile)
+			if err != nil {
+				return nil, fmt.Errorf("error getting credentials using %v JSON file in a directory with error: %w", jsonCredentialFile, err)
+			}
+			return ao, nil
+		}
+		// Non JSON credential files might exist in the credential directory, do not return
 	}
 
 	if dir, isSet := os.LookupEnv(prefix + ocsCredentialDirectory); isSet {
 		ao, err := readOCSCredentialFromDir(dir)
 		if err != nil {
-			return nil, fmt.Errorf("error getting credentials from %v directory", dir)
+			return nil, fmt.Errorf("error getting credentials from %v directory with error: %w", dir, err)
 		}
 		return ao, nil
 	}
@@ -171,6 +188,19 @@ func isOCSConfigEmpty(config ocsAuthOptions) error {
 
 // GetOCSCredentialsLastModifiedTime returns the latest modification timestamp of the OCS credential file(s)
 func GetOCSCredentialsLastModifiedTime() (time.Time, error) {
+	// TODO: @renormalize Remove this extra handling in v0.31.0
+	// Check if a JSON file is present in the directory, if it is present -> the JSON file must be used for credentials.
+	if dir, isSet := os.LookupEnv(ocsCredentialDirectory); isSet {
+		modificationTimeStamp, err := getJSONCredentialModifiedTime(dir, "OCS")
+		if err != nil {
+			return time.Time{}, err
+		}
+		if !modificationTimeStamp.IsZero() {
+			return modificationTimeStamp, nil
+		}
+		// Non JSON credential files might exist in the credential directory, do not return
+	}
+
 	if dir, isSet := os.LookupEnv(ocsCredentialDirectory); isSet {
 		// credential files which are essential for creating the snapstore
 		credentialFiles := []string{"accessKeyID", "region", "endpoint", "secretAccessKey"}
@@ -179,7 +209,7 @@ func GetOCSCredentialsLastModifiedTime() (time.Time, error) {
 		}
 		ocsTimeStamp, err := getLatestCredentialsModifiedTime(credentialFiles)
 		if err != nil {
-			return time.Time{}, fmt.Errorf("failed to get OCS credential timestamp from the directory %v with error: %v", dir, err)
+			return time.Time{}, fmt.Errorf("failed to get OCS credential timestamp from the directory %v with error: %w", dir, err)
 		}
 		return ocsTimeStamp, nil
 	}
@@ -188,7 +218,7 @@ func GetOCSCredentialsLastModifiedTime() (time.Time, error) {
 		credentialFiles := []string{filename}
 		ocsTimeStamp, err := getLatestCredentialsModifiedTime(credentialFiles)
 		if err != nil {
-			return time.Time{}, fmt.Errorf("failed to fetch file information of the OCS JSON credential file %v with error: %v", filename, err)
+			return time.Time{}, fmt.Errorf("failed to fetch file information of the OCS JSON credential file %v with error: %w", filename, err)
 		}
 		return ocsTimeStamp, nil
 	}

--- a/pkg/snapstore/ocs_s3_snapstore.go
+++ b/pkg/snapstore/ocs_s3_snapstore.go
@@ -191,9 +191,9 @@ func GetOCSCredentialsLastModifiedTime() (time.Time, error) {
 	// TODO: @renormalize Remove this extra handling in v0.31.0
 	// Check if a JSON file is present in the directory, if it is present -> the JSON file must be used for credentials.
 	if dir, isSet := os.LookupEnv(ocsCredentialDirectory); isSet {
-		modificationTimeStamp, err := getJSONCredentialModifiedTime(dir, "OCS")
+		modificationTimeStamp, err := getJSONCredentialModifiedTime(dir)
 		if err != nil {
-			return time.Time{}, err
+			return time.Time{}, fmt.Errorf("failed to fetch credential modification time for OCS with error: %w", err)
 		}
 		if !modificationTimeStamp.IsZero() {
 			return modificationTimeStamp, nil

--- a/pkg/snapstore/oss_snapstore.go
+++ b/pkg/snapstore/oss_snapstore.go
@@ -354,9 +354,9 @@ func GetOSSCredentialsLastModifiedTime() (time.Time, error) {
 	// TODO: @renormalize Remove this extra handling in v0.31.0
 	// Check if a JSON file is present in the directory, if it is present -> the JSON file must be used for credentials.
 	if dir, isSet := os.LookupEnv(aliCredentialDirectory); isSet {
-		modificationTimeStamp, err := getJSONCredentialModifiedTime(dir, "OSS")
+		modificationTimeStamp, err := getJSONCredentialModifiedTime(dir)
 		if err != nil {
-			return time.Time{}, err
+			return time.Time{}, fmt.Errorf("failed to fetch credential modification time for OSS with error: %w", err)
 		}
 		if !modificationTimeStamp.IsZero() {
 			return modificationTimeStamp, nil

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -90,13 +90,29 @@ func NewS3SnapStore(config *brtypes.SnapstoreConfig) (*S3SnapStore, error) {
 }
 
 func getSessionOptions(prefixString string) (session.Options, SSECredentials, error) {
-
 	if filename, isSet := os.LookupEnv(prefixString + awsCredentialJSONFile); isSet {
 		creds, sseCreds, err := readAWSCredentialsJSONFile(filename)
 		if err != nil {
 			return session.Options{}, SSECredentials{}, fmt.Errorf("error getting credentials using %v file with error %w", filename, err)
 		}
 		return creds, sseCreds, nil
+	}
+
+	// TODO: @renormalize Remove this extra handling in v0.31.0
+	// Check if a JSON file is present in the directory, if it is present -> the JSON file must be used for credentials.
+	if dir, isSet := os.LookupEnv(prefixString + awsCredentialDirectory); isSet {
+		jsonCredentialFile, err := findFileWithExtensionInDir(dir, ".json")
+		if err != nil {
+			return session.Options{}, SSECredentials{}, fmt.Errorf("error while finding a JSON credential file in %v directory with error: %w", dir, err)
+		}
+		if jsonCredentialFile != "" {
+			creds, sseCreds, err := readAWSCredentialsJSONFile(jsonCredentialFile)
+			if err != nil {
+				return session.Options{}, SSECredentials{}, fmt.Errorf("error getting credentials using %v JSON file in a directory with error: %w", jsonCredentialFile, err)
+			}
+			return creds, sseCreds, nil
+		}
+		// Non JSON credential files might exist in the credential directory, do not return
 	}
 
 	if dir, isSet := os.LookupEnv(prefixString + awsCredentialDirectory); isSet {
@@ -540,6 +556,19 @@ func (s *S3SnapStore) Delete(snap brtypes.Snapshot) error {
 
 // GetS3CredentialsLastModifiedTime returns the latest modification timestamp of the AWS credential file(s)
 func GetS3CredentialsLastModifiedTime() (time.Time, error) {
+	// TODO: @renormalize Remove this extra handling in v0.31.0
+	// Check if a JSON file is present in the directory, if it is present -> the JSON file must be used for credentials.
+	if dir, isSet := os.LookupEnv(awsCredentialDirectory); isSet {
+		modificationTimeStamp, err := getJSONCredentialModifiedTime(dir, "AWS")
+		if err != nil {
+			return time.Time{}, err
+		}
+		if !modificationTimeStamp.IsZero() {
+			return modificationTimeStamp, nil
+		}
+		// Non JSON credential files might exist in the credential directory, do not return
+	}
+
 	if dir, isSet := os.LookupEnv(awsCredentialDirectory); isSet {
 		// credential files which are essential for creating the S3 snapstore
 		credentialFiles := []string{"accessKeyID", "region", "secretAccessKey"}
@@ -548,7 +577,7 @@ func GetS3CredentialsLastModifiedTime() (time.Time, error) {
 		}
 		awsTimeStamp, err := getLatestCredentialsModifiedTime(credentialFiles)
 		if err != nil {
-			return time.Time{}, fmt.Errorf("failed to get AWS credential timestamp from the directory %v with error: %v", dir, err)
+			return time.Time{}, fmt.Errorf("failed to get AWS credential timestamp from the directory %v with error: %w", dir, err)
 		}
 		return awsTimeStamp, nil
 	}
@@ -557,7 +586,7 @@ func GetS3CredentialsLastModifiedTime() (time.Time, error) {
 		credentialFiles := []string{filename}
 		awsTimeStamp, err := getLatestCredentialsModifiedTime(credentialFiles)
 		if err != nil {
-			return time.Time{}, fmt.Errorf("failed to fetch file information of the AWS JSON credential file %v with error: %v", filename, err)
+			return time.Time{}, fmt.Errorf("failed to fetch file information of the AWS JSON credential file %v with error: %w", filename, err)
 		}
 		return awsTimeStamp, nil
 	}

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -559,9 +559,9 @@ func GetS3CredentialsLastModifiedTime() (time.Time, error) {
 	// TODO: @renormalize Remove this extra handling in v0.31.0
 	// Check if a JSON file is present in the directory, if it is present -> the JSON file must be used for credentials.
 	if dir, isSet := os.LookupEnv(awsCredentialDirectory); isSet {
-		modificationTimeStamp, err := getJSONCredentialModifiedTime(dir, "AWS")
+		modificationTimeStamp, err := getJSONCredentialModifiedTime(dir)
 		if err != nil {
-			return time.Time{}, err
+			return time.Time{}, fmt.Errorf("failed to fetch credential modification time for AWS with error: %w", err)
 		}
 		if !modificationTimeStamp.IsZero() {
 			return modificationTimeStamp, nil

--- a/pkg/snapstore/swift_snapstore.go
+++ b/pkg/snapstore/swift_snapstore.go
@@ -568,9 +568,9 @@ func GetSwiftCredentialsLastModifiedTime() (time.Time, error) {
 	// TODO: @renormalize Remove this extra handling in v0.31.0
 	// Check if a JSON file is present in the directory, if it is present -> the JSON file must be used for credentials.
 	if dir, isSet := os.LookupEnv(swiftCredentialDirectory); isSet {
-		modificationTimeStamp, err := getJSONCredentialModifiedTime(dir, "Swift")
+		modificationTimeStamp, err := getJSONCredentialModifiedTime(dir)
 		if err != nil {
-			return time.Time{}, err
+			return time.Time{}, fmt.Errorf("failed to fetch credential modification time for Swift with error: %w", err)
 		}
 		if !modificationTimeStamp.IsZero() {
 			return modificationTimeStamp, nil

--- a/pkg/snapstore/swift_snapstore.go
+++ b/pkg/snapstore/swift_snapstore.go
@@ -112,15 +112,32 @@ func getClientOpts(isSource bool) (*clientconfig.ClientOpts, error) {
 	if filename, isSet := os.LookupEnv(prefix + swiftCredentialJSONFile); isSet {
 		clientOpts, err := readSwiftCredentialsJSON(filename)
 		if err != nil {
-			return &clientconfig.ClientOpts{}, fmt.Errorf("error getting credentials using %v file", filename)
+			return &clientconfig.ClientOpts{}, fmt.Errorf("error getting credentials using %v file with error: %w", filename, err)
 		}
 		return clientOpts, nil
+	}
+
+	// TODO: @renormalize Remove this extra handling in v0.31.0
+	// Check if a JSON file is present in the directory, if it is present -> the JSON file must be used for credentials.
+	if dir, isSet := os.LookupEnv(prefix + swiftCredentialDirectory); isSet {
+		jsonCredentialFile, err := findFileWithExtensionInDir(dir, ".json")
+		if err != nil {
+			return &clientconfig.ClientOpts{}, fmt.Errorf("error getting credentials using %v JSON file in a directory with error: %w", jsonCredentialFile, err)
+		}
+		if jsonCredentialFile != "" {
+			clientOpts, err := readSwiftCredentialsJSON(jsonCredentialFile)
+			if err != nil {
+				return &clientconfig.ClientOpts{}, fmt.Errorf("error getting credentials using %v JSON file in a directory with error: %w", jsonCredentialFile, err)
+			}
+			return clientOpts, nil
+		}
+		// Non JSON credential files might exist in the credential directory, do not return
 	}
 
 	if dir, isSet := os.LookupEnv(prefix + swiftCredentialDirectory); isSet {
 		clientOpts, err := readSwiftCredentialFiles(dir)
 		if err != nil {
-			return &clientconfig.ClientOpts{}, fmt.Errorf("error getting credentials from %v directory", dir)
+			return &clientconfig.ClientOpts{}, fmt.Errorf("error getting credentials from %v directory with error: %w", dir, err)
 		}
 		return clientOpts, nil
 	}
@@ -548,6 +565,19 @@ func (s *SwiftSnapStore) Delete(snap brtypes.Snapshot) error {
 
 // GetSwiftCredentialsLastModifiedTime returns the latest modification timestamp of the Swift credential file(s)
 func GetSwiftCredentialsLastModifiedTime() (time.Time, error) {
+	// TODO: @renormalize Remove this extra handling in v0.31.0
+	// Check if a JSON file is present in the directory, if it is present -> the JSON file must be used for credentials.
+	if dir, isSet := os.LookupEnv(swiftCredentialDirectory); isSet {
+		modificationTimeStamp, err := getJSONCredentialModifiedTime(dir, "Swift")
+		if err != nil {
+			return time.Time{}, err
+		}
+		if !modificationTimeStamp.IsZero() {
+			return modificationTimeStamp, nil
+		}
+		// Non JSON credential files might exist in the credential directory, do not return
+	}
+
 	if dir, isSet := os.LookupEnv(swiftCredentialDirectory); isSet {
 		// credential files which are essential for creating the snapstore
 		var credentialFiles []string
@@ -572,7 +602,7 @@ func GetSwiftCredentialsLastModifiedTime() (time.Time, error) {
 
 		swiftTimeStamp, err := getLatestCredentialsModifiedTime(credentialFiles)
 		if err != nil {
-			return time.Time{}, fmt.Errorf("failed to get Swift credential timestamp from the directory %v with error: %v", dir, err)
+			return time.Time{}, fmt.Errorf("failed to get Swift credential timestamp from the directory %v with error: %w", dir, err)
 		}
 		return swiftTimeStamp, nil
 	}
@@ -581,7 +611,7 @@ func GetSwiftCredentialsLastModifiedTime() (time.Time, error) {
 		credentialFiles := []string{filename}
 		swiftTimeStamp, err := getLatestCredentialsModifiedTime(credentialFiles)
 		if err != nil {
-			return time.Time{}, fmt.Errorf("failed to fetch file information of the Swift JSON credential file %v with error: %v", filename, err)
+			return time.Time{}, fmt.Errorf("failed to fetch file information of the Swift JSON credential file %v with error: %w", filename, err)
 		}
 		return swiftTimeStamp, nil
 	}

--- a/pkg/snapstore/utils.go
+++ b/pkg/snapstore/utils.go
@@ -213,7 +213,7 @@ func getLatestCredentialsModifiedTime(credentialFiles []string) (time.Time, erro
 	return latestModifiedTime, nil
 }
 
-// findFileWithExtensionInDir checks if there is any file in directory dir which has the file extension extension.
+// findFileWithExtensionInDir checks whether there is any file present in a given directory with given file extension.
 func findFileWithExtensionInDir(dir, extension string) (string, error) {
 	dirEntries, err := os.ReadDir(dir)
 	if err != nil {
@@ -230,22 +230,22 @@ func findFileWithExtensionInDir(dir, extension string) (string, error) {
 	return credentialFile, nil
 }
 
-// getJSONCredentialModifiedTime returns the modification time of a JSON file if it is present in the directory dir.
+// getJSONCredentialModifiedTime returns the modification time of a JSON file if it is present in a given directory.
 // This function is introduced only to support JSON files being present in the directory which is passed through the
 // PROVIDER_APPLICATION_CREDENTIAL environment variable. Will be removed by v0.31.0.
-func getJSONCredentialModifiedTime(dir, providerErrorString string) (time.Time, error) {
+func getJSONCredentialModifiedTime(dir string) (time.Time, error) {
 	jsonCredentialFile, err := findFileWithExtensionInDir(dir, ".json")
 	if err != nil {
-		return time.Time{}, fmt.Errorf("failed to fetch file information of the "+providerErrorString+" JSON credential file %v in the directory %v with error: %w", jsonCredentialFile, dir, err)
+		return time.Time{}, fmt.Errorf("failed to fetch file information of the JSON credential file %v in the directory %v with error: %w", jsonCredentialFile, dir, err)
 	}
 	if jsonCredentialFile != "" {
 		credentialFiles := []string{jsonCredentialFile}
 		timestamp, err := getLatestCredentialsModifiedTime(credentialFiles)
 		if err != nil {
-			return time.Time{}, fmt.Errorf("failed to fetch file modification information of the "+providerErrorString+" JSON credential file %v in the directory %v with error: %w", jsonCredentialFile, dir, err)
+			return time.Time{}, fmt.Errorf("failed to fetch file modification information of the JSON credential file %v in the directory %v with error: %w", jsonCredentialFile, dir, err)
 		}
 		return timestamp, nil
 	}
-	// No JSON credential file was found in the directory dir
+	// No JSON credential file was found in a given directory.
 	return time.Time{}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The dual way of passing credentials to etcd-backup-restore, but the file-type agnostic way of passing credentials in [gardener/etcd-druid](https://github.com/gardener/etcd-druid) caused confusion in the community consuming both etcd-druid and etcd-backup-restore.

Passing credentials through a JSON file in etcd-druid does not cause it to error, but is not supported by etcd-druid - and thereby causes etcd-backup-restore to error as a result, even though etcd-backup-restore supports credentials in JSON files. 
If consumers familiar with etcd-backup-restore who pass credentials as JSON typically, use the same method to pass credentials in etcd-druid, etcd-backup-restore errors.

To temporarily solve this, if credentials are passed through a JSON file in etcd-druid (i.e. as a file in a directory whose path is exported in `<PROVIDER>_APPLICATION_CREDENTIALS`), etcd-backup-restore handles this and fetches the credentials from the JSON file. If a JSON file is present in the directory, all other files are ignored.

However, as mentioned in #729, credentials will only be passed to etcd-backup-restore as individual files in a directory in 3 releases from the next (as of writing, v0.31.0), and credentials in the form of JSON files will be deprecated.

This PR makes the following changes:

* Add support to read JSON credential files present in a directory which is passed through the `<PROVIDER>_APPLICATION_CREDENTIALS` environment variable for all (applicable) providers.

* Remove examples which suggest that cloud provider credentials can be passed through a JSON file since this will be deprecated in future releases.

* Improve error handling in various `SnapStore` related files for each cloud provider.

* Updated docs to discourage usage of JSON files to pass credentials.

* Housekeeping in `pkg/server/backuprestoreserver.go`. Changed an unused named function parameter to `_`, and removed a tautological if condition.

Tested with the following cloud providers to test the feature and check for regressions:

- [x] AWS S3
- [x] Azure Blob Storage
- [x] GCS (currently only a `service_account.json` is accepted so this issue will not be faced.)
- [x] OpenStack Swift


**Which issue(s) this PR fixes**:
Fixes #729 

**Special notes for your reviewer**:

Please update the block header and the release note to something that you feel is more appropriate.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->

```noteworthy|action user|operator
Passing object store credentials to etcd-backup-restore in the form of a JSON file is now deprecated. Support to pass JSON credentials via file mount (File Path Set through Env: <ProviderName>_APPLICATION_CREDENTIALS_JSON) will be dropped by v0.31.0.
```

```noteworthy|action user|operator
Please switch to passing credentials through non-JSON file as mentioned in https://github.com/gardener/etcd-backup-restore/tree/master/example/storage-provider-secrets and Set File Path through Env: `<ProviderName>_APPLICATION_CREDENTIALS`
```
