### PR TITLE
Update the full snapshot lease with `renewTime` set to the time FullSnapshot is taken

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -182,7 +182,7 @@ func (cp *Compactor) Compact(ctx context.Context, opts *brtypes.CompactOptions) 
 	if opts.EnabledLeaseRenewal {
 		// Update revisions in holder identity of full snapshot lease.
 		ctx, cancel := context.WithTimeout(ctx, brtypes.LeaseUpdateTimeoutDuration)
-		if err := heartbeat.FullSnapshotCaseLeaseUpdate(ctx, cp.logger, snapshot, cp.k8sClientset, opts.FullSnapshotLeaseName); err != nil {
+		if err := heartbeat.FullSnapshotCaseLeaseUpdate(ctx, cp.logger, snapshot, cp.k8sClientset, opts.FullSnapshotLeaseName, time.Now()); err != nil {
 			cp.logger.Warnf("Snapshot lease update failed : %v", err)
 		}
 		cancel()

--- a/pkg/health/heartbeat/heartbeat.go
+++ b/pkg/health/heartbeat/heartbeat.go
@@ -144,7 +144,7 @@ func (hb *Heartbeat) RenewMemberLease(ctx context.Context) error {
 }
 
 // UpdateFullSnapshotLease renews the full snapshot lease and updates the holderIdentity field with the last revision in the latest full snapshot.
-func UpdateFullSnapshotLease(ctx context.Context, logger *logrus.Entry, fullSnapshot *brtypes.Snapshot, k8sClientset client.Client, fullSnapshotLeaseName string) error {
+func UpdateFullSnapshotLease(ctx context.Context, logger *logrus.Entry, fullSnapshot *brtypes.Snapshot, k8sClientset client.Client, fullSnapshotLeaseName string, fullSnapshotTime time.Time) error {
 	if k8sClientset == nil {
 		return &errors.EtcdError{
 			Message: "nil clientset passed",
@@ -191,7 +191,7 @@ func UpdateFullSnapshotLease(ctx context.Context, logger *logrus.Entry, fullSnap
 		}
 
 		renewedLease := fullSnapLease.DeepCopy()
-		renewedTime := time.Now()
+		renewedTime := fullSnapshotTime
 		renewedLease.Spec.RenewTime = &metav1.MicroTime{Time: renewedTime}
 		// Update revisions in fullSnapLease.Spec.HolderIdentity only when its value is less than latest fullSnap.LastRevision
 		if fullSnapLease.Spec.HolderIdentity == nil || rev < fullSnapshot.LastRevision {
@@ -278,8 +278,8 @@ func UpdateDeltaSnapshotLease(ctx context.Context, logger *logrus.Entry, prevDel
 }
 
 // FullSnapshotCaseLeaseUpdate Updates the fullsnapshot lease as needed when a full snapshot is taken
-func FullSnapshotCaseLeaseUpdate(ctx context.Context, logger *logrus.Entry, fullSnapshot *brtypes.Snapshot, k8sClientset client.Client, fullSnapshotLeaseName string) error {
-	if err := UpdateFullSnapshotLease(ctx, logger, fullSnapshot, k8sClientset, fullSnapshotLeaseName); err != nil {
+func FullSnapshotCaseLeaseUpdate(ctx context.Context, logger *logrus.Entry, fullSnapshot *brtypes.Snapshot, k8sClientset client.Client, fullSnapshotLeaseName string, fullSnapshotTime time.Time) error {
+	if err := UpdateFullSnapshotLease(ctx, logger, fullSnapshot, k8sClientset, fullSnapshotLeaseName, fullSnapshotTime); err != nil {
 		return &errors.EtcdError{
 			Message: fmt.Sprintf("Failed to update full snapshot lease: %v", err),
 		}

--- a/pkg/health/heartbeat/heartbeat_test.go
+++ b/pkg/health/heartbeat/heartbeat_test.go
@@ -120,7 +120,7 @@ var _ = Describe("Heartbeat", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				// Update full snapshot lease with the first full snapshot
-				err = heartbeat.UpdateFullSnapshotLease(context.TODO(), logger, prevFullSnap, k8sClientset, brtypes.DefaultFullSnapshotLeaseName)
+				err = heartbeat.UpdateFullSnapshotLease(context.TODO(), logger, prevFullSnap, k8sClientset, brtypes.DefaultFullSnapshotLeaseName, time.Now())
 				Expect(err).ShouldNot(HaveOccurred())
 
 				l := &v1.Lease{}
@@ -131,7 +131,7 @@ var _ = Describe("Heartbeat", func() {
 				Expect(l.Spec.HolderIdentity).To(PointTo(Equal("980")))
 
 				// Trigger full snapshot lease update with latest full snapshot which is not the first full snapshot
-				err = heartbeat.UpdateFullSnapshotLease(context.TODO(), logger, latestFullSnap, k8sClientset, brtypes.DefaultFullSnapshotLeaseName)
+				err = heartbeat.UpdateFullSnapshotLease(context.TODO(), logger, latestFullSnap, k8sClientset, brtypes.DefaultFullSnapshotLeaseName, time.Now())
 				Expect(err).ShouldNot(HaveOccurred())
 
 				l = &v1.Lease{}
@@ -150,7 +150,7 @@ var _ = Describe("Heartbeat", func() {
 
 				Expect(k8sClientset.Create(context.TODO(), lease)).To(Succeed())
 
-				err := heartbeat.UpdateFullSnapshotLease(context.TODO(), logger, nil, k8sClientset, brtypes.DefaultFullSnapshotLeaseName)
+				err := heartbeat.UpdateFullSnapshotLease(context.TODO(), logger, nil, k8sClientset, brtypes.DefaultFullSnapshotLeaseName, time.Now())
 				Expect(err).Should(HaveOccurred())
 
 				err = k8sClientset.Delete(context.TODO(), lease)

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -423,7 +423,7 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 				if b.config.HealthConfig.SnapshotLeaseRenewalEnabled {
 					leaseUpdatectx, cancel := context.WithTimeout(ctx, brtypes.LeaseUpdateTimeoutDuration)
 					defer cancel()
-					if err = heartbeat.FullSnapshotCaseLeaseUpdate(leaseUpdatectx, b.logger, snapshot, ssr.K8sClientset, b.config.HealthConfig.FullSnapshotLeaseName); err != nil {
+					if err = heartbeat.FullSnapshotCaseLeaseUpdate(leaseUpdatectx, b.logger, snapshot, ssr.K8sClientset, b.config.HealthConfig.FullSnapshotLeaseName, time.Now()); err != nil {
 						b.logger.Warnf("Snapshot lease update failed : %v", err)
 					}
 				}

--- a/pkg/snapshot/snapshotter/fullsnapshotleaseupdate.go
+++ b/pkg/snapshot/snapshotter/fullsnapshotleaseupdate.go
@@ -15,9 +15,10 @@ import (
 
 // RenewFullSnapshotLeasePeriodically has a timer and will periodically call FullSnapshotCaseLeaseUpdate to renew the fullsnapshot lease until it is updated or stopped.
 // The timer starts upon snapshotter initialization and is reset after every full snapshot is taken.
-func (ssr *Snapshotter) RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh chan struct{}, fullSnapshotLeaseUpdateInterval time.Duration) {
+func (ssr *Snapshotter) RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh chan struct{}, fullSnapshotLeaseUpdateInterval time.Duration, FullSnapshotTriggeredTimeCh chan time.Time) {
 	logger := logrus.NewEntry(logrus.New()).WithField("actor", "FullSnapLeaseUpdater")
 	ssr.FullSnapshotLeaseUpdateTimer = time.NewTimer(fullSnapshotLeaseUpdateInterval)
+	var fullSnapshotTriggeredTime time.Time
 	fullSnapshotLeaseUpdateCtx, fullSnapshotLeaseUpdateCancel := context.WithCancel(context.TODO())
 	defer func() {
 		fullSnapshotLeaseUpdateCancel()
@@ -30,11 +31,19 @@ func (ssr *Snapshotter) RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStop
 	for {
 		select {
 		case <-ssr.FullSnapshotLeaseUpdateTimer.C:
+			select {
+			case time := <-FullSnapshotTriggeredTimeCh:
+				fullSnapshotTriggeredTime = time
+			case <-time.After(2 * time.Second):
+				if fullSnapshotTriggeredTime.IsZero() {
+					fullSnapshotTriggeredTime = time.Now()
+				}
+			}
 			if ssr.PrevFullSnapshot != nil {
 				if err := func() error {
 					ctx, cancel := context.WithTimeout(fullSnapshotLeaseUpdateCtx, brtypes.LeaseUpdateTimeoutDuration)
 					defer cancel()
-					return heartbeat.FullSnapshotCaseLeaseUpdate(ctx, logger, ssr.PrevFullSnapshot, ssr.K8sClientset, ssr.HealthConfig.FullSnapshotLeaseName)
+					return heartbeat.FullSnapshotCaseLeaseUpdate(ctx, logger, ssr.PrevFullSnapshot, ssr.K8sClientset, ssr.HealthConfig.FullSnapshotLeaseName, fullSnapshotTriggeredTime)
 				}(); err != nil {
 					//FullSnapshot lease update failed. Retry after interval
 					logger.Warnf("FullSnapshot lease update failed with error: %v", err)

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -166,6 +166,7 @@ func NewSnapshotter(logger *logrus.Entry, config *brtypes.SnapshotterConfig, sto
 // taking the first full snapshot.
 func (ssr *Snapshotter) Run(stopCh <-chan struct{}, startWithFullSnapshot bool) error {
 	FullSnapshotLeaseStopCh := make(chan struct{})
+	FullSnapshotTriggeredTimeCh := make(chan time.Time, 1)
 	defer ssr.stop(FullSnapshotLeaseStopCh)
 	if startWithFullSnapshot {
 		ssr.fullSnapshotTimer = time.NewTimer(0)
@@ -188,7 +189,7 @@ func (ssr *Snapshotter) Run(stopCh <-chan struct{}, startWithFullSnapshot bool) 
 		}
 	}
 	if ssr.HealthConfig.SnapshotLeaseRenewalEnabled {
-		go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh, brtypes.FullSnapshotLeaseUpdateInterval)
+		go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh, brtypes.FullSnapshotLeaseUpdateInterval, FullSnapshotTriggeredTimeCh)
 	}
 	ssr.deltaSnapshotTimer = time.NewTimer(brtypes.DefaultDeltaSnapshotInterval)
 	if ssr.config.DeltaSnapshotPeriod.Duration >= brtypes.DeltaSnapshotIntervalThreshold {
@@ -196,7 +197,7 @@ func (ssr *Snapshotter) Run(stopCh <-chan struct{}, startWithFullSnapshot bool) 
 		ssr.deltaSnapshotTimer.Reset(ssr.config.DeltaSnapshotPeriod.Duration)
 	}
 
-	return ssr.snapshotEventHandler(stopCh)
+	return ssr.snapshotEventHandler(stopCh, FullSnapshotTriggeredTimeCh)
 }
 
 // TriggerFullSnapshot sends the events to take full snapshot. This is to
@@ -624,7 +625,7 @@ func newEvent(e *clientv3.Event) *event {
 	}
 }
 
-func (ssr *Snapshotter) snapshotEventHandler(stopCh <-chan struct{}) error {
+func (ssr *Snapshotter) snapshotEventHandler(stopCh <-chan struct{}, FullSnapshotTriggeredTimeCh chan time.Time) error {
 	leaseUpdateCtx, leaseUpdateCancel := context.WithCancel(context.TODO())
 	defer leaseUpdateCancel()
 	ssr.logger.Info("Starting the Snapshot EventHandler.")
@@ -643,6 +644,7 @@ func (ssr *Snapshotter) snapshotEventHandler(stopCh <-chan struct{}) error {
 			if ssr.HealthConfig.SnapshotLeaseRenewalEnabled {
 				ssr.FullSnapshotLeaseUpdateTimer.Stop()
 				ssr.FullSnapshotLeaseUpdateTimer.Reset(time.Nanosecond)
+				FullSnapshotTriggeredTimeCh <- time.Now()
 			}
 
 		case <-ssr.deltaSnapshotReqCh:
@@ -670,6 +672,7 @@ func (ssr *Snapshotter) snapshotEventHandler(stopCh <-chan struct{}) error {
 			if ssr.HealthConfig.SnapshotLeaseRenewalEnabled {
 				ssr.FullSnapshotLeaseUpdateTimer.Stop()
 				ssr.FullSnapshotLeaseUpdateTimer.Reset(time.Nanosecond)
+				FullSnapshotTriggeredTimeCh <- time.Now()
 			}
 
 		case <-ssr.deltaSnapshotTimer.C:

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -903,6 +903,7 @@ var _ = Describe("Snapshotter", func() {
 				ssr                             *Snapshotter
 				lease                           *v1.Lease
 				FullSnapshotLeaseStopCh         chan struct{}
+				FullSnapshotTriggeredTimeCh     chan time.Time
 				ctx                             context.Context
 				cancel                          context.CancelFunc
 				fullSnapshotLeaseUpdateInterval time.Duration
@@ -933,6 +934,7 @@ var _ = Describe("Snapshotter", func() {
 				ssr.K8sClientset = fake.NewClientBuilder().Build()
 				ssr.HealthConfig.SnapshotLeaseRenewalEnabled = true
 				FullSnapshotLeaseStopCh = make(chan struct{})
+				FullSnapshotTriggeredTimeCh = make(chan time.Time, 1)
 			})
 			AfterEach(func() {
 				Expect(os.Unsetenv("POD_NAME")).To(Succeed())
@@ -947,7 +949,8 @@ var _ = Describe("Snapshotter", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					fullSnapshotLeaseUpdateInterval = 2 * time.Second
-					go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh, fullSnapshotLeaseUpdateInterval)
+					FullSnapshotTriggeredTimeCh <- time.Now()
+					go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh, fullSnapshotLeaseUpdateInterval, FullSnapshotTriggeredTimeCh)
 					time.Sleep(2 * time.Second)
 					close(FullSnapshotLeaseStopCh)
 
@@ -976,7 +979,8 @@ var _ = Describe("Snapshotter", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					fullSnapshotLeaseUpdateInterval = time.Second
-					go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh, fullSnapshotLeaseUpdateInterval)
+					FullSnapshotTriggeredTimeCh <- time.Now()
+					go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh, fullSnapshotLeaseUpdateInterval, FullSnapshotTriggeredTimeCh)
 					time.Sleep(2 * time.Second)
 					close(FullSnapshotLeaseStopCh)
 
@@ -1000,7 +1004,8 @@ var _ = Describe("Snapshotter", func() {
 					prevFullSnap.GenerateSnapshotName()
 					ssr.PrevFullSnapshot = prevFullSnap
 					fullSnapshotLeaseUpdateInterval = 3 * time.Second
-					go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh, fullSnapshotLeaseUpdateInterval)
+					FullSnapshotTriggeredTimeCh <- time.Now()
+					go ssr.RenewFullSnapshotLeasePeriodically(FullSnapshotLeaseStopCh, fullSnapshotLeaseUpdateInterval, FullSnapshotTriggeredTimeCh)
 					time.Sleep(time.Second)
 					err := ssr.K8sClientset.Create(ctx, lease)
 					Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:

During update of full snapshot lease, set renewTime to the time the full snapshot was taken, instead of setting it to the time when the lease was updated as part of retry mechanism.

**Which issue(s) this PR fixes**:
Fixes #752

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
improve the `renewTime` of full snapshot lease when the lease is updated as part of retry mechanism
```
