### PR TITLE
Remove the `full-snapshot-lease-update-interval` flag from etcdbr API

### DIFF
--- a/pkg/snapshot/snapshotter/fullsnapshotleaseupdate.go
+++ b/pkg/snapshot/snapshotter/fullsnapshotleaseupdate.go
@@ -15,9 +15,8 @@ import (
 
 // RenewFullSnapshotLeasePeriodically has a timer and will periodically call FullSnapshotCaseLeaseUpdate to renew the fullsnapshot lease until it is updated or stopped.
 // The timer starts upon snapshotter initialization and is reset after every full snapshot is taken.
-func (ssr *Snapshotter) RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh chan struct{}) {
+func (ssr *Snapshotter) RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh chan struct{}, fullSnapshotLeaseUpdateInterval time.Duration) {
 	logger := logrus.NewEntry(logrus.New()).WithField("actor", "FullSnapLeaseUpdater")
-	fullSnapshotLeaseUpdateInterval := ssr.HealthConfig.FullSnapshotLeaseUpdateInterval.Duration
 	ssr.FullSnapshotLeaseUpdateTimer = time.NewTimer(fullSnapshotLeaseUpdateInterval)
 	fullSnapshotLeaseUpdateCtx, fullSnapshotLeaseUpdateCancel := context.WithCancel(context.TODO())
 	defer func() {

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -188,7 +188,7 @@ func (ssr *Snapshotter) Run(stopCh <-chan struct{}, startWithFullSnapshot bool) 
 		}
 	}
 	if ssr.HealthConfig.SnapshotLeaseRenewalEnabled {
-		go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh)
+		go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh, brtypes.FullSnapshotLeaseUpdateInterval)
 	}
 	ssr.deltaSnapshotTimer = time.NewTimer(brtypes.DefaultDeltaSnapshotInterval)
 	if ssr.config.DeltaSnapshotPeriod.Duration >= brtypes.DeltaSnapshotIntervalThreshold {

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -945,8 +945,8 @@ var _ = Describe("Snapshotter", func() {
 					err := ssr.K8sClientset.Create(ctx, lease)
 					Expect(err).ShouldNot(HaveOccurred())
 
-					ssr.HealthConfig.FullSnapshotLeaseUpdateInterval.Duration = 2 * time.Second
-					go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh)
+					fullSnapshotLeaseUpdateInterval := 2 * time.Second
+					go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh, fullSnapshotLeaseUpdateInterval)
 					time.Sleep(2 * time.Second)
 					close(FullSnapshotLeaseStopCh)
 
@@ -974,8 +974,8 @@ var _ = Describe("Snapshotter", func() {
 					err := ssr.K8sClientset.Create(ctx, lease)
 					Expect(err).ShouldNot(HaveOccurred())
 
-					ssr.HealthConfig.FullSnapshotLeaseUpdateInterval.Duration = time.Second
-					go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh)
+					fullSnapshotLeaseUpdateInterval := time.Second
+					go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh, fullSnapshotLeaseUpdateInterval)
 					time.Sleep(2 * time.Second)
 					close(FullSnapshotLeaseStopCh)
 
@@ -998,8 +998,8 @@ var _ = Describe("Snapshotter", func() {
 					}
 					prevFullSnap.GenerateSnapshotName()
 					ssr.PrevFullSnapshot = prevFullSnap
-					ssr.HealthConfig.FullSnapshotLeaseUpdateInterval.Duration = 3 * time.Second
-					go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh)
+					fullSnapshotLeaseUpdateInterval := 3 * time.Second
+					go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh, fullSnapshotLeaseUpdateInterval)
 					time.Sleep(time.Second)
 					err := ssr.K8sClientset.Create(ctx, lease)
 					Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -900,11 +900,12 @@ var _ = Describe("Snapshotter", func() {
 
 		Describe("Scenarios to update full snapshot lease", func() {
 			var (
-				ssr                     *Snapshotter
-				lease                   *v1.Lease
-				FullSnapshotLeaseStopCh chan struct{}
-				ctx                     context.Context
-				cancel                  context.CancelFunc
+				ssr                             *Snapshotter
+				lease                           *v1.Lease
+				FullSnapshotLeaseStopCh         chan struct{}
+				ctx                             context.Context
+				cancel                          context.CancelFunc
+				fullSnapshotLeaseUpdateInterval time.Duration
 			)
 			BeforeEach(func() {
 				snapstoreConfig = &brtypes.SnapstoreConfig{Container: path.Join(outputDir, "default.bkp")}
@@ -945,7 +946,7 @@ var _ = Describe("Snapshotter", func() {
 					err := ssr.K8sClientset.Create(ctx, lease)
 					Expect(err).ShouldNot(HaveOccurred())
 
-					fullSnapshotLeaseUpdateInterval := 2 * time.Second
+					fullSnapshotLeaseUpdateInterval = 2 * time.Second
 					go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh, fullSnapshotLeaseUpdateInterval)
 					time.Sleep(2 * time.Second)
 					close(FullSnapshotLeaseStopCh)
@@ -974,7 +975,7 @@ var _ = Describe("Snapshotter", func() {
 					err := ssr.K8sClientset.Create(ctx, lease)
 					Expect(err).ShouldNot(HaveOccurred())
 
-					fullSnapshotLeaseUpdateInterval := time.Second
+					fullSnapshotLeaseUpdateInterval = time.Second
 					go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh, fullSnapshotLeaseUpdateInterval)
 					time.Sleep(2 * time.Second)
 					close(FullSnapshotLeaseStopCh)
@@ -998,7 +999,7 @@ var _ = Describe("Snapshotter", func() {
 					}
 					prevFullSnap.GenerateSnapshotName()
 					ssr.PrevFullSnapshot = prevFullSnap
-					fullSnapshotLeaseUpdateInterval := 3 * time.Second
+					fullSnapshotLeaseUpdateInterval = 3 * time.Second
 					go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh, fullSnapshotLeaseUpdateInterval)
 					time.Sleep(time.Second)
 					err := ssr.K8sClientset.Create(ctx, lease)

--- a/pkg/types/health.go
+++ b/pkg/types/health.go
@@ -35,27 +35,25 @@ const (
 
 // HealthConfig holds the health configuration.
 type HealthConfig struct {
-	SnapshotLeaseRenewalEnabled     bool              `json:"snapshotLeaseRenewalEnabled,omitempty"`
-	FullSnapshotLeaseUpdateInterval wrappers.Duration `json:"fullSnapshotLeaseUpdateInterval,omitempty"`
-	MemberLeaseRenewalEnabled       bool              `json:"memberLeaseRenewalEnabled,omitempty"`
-	EtcdMemberGCEnabled             bool              `json:"etcdMemberGCEnabled,omitempty"`
-	HeartbeatDuration               wrappers.Duration `json:"heartbeatDuration,omitempty"`
-	MemberGCDuration                wrappers.Duration `json:"memberGCDuration,omitempty"`
-	FullSnapshotLeaseName           string            `json:"fullSnapshotLeaseName,omitempty"`
-	DeltaSnapshotLeaseName          string            `json:"deltaSnapshotLeaseName,omitempty"`
+	SnapshotLeaseRenewalEnabled bool              `json:"snapshotLeaseRenewalEnabled,omitempty"`
+	MemberLeaseRenewalEnabled   bool              `json:"memberLeaseRenewalEnabled,omitempty"`
+	EtcdMemberGCEnabled         bool              `json:"etcdMemberGCEnabled,omitempty"`
+	HeartbeatDuration           wrappers.Duration `json:"heartbeatDuration,omitempty"`
+	MemberGCDuration            wrappers.Duration `json:"memberGCDuration,omitempty"`
+	FullSnapshotLeaseName       string            `json:"fullSnapshotLeaseName,omitempty"`
+	DeltaSnapshotLeaseName      string            `json:"deltaSnapshotLeaseName,omitempty"`
 }
 
 // NewHealthConfig returns the health config.
 func NewHealthConfig() *HealthConfig {
 	return &HealthConfig{
-		SnapshotLeaseRenewalEnabled:     DefaultSnapshotLeaseRenewalEnabled,
-		FullSnapshotLeaseUpdateInterval: wrappers.Duration{Duration: FullSnapshotLeaseUpdateInterval},
-		MemberLeaseRenewalEnabled:       DefaultMemberLeaseRenewalEnabled,
-		EtcdMemberGCEnabled:             DefaultEtcdMemberGCEnabled,
-		HeartbeatDuration:               wrappers.Duration{Duration: DefaultHeartbeatDuration},
-		MemberGCDuration:                wrappers.Duration{Duration: DefaultMemberGarbageCollectionPeriod},
-		FullSnapshotLeaseName:           DefaultFullSnapshotLeaseName,
-		DeltaSnapshotLeaseName:          DefaultDeltaSnapshotLeaseName,
+		SnapshotLeaseRenewalEnabled: DefaultSnapshotLeaseRenewalEnabled,
+		MemberLeaseRenewalEnabled:   DefaultMemberLeaseRenewalEnabled,
+		EtcdMemberGCEnabled:         DefaultEtcdMemberGCEnabled,
+		HeartbeatDuration:           wrappers.Duration{Duration: DefaultHeartbeatDuration},
+		MemberGCDuration:            wrappers.Duration{Duration: DefaultMemberGarbageCollectionPeriod},
+		FullSnapshotLeaseName:       DefaultFullSnapshotLeaseName,
+		DeltaSnapshotLeaseName:      DefaultDeltaSnapshotLeaseName,
 	}
 }
 

--- a/pkg/types/health.go
+++ b/pkg/types/health.go
@@ -15,8 +15,8 @@ import (
 const (
 	// DefaultSnapshotLeaseRenewalEnabled is a default value for enabling the snapshot lease renewal feature
 	DefaultSnapshotLeaseRenewalEnabled = false
-	// DefaultFullSnapshotLeaseUpdateInterval is a default interval for updating full snapshot lease
-	DefaultFullSnapshotLeaseUpdateInterval = 3 * time.Minute
+	// FullSnapshotLeaseUpdateInterval is a default interval for updating full snapshot lease
+	FullSnapshotLeaseUpdateInterval = 1 * time.Minute
 	// DefaultMemberLeaseRenewalEnabled is a default value for enabling the member lease renewal feature
 	DefaultMemberLeaseRenewalEnabled = false
 	// DefaultEtcdMemberGCEnabled is a default value for enabling the etcd member garbage collection feature
@@ -49,7 +49,7 @@ type HealthConfig struct {
 func NewHealthConfig() *HealthConfig {
 	return &HealthConfig{
 		SnapshotLeaseRenewalEnabled:     DefaultSnapshotLeaseRenewalEnabled,
-		FullSnapshotLeaseUpdateInterval: wrappers.Duration{Duration: DefaultFullSnapshotLeaseUpdateInterval},
+		FullSnapshotLeaseUpdateInterval: wrappers.Duration{Duration: FullSnapshotLeaseUpdateInterval},
 		MemberLeaseRenewalEnabled:       DefaultMemberLeaseRenewalEnabled,
 		EtcdMemberGCEnabled:             DefaultEtcdMemberGCEnabled,
 		HeartbeatDuration:               wrappers.Duration{Duration: DefaultHeartbeatDuration},
@@ -63,7 +63,6 @@ func NewHealthConfig() *HealthConfig {
 func (c *HealthConfig) AddFlags(fs *flag.FlagSet) {
 
 	fs.BoolVar(&c.SnapshotLeaseRenewalEnabled, "enable-snapshot-lease-renewal", c.SnapshotLeaseRenewalEnabled, "Allows sidecar to renew the snapshot leases when snapshots are taken")
-	fs.DurationVar(&c.FullSnapshotLeaseUpdateInterval.Duration, "full-snapshot-lease-update-interval", c.FullSnapshotLeaseUpdateInterval.Duration, "Interval for Periodic Full Snapshot lease updates")
 	fs.BoolVar(&c.MemberLeaseRenewalEnabled, "enable-member-lease-renewal", c.MemberLeaseRenewalEnabled, "Allows sidecar to periodically renew the member leases")
 	fs.BoolVar(&c.EtcdMemberGCEnabled, "enable-etcd-member-gc", c.EtcdMemberGCEnabled, "Allows leading sidecar to remove any superfluous etcd members from the cluster")
 	fs.DurationVar(&c.HeartbeatDuration.Duration, "k8s-heartbeat-duration", c.HeartbeatDuration.Duration, "Heartbeat duration")
@@ -80,10 +79,6 @@ func (c *HealthConfig) Validate() error {
 
 	if c.MemberGCDuration.Seconds() <= 0 {
 		return fmt.Errorf("etcd member garbage collection period should be greater than zero")
-	}
-
-	if c.FullSnapshotLeaseUpdateInterval.Seconds() <= 0 {
-		return fmt.Errorf("full snapshot lease update retry interval should be greater than zero")
 	}
 
 	if c.SnapshotLeaseRenewalEnabled {

--- a/pkg/types/health.go
+++ b/pkg/types/health.go
@@ -15,7 +15,7 @@ import (
 const (
 	// DefaultSnapshotLeaseRenewalEnabled is a default value for enabling the snapshot lease renewal feature
 	DefaultSnapshotLeaseRenewalEnabled = false
-	// FullSnapshotLeaseUpdateInterval is a default interval for updating full snapshot lease
+	// FullSnapshotLeaseUpdateInterval is the interval for updating full snapshot lease
 	FullSnapshotLeaseUpdateInterval = 1 * time.Minute
 	// DefaultMemberLeaseRenewalEnabled is a default value for enabling the member lease renewal feature
 	DefaultMemberLeaseRenewalEnabled = false


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the flag `full-snapshot-lease-update-interval` from the etcdbr API. The flag was introduced in PR #711 to let druid configure the interval for retrying to update full snapshot lease when the lease is stale. But from the internal discussions among the team, we've decided that this flag is of not much help and unnecessarily extends the API. So this PR removes the flag. 

Also update the default retry interval from `3 min` to `1 min` to allow faster periodic retry. For more information refer PR #711.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Reverted the decision to have the flag `full-snapshot-lease-update-interval` to configure periodic interval for full snapshot lease update. And reduce the retry interval from `3 minutes` to `1 minute`
```
