### PR TITLE
Fix a detection for a single member restoration when snapstore is not configured for zeroth pod.

### DIFF
--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/gardener/etcd-backup-restore/pkg/errors"
@@ -48,15 +47,12 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 	ctx := context.Background()
 	var err error
 
-	podName, err := miscellaneous.GetEnvVarOrError("POD_NAME")
 	if err != nil {
 		logger.Fatalf("Error reading POD_NAME env var : %v", err)
 	}
 
 	// Etcd cluster scale-up case
-	// Note: first member of etcd cluster can never be part of scale-up case.
-	// TODO: consider removing this special check for first cluster member when backup-restore can check presence of any member in cluster.
-	if miscellaneous.IsMultiNode(logger) && !strings.HasSuffix(podName, "0") {
+	if miscellaneous.IsMultiNode(logger) {
 		clientSet, err := miscellaneous.GetKubernetesClientSetOrError()
 		if err != nil {
 			logger.Fatalf("failed to create clientset, %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will fix a bug in detection of a single member restoration case when snapstore is not configured for zeroth pod.

**Which issue(s) this PR fixes**:
Fixes #760 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bugfix operator
Fixed a bug in detecting single member restoration scenario for the zeroth pod and when no storage provider for backups is configured.
```

