### PR TITLE
Stop using `*_STORAGE_API_ENDPOINT` environment variables

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
@@ -20,8 +20,8 @@ data:
   {{- if .Values.backup.abs.emulatorEnabled }}
   emulatorEnabled: {{ .Values.backup.abs.emulatorEnabled | b64enc}}
   {{- end }}
-  {{- if .Values.backup.abs.storageAPIEndpoint }}
-  storageAPIEndpoint: {{ .Values.backup.abs.storageAPIEndpoint | b64enc}}
+  {{- if .Values.backup.abs.domain }}
+  domain: {{ .Values.backup.abs.domain | b64enc}}
   {{- end }}
 {{- else if eq .Values.backup.storageProvider "GCS" }}
   serviceaccount.json : {{ .Values.backup.gcs.serviceAccountJson | b64enc }}

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -210,14 +210,6 @@ spec:
 {{- else if eq .Values.backup.storageProvider "GCS" }}
         - name: "GOOGLE_APPLICATION_CREDENTIALS"
           value: "/root/.gcp/serviceaccount.json"
-  {{- if .Values.backup.gcs.storageAPIEndpoint }}
-        - name: "GOOGLE_STORAGE_API_ENDPOINT"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-etcd-backup
-              key: "storageAPIEndpoint"
-              optional: true
-  {{- end }}
   {{- if .Values.backup.gcs.emulatorEnabled }}
         - name: "GOOGLE_EMULATOR_ENABLED"
           valueFrom:

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -199,14 +199,6 @@ spec:
               key: "emulatorEnabled"
               optional: true
   {{- end }}
-  {{- if .Values.backup.abs.storageAPIEndpoint }}
-        - name: "AZURE_STORAGE_API_ENDPOINT"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-etcd-backup
-              key: "storageAPIEndpoint"
-              optional: true
-  {{- end }}
 {{- else if eq .Values.backup.storageProvider "GCS" }}
         - name: "GOOGLE_APPLICATION_CREDENTIALS"
           value: "/root/.gcp/serviceaccount.json"

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -97,8 +97,8 @@ backup:
   # abs:
   #   storageAccount: storage-account-with-object-storage-privileges
   #   storageKey: storage-key-with-object-storage-privileges
+  #   domain: non-default-domain-for-object-storage-service
   #   emulatorEnabled: boolean-float-to-enable-e2e-tests-to-use-azure-emulator # optional
-  #   storageAPIEndpoint: endpoint-override-for-storage-api # if emulatorEnabled is true
   # swift:
   #   authURL: identity-server-url
   #   domainName: domain-name

--- a/docs/deployment/getting_started.md
+++ b/docs/deployment/getting_started.md
@@ -20,7 +20,7 @@ The procedure to provide credentials to access the cloud provider object store v
 * For `Google Cloud Storage`:
    1. The service account json file should be provided in the `~/.gcp` as a `service-account-file.json` file.
    2. The service account json file should be provided, and the file path should be made available as environment variable `GOOGLE_APPLICATION_CREDENTIALS`.
-   3. If using a storage API [endpoint override](https://pkg.go.dev/cloud.google.com/go#hdr-Endpoint_Override), such as a [regional endpoint](https://cloud.google.com/storage/docs/regional-endpoints) or a local GCS emulator endpoint, then the endpoint must be made available via environment variable `GOOGLE_STORAGE_API_ENDPOINT`, in the format `http[s]://host[:port]/storage/v1/`.
+   3. If using a storage API [endpoint override](https://pkg.go.dev/cloud.google.com/go#hdr-Endpoint_Override), such as a [regional endpoint](https://cloud.google.com/storage/docs/regional-endpoints) or a local GCS emulator endpoint, then the endpoint must be made available via a file named `storageAPIEndpoint` residing in the `~/.gcp` directory.
 
 * For `Azure Blob storage`:
    1. The secret file should be provided, and the file path should be made available as an environment variable: `AZURE_APPLICATION_CREDENTIALS`.

--- a/docs/deployment/getting_started.md
+++ b/docs/deployment/getting_started.md
@@ -23,7 +23,8 @@ The procedure to provide credentials to access the cloud provider object store v
    3. If using a storage API [endpoint override](https://pkg.go.dev/cloud.google.com/go#hdr-Endpoint_Override), such as a [regional endpoint](https://cloud.google.com/storage/docs/regional-endpoints) or a local GCS emulator endpoint, then the endpoint must be made available via a file named `storageAPIEndpoint` residing in the `~/.gcp` directory.
 
 * For `Azure Blob storage`:
-   1. The secret file should be provided, and the file path should be made available as an environment variable: `AZURE_APPLICATION_CREDENTIALS`.
+   1. The JSON secret file should be provided, and the file path should be made available as an environment variable: `AZURE_APPLICATION_CREDENTIALS`.
+   2. The Azure Blob Storage domain can be overridden by providing it via an optional field `domain` in the above-mentioned JSON secret file.
 
 * For `Openstack Swift`:
   1. The secret file should be provided, and the file path should be made available as an environment variable: `OPENSTACK_APPLICATION_CREDENTIALS`.

--- a/example/storage-provider-secrets/00-azure-blob-storage-secret.yaml
+++ b/example/storage-provider-secrets/00-azure-blob-storage-secret.yaml
@@ -8,4 +8,4 @@ data:
   storageAccount: YWRtaW4= # admin
   storageKey: YWRtaW4= # admin
   # emulatorEnabled: dHJ1ZQ== # true (optional)
-  # storageAPIEndpoint: aHR0cDovL2F6dXJpdGUtc2VydmljZToxMDAwMA== # http://azurite-service:10000 (optional)
+  # domain: YmxvYi5jb3JlLmNoaW5hY2xvdWRhcGkuY24= # blob.core.chinacloudapi.cn (optional)

--- a/pkg/snapstore/abs_snapstore_test.go
+++ b/pkg/snapstore/abs_snapstore_test.go
@@ -31,7 +31,7 @@ func newFakeABSSnapstore() brtypes.SnapStore {
 		newFakePolicyFactory(bucket, prefixV2, objectMap),
 	}
 	p := pipeline.NewPipeline(f, pipeline.Options{HTTPSender: newFakePolicyFactory(bucket, prefixV2, objectMap)})
-	u, err := url.Parse(fmt.Sprintf("https://%s.%s", "dummyaccount", brtypes.AzureBlobStorageHostName))
+	u, err := url.Parse(fmt.Sprintf("https://%s.%s", "dummyaccount", brtypes.AzureBlobStorageGlobalDomain))
 	Expect(err).ShouldNot(HaveOccurred())
 	serviceURL := azblob.NewServiceURL(*u, p)
 	containerURL := serviceURL.NewContainerURL(bucket)

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -65,10 +65,10 @@ func NewGCSSnapStore(config *brtypes.SnapstoreConfig) (*GCSSnapStore, error) {
 	var opts []option.ClientOption // no need to explicitly set store credentials here since the Google SDK picks it up from the standard environment variable
 
 	if gcsApplicationCredentialsPath, isSet := os.LookupEnv(getEnvPrefixString(config.IsSource) + envStoreCredentials); isSet {
-		endpointFilePath := path.Join(path.Dir(gcsApplicationCredentialsPath), storageAPIEndpointFileName)
-		endpoint, err := getGCSStorageAPIEndpoint(endpointFilePath)
+		storageAPIEndpointFilePath := path.Join(path.Dir(gcsApplicationCredentialsPath), storageAPIEndpointFileName)
+		endpoint, err := getGCSStorageAPIEndpoint(storageAPIEndpointFilePath)
 		if err != nil {
-			return nil, fmt.Errorf("error getting storage API endpoint from %v", endpointFilePath)
+			return nil, fmt.Errorf("error getting storage API endpoint from %v", storageAPIEndpointFilePath)
 		}
 		if endpoint != "" {
 			opts = append(opts, option.WithEndpoint(endpoint))
@@ -329,8 +329,7 @@ func (s *GCSSnapStore) Delete(snap brtypes.Snapshot) error {
 // GetGCSCredentialsLastModifiedTime returns the latest modification timestamp of the GCS credential file
 func GetGCSCredentialsLastModifiedTime() (time.Time, error) {
 	if credentialsFilePath, isSet := os.LookupEnv(envStoreCredentials); isSet {
-		endpointFilePath := path.Join(path.Dir(credentialsFilePath), storageAPIEndpointFileName)
-		credentialFiles := []string{credentialsFilePath, endpointFilePath}
+		credentialFiles := []string{credentialsFilePath}
 		gcsTimeStamp, err := getLatestCredentialsModifiedTime(credentialFiles)
 		if err != nil {
 			return time.Time{}, fmt.Errorf("failed to fetch file information of the GCS JSON credential dir %v with error: %v", path.Dir(credentialsFilePath), err)

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -109,9 +109,10 @@ func getGCSStorageAPIEndpoint(path string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if len(data) != 0 {
-			return strings.TrimSpace(string(data)), nil
+		if len(data) == 0 {
+			return "", fmt.Errorf("file %s is empty", path)
 		}
+		return strings.TrimSpace(string(data)), nil
 	}
 
 	// support falling back to environment variable `GOOGLE_STORAGE_API_ENDPOINT`

--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -42,8 +42,8 @@ const (
 	// SnapshotKindChunk is constant for chunk snapshot kind.
 	SnapshotKindChunk = "Chunk"
 
-	// AzureBlobStorageHostName is the host name for azure blob storage service.
-	AzureBlobStorageHostName = "blob.core.windows.net"
+	// AzureBlobStorageGlobalDomain is the default domain for azure blob storage service.
+	AzureBlobStorageGlobalDomain = "blob.core.windows.net"
 
 	// FinalSuffix is the suffix appended to the names of final snapshots.
 	FinalSuffix = ".final"


### PR DESCRIPTION
**What this PR does / why we need it**:
As mentioned in #727, it is not secure to be passing credential (secret) information to the etcdbr process via environment variables. This is ok while running locally, but when running on a k8s cluster (deployed by etcd-druid), it becomes important for etcdbrctl to be able to fetch the information about endpoint overrides directly from the mounted secret file, where the other default credentials already exist today.

This PR does two things:
1. For provider GCP, adds support for specifying `storageAPIEndpoint` via file path, while still supporting the environment variable `GOOGLE_STORAGE_API_ENDPOINT` env var (for users who may already be using it.
2. For provider Azure, removes support for `AZURE_STORAGE_API_ENDPOINT` and now uses field `domain`, in-line with #756 . This now allows users to use custom domains for accessing special Azure region services, like [this](https://learn.microsoft.com/en-us/azure/china/resources-developer-guide).

**Which issue(s) this PR fixes**:
Fixes #727 

**Special notes for your reviewer**:
/assign @renormalize @unmarshall 
/cc @AleksandarSavchev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Add support for specifying Google storage API endpoint via file `~/.gcp/storageAPIEndpoint`. Environment variable `GOOGLE_STORAGE_API_ENDPOINT` is deprecated, and will be removed shortly.
```
```improvement user
Add support for specifying custom domains for Azure storage. 
```
```action user
Remove support for specifying Azure custom endpoint via environment variable `AZURE_STORAGE_API_ENDPOINT`. Please use the new `domain` field (via JSON or file) instead.
```