### PR TITLE
Add support to override Azure Blob Storage Domain

### DIFF
--- a/docs/deployment/getting_started.md
+++ b/docs/deployment/getting_started.md
@@ -24,7 +24,7 @@ The procedure to provide credentials to access the cloud provider object store v
 
 * For `Azure Blob storage`:
    1. The secret file should be provided, and the file path should be made available as environment variables: `AZURE_APPLICATION_CREDENTIALS` or `AZURE_APPLICATION_CREDENTIALS_JSON`.
-   2. The Azure Blob Storage endpoint can be overridden by providing the optional field `storageAPIEndpoint` in the secret file, as can be seen in the [example](../../example/storage-provider-secrets/00-azure-blob-storage-secret.yaml) file.
+   2. The Azure Blob Storage domain can be overridden by providing the optional field `domain` in the secret file, as can be seen in the [example](../../example/storage-provider-secrets/00-azure-blob-storage-secret.yaml) file.
 
 * For `Openstack Swift`:
   1. The secret file should be provided, and the file path should be made available as environment variables: `OPENSTACK_APPLICATION_CREDENTIALS` or `OPENSTACK_APPLICATION_CREDENTIALS_JSON`.

--- a/docs/deployment/getting_started.md
+++ b/docs/deployment/getting_started.md
@@ -24,6 +24,7 @@ The procedure to provide credentials to access the cloud provider object store v
 
 * For `Azure Blob storage`:
    1. The secret file should be provided, and the file path should be made available as environment variables: `AZURE_APPLICATION_CREDENTIALS` or `AZURE_APPLICATION_CREDENTIALS_JSON`.
+   2. The Azure Blob Storage URI can be overriden by providing the optional field `uri` in the secret file, as can be seen in the [example](../../example/storage-provider-secrets/00-azure-blob-storage-secret.yaml) file.
 
 * For `Openstack Swift`:
   1. The secret file should be provided, and the file path should be made available as environment variables: `OPENSTACK_APPLICATION_CREDENTIALS` or `OPENSTACK_APPLICATION_CREDENTIALS_JSON`.

--- a/docs/deployment/getting_started.md
+++ b/docs/deployment/getting_started.md
@@ -24,7 +24,7 @@ The procedure to provide credentials to access the cloud provider object store v
 
 * For `Azure Blob storage`:
    1. The secret file should be provided, and the file path should be made available as environment variables: `AZURE_APPLICATION_CREDENTIALS` or `AZURE_APPLICATION_CREDENTIALS_JSON`.
-   2. The Azure Blob Storage URI can be overriden by providing the optional field `uri` in the secret file, as can be seen in the [example](../../example/storage-provider-secrets/00-azure-blob-storage-secret.yaml) file.
+   2. The Azure Blob Storage endpoint can be overridden by providing the optional field `storageAPIEndpoint` in the secret file, as can be seen in the [example](../../example/storage-provider-secrets/00-azure-blob-storage-secret.yaml) file.
 
 * For `Openstack Swift`:
   1. The secret file should be provided, and the file path should be made available as environment variables: `OPENSTACK_APPLICATION_CREDENTIALS` or `OPENSTACK_APPLICATION_CREDENTIALS_JSON`.

--- a/example/storage-provider-secrets/00-azure-blob-storage-secret.yaml
+++ b/example/storage-provider-secrets/00-azure-blob-storage-secret.yaml
@@ -7,6 +7,7 @@ type: Opaque
 data: 
   storageAccount: YWRtaW4= # admin
   storageKey: YWRtaW4= # admin
+  # uri: blob.core.windows.net # override the ABS URI
 
 #### OR ####
 

--- a/example/storage-provider-secrets/00-azure-blob-storage-secret.yaml
+++ b/example/storage-provider-secrets/00-azure-blob-storage-secret.yaml
@@ -7,7 +7,7 @@ type: Opaque
 data: 
   storageAccount: YWRtaW4= # admin
   storageKey: YWRtaW4= # admin
-  # uri: blob.core.windows.net # override the ABS URI
+  # storageAPIEndpoint: http[s]://<storage-account>.<domain> # override the ABS endpoint
 
 #### OR ####
 

--- a/example/storage-provider-secrets/00-azure-blob-storage-secret.yaml
+++ b/example/storage-provider-secrets/00-azure-blob-storage-secret.yaml
@@ -7,7 +7,7 @@ type: Opaque
 data: 
   storageAccount: YWRtaW4= # admin
   storageKey: YWRtaW4= # admin
-  # storageAPIEndpoint: http[s]://<storage-account>.<domain> # override the ABS endpoint
+  # domain: blob.core.windows.net # override the ABS domain
 
 #### OR ####
 

--- a/pkg/snapstore/abs_snapstore_test.go
+++ b/pkg/snapstore/abs_snapstore_test.go
@@ -41,7 +41,7 @@ func newFakeABSSnapstore() brtypes.SnapStore {
 		newFakePolicyFactory(bucket, prefixV2, objectMap),
 	}
 	p := pipeline.NewPipeline(f, pipeline.Options{HTTPSender: newFakePolicyFactory(bucket, prefixV2, objectMap)})
-	u, err := url.Parse(fmt.Sprintf("https://%s.%s", "dummyaccount", brtypes.AzureBlobStorageGlobalURI))
+	u, err := url.Parse(fmt.Sprintf("https://%s.%s", "dummyaccount", brtypes.AzureBlobStorageHostName))
 	Expect(err).ShouldNot(HaveOccurred())
 	serviceURL := azblob.NewServiceURL(*u, p)
 	containerURL := serviceURL.NewContainerURL(bucket)

--- a/pkg/snapstore/abs_snapstore_test.go
+++ b/pkg/snapstore/abs_snapstore_test.go
@@ -41,7 +41,7 @@ func newFakeABSSnapstore() brtypes.SnapStore {
 		newFakePolicyFactory(bucket, prefixV2, objectMap),
 	}
 	p := pipeline.NewPipeline(f, pipeline.Options{HTTPSender: newFakePolicyFactory(bucket, prefixV2, objectMap)})
-	u, err := url.Parse(fmt.Sprintf("https://%s.%s", "dummyaccount", brtypes.AzureBlobStorageHostName))
+	u, err := url.Parse(fmt.Sprintf("https://%s.%s", "dummyaccount", brtypes.AzureBlobStorageGlobalURI))
 	Expect(err).ShouldNot(HaveOccurred())
 	serviceURL := azblob.NewServiceURL(*u, p)
 	containerURL := serviceURL.NewContainerURL(bucket)

--- a/pkg/snapstore/abs_snapstore_test.go
+++ b/pkg/snapstore/abs_snapstore_test.go
@@ -41,7 +41,7 @@ func newFakeABSSnapstore() brtypes.SnapStore {
 		newFakePolicyFactory(bucket, prefixV2, objectMap),
 	}
 	p := pipeline.NewPipeline(f, pipeline.Options{HTTPSender: newFakePolicyFactory(bucket, prefixV2, objectMap)})
-	u, err := url.Parse(fmt.Sprintf("https://%s.%s", "dummyaccount", brtypes.AzureBlobStorageHostName))
+	u, err := url.Parse(fmt.Sprintf("https://%s.%s", "dummyaccount", brtypes.AzureBlobStorageGlobalDomain))
 	Expect(err).ShouldNot(HaveOccurred())
 	serviceURL := azblob.NewServiceURL(*u, p)
 	containerURL := serviceURL.NewContainerURL(bucket)

--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -52,8 +52,8 @@ const (
 	// SnapshotKindChunk is constant for chunk snapshot kind.
 	SnapshotKindChunk = "Chunk"
 
-	// AzureBlobStorageHostName is the host name for azure blob storage service.
-	AzureBlobStorageHostName = "blob.core.windows.net"
+	// AzureBlobStorageGlobalURI is the default global URI for azure blob storage.
+	AzureBlobStorageGlobalURI = "blob.core.windows.net"
 
 	// FinalSuffix is the suffix appended to the names of final snapshots.
 	FinalSuffix = ".final"

--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -52,8 +52,8 @@ const (
 	// SnapshotKindChunk is constant for chunk snapshot kind.
 	SnapshotKindChunk = "Chunk"
 
-	// AzureBlobStorageHostName is the host name for azure blob storage service.
-	AzureBlobStorageHostName = "blob.core.windows.net"
+	// AzureBlobStorageGlobalDomain is the default domain for azure blob storage service.
+	AzureBlobStorageGlobalDomain = "blob.core.windows.net"
 
 	// FinalSuffix is the suffix appended to the names of final snapshots.
 	FinalSuffix = ".final"

--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -52,8 +52,8 @@ const (
 	// SnapshotKindChunk is constant for chunk snapshot kind.
 	SnapshotKindChunk = "Chunk"
 
-	// AzureBlobStorageGlobalURI is the default global URI for azure blob storage.
-	AzureBlobStorageGlobalURI = "blob.core.windows.net"
+	// AzureBlobStorageHostName is the host name for azure blob storage service.
+	AzureBlobStorageHostName = "blob.core.windows.net"
 
 	// FinalSuffix is the suffix appended to the names of final snapshots.
 	FinalSuffix = ".final"


### PR DESCRIPTION
**What this PR does / why we need it**:

* Add support to override the domain for ABS in `pkg/snapstore/abs_snapstore.go`.

* Adapt example in `example/storage-provider-secrets/00-azure-blob-storage-secret.yaml` to explain the override feature.

* Enhance documentation to explain the override feature in `docs/deployment/getting_started.md`.

For example if a consumer provides the overriding `domain` as `blob.core.windows.net`, the service URL that is formed will be:

```
https://<storage-account>.blob.core.windows.net
```

Similarly, if the overriding `domain` is provided as `blob.core.chinacloudapi.cn`, then the service URL that is formed will be:

```
https://<storage-account>.blob.core.chinacloudapi.cn
```

**Which issue(s) this PR fixes**:
Fixes #757

**Special notes for your reviewer**:

cc @unmarshall

**Release note**:

```improvement user
The Azure Blob Storage domain can now be overridden by providing the overriding domain as a field in the Secret which provides credentials to etcd-backup-restore
```
