### PR TITLE
Fix the registry link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 VERSION             ?= $(shell cat VERSION)
-REGISTRY            ?= europe-docker.pkg.dev/gardener-project/snapshots
+REGISTRY            ?= europe-docker.pkg.dev/gardener-project/public
 IMAGE_REPOSITORY    := $(REGISTRY)/gardener/etcdbrctl
 IMAGE_TAG           := $(VERSION)
 BUILD_DIR           := build


### PR DESCRIPTION
**What this PR does / why we need it**:

Registry link of etcd-backup-restore is different from what is currently being used in etcd-druid, and this makes development of etcd-backup-restore while using it in etcd-druid slightly painful. Fixing the link here in etcd-backup-restore makes development smoother.

`kind load` operations would be made easier since etcd-druid expects `europe-docker.pkg.dev/gardener-project/public` and the built image of etcd-backup-restore has `europe-docker.pkg.dev/gardener-project/snapshots`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Registry link changed to match the one used elsewhere during development in the gardener org.
```