### PR TITLE
Fix `make check` and other house keeping

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -30,7 +30,6 @@ VCS="github.com"
 ORGANIZATION="gardener"
 PROJECT="etcd-backup-restore"
 REPOSITORY=${VCS}/${ORGANIZATION}/${PROJECT}
-export GO111MODULE=on
 cd "${SOURCE_PATH}"
 
 

--- a/.ci/check
+++ b/.ci/check
@@ -25,7 +25,7 @@ REPOSITORY=${VCS}/${ORGANIZATION}/${PROJECT}
 cd "${SOURCE_PATH}"
 
 # Install Golint (linting tool).
-GO111MODULE=off go get -u golang.org/x/lint/golint
+go install golang.org/x/lint/golint@latest
 
 # Install Helm from binary.
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
@@ -38,12 +38,12 @@ rm get_helm.sh
 
 ###############################################################################
 
-PACKAGES="$(GO111MODULE=on go list -mod=vendor -e ./...)"
+PACKAGES="$(go list -mod=vendor -e ./...)"
 LINT_FOLDERS="$(echo ${PACKAGES} | sed "s|github.com/gardener/etcd-backup-restore|.|g")"
 HELM_CHART_PATH="${SOURCE_PATH}/chart/etcd-backup-restore"
 
 # Execute static code checks.
-GO111MODULE=on go vet -mod vendor ${PACKAGES}
+go vet -mod vendor ${PACKAGES}
 
 # Execute automatic code formatting directive.
 go fmt ${PACKAGES}

--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -92,7 +92,7 @@ function setup_etcd(){
 
 function setup_etcdbrctl(){
     echo "Installing etcdbrctl..."
-    GO111MODULE=on go build \
+    go build \
     -v \
     -o ${GOBIN}/etcdbrctl \
     -ldflags "-w -X ${REPOSITORY}/pkg/version.Version=${VERSION}" \

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,12 @@ IMG ?= ${IMAGE_REPOSITORY}:${IMAGE_TAG}
 
 .PHONY: revendor
 revendor:
-	@env GO111MODULE=on go mod tidy -v
-	@env GO111MODULE=on go mod vendor -v
+	@env go mod tidy -v
+	@env go mod vendor -v
 
 .PHONY: update-dependencies
 update-dependencies:
-	@env GO111MODULE=on go get -u
+	@env go get -u
 	@make revendor
 
 .PHONY: build

--- a/docs/development/new_cp_support.md
+++ b/docs/development/new_cp_support.md
@@ -7,9 +7,9 @@
     - :warning: Please use environment variable(s) to pass the object store credentials.
     - Provide the factory method to create provider implementation object by loading required access credentials from environment variable(s).
     - Avoid introducing new command line flags for provider.
-1. Import the required SDK and any other libraries for provider using `GO111MODULE=on go get <provider-sdk>`. This will update the dependency in [go.mod](../../go.mod) and [go.sum](../../go.sum).
+1. Import the required SDK and any other libraries for provider using `go get <provider-sdk>`. This will update the dependency in [go.mod](../../go.mod) and [go.sum](../../go.sum).
 1. Run `make revendor` to download the dependency library to [vendor](../../vendor) directory.
-1. Update the [LICENSE.md](../../LICENSE.md) with license details of newly added dependencies.
+1. Update the [LICENSE](../../LICENSE) with license details of newly added dependencies.
 1. Update the `GetSnapstore` method in `pkg/snapstore/utils.go` to add a new case in switch block to support creation of the new provider implementation object.
 1. Add the fake implementation of provider SDK calls under `pkg/snapstore/provider_snapstore_test.go` for unit testing the provider implementation.
 1. Register the provider implementation object for testing at the appropriate place under `pkg/snapstore/snapstore_test.go`. This will run generic test against provider implementation.

--- a/go.mod
+++ b/go.mod
@@ -40,9 +40,9 @@ require (
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
+	k8s.io/helm v2.17.0+incompatible
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/controller-runtime v0.14.4
-	k8s.io/helm v2.17.0+incompatible
 )
 
 require (


### PR DESCRIPTION
**What this PR does / why we need it**:

* `make check` failed to run correctly locally - fixed by using `go install`.

* Remove references to the deprecated `GO111MODULE`.

* Fixed a broken link in `docs/development/new_cp_support.md`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Fixed the `check` make target when run locally, and a link in docs/development/new_cp_support.md.
```
