### PR TITLE
[Cherry-pick #765] Retry to take full snapshot if prev full snapshot fails due to any reason.

### DIFF
--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -109,6 +109,7 @@ type Snapshotter struct {
 	K8sClientset                 client.Client
 	snapstoreConfig              *brtypes.SnapstoreConfig
 	lastSecretModifiedTime       time.Time
+	PrevFullSnapshotSucceeded    bool
 }
 
 // NewSnapshotter returns the snapshotter object.
@@ -149,25 +150,26 @@ func NewSnapshotter(logger *logrus.Entry, config *brtypes.SnapshotterConfig, sto
 	}
 
 	return &Snapshotter{
-		logger:               logger.WithField("actor", "snapshotter"),
-		store:                store,
-		config:               config,
-		etcdConnectionConfig: etcdConnectionConfig,
-		compressionConfig:    compressionConfig,
-		HealthConfig:         healthConfig,
-		schedule:             sdl,
-		PrevSnapshot:         prevSnapshot,
-		PrevFullSnapshot:     fullSnap,
-		PrevDeltaSnapshots:   deltaSnapList,
-		SsrState:             brtypes.SnapshotterInactive,
-		SsrStateMutex:        &sync.Mutex{},
-		fullSnapshotReqCh:    make(chan bool),
-		deltaSnapshotReqCh:   make(chan struct{}),
-		fullSnapshotAckCh:    make(chan result),
-		deltaSnapshotAckCh:   make(chan result),
-		cancelWatch:          func() {},
-		K8sClientset:         clientSet,
-		snapstoreConfig:      storeConfig,
+		logger:                    logger.WithField("actor", "snapshotter"),
+		store:                     store,
+		config:                    config,
+		etcdConnectionConfig:      etcdConnectionConfig,
+		compressionConfig:         compressionConfig,
+		HealthConfig:              healthConfig,
+		schedule:                  sdl,
+		PrevSnapshot:              prevSnapshot,
+		PrevFullSnapshot:          fullSnap,
+		PrevDeltaSnapshots:        deltaSnapList,
+		SsrState:                  brtypes.SnapshotterInactive,
+		SsrStateMutex:             &sync.Mutex{},
+		fullSnapshotReqCh:         make(chan bool),
+		deltaSnapshotReqCh:        make(chan struct{}),
+		fullSnapshotAckCh:         make(chan result),
+		deltaSnapshotAckCh:        make(chan result),
+		cancelWatch:               func() {},
+		K8sClientset:              clientSet,
+		snapstoreConfig:           storeConfig,
+		PrevFullSnapshotSucceeded: true,
 	}, nil
 }
 
@@ -648,8 +650,10 @@ func (ssr *Snapshotter) snapshotEventHandler(stopCh <-chan struct{}) error {
 			}
 			ssr.fullSnapshotAckCh <- res
 			if err != nil {
+				ssr.PrevFullSnapshotSucceeded = false
 				return err
 			}
+			ssr.PrevFullSnapshotSucceeded = true
 			if ssr.HealthConfig.SnapshotLeaseRenewalEnabled {
 				ssr.FullSnapshotLeaseUpdateTimer.Stop()
 				ssr.FullSnapshotLeaseUpdateTimer.Reset(time.Nanosecond)
@@ -675,8 +679,10 @@ func (ssr *Snapshotter) snapshotEventHandler(stopCh <-chan struct{}) error {
 
 		case <-ssr.fullSnapshotTimer.C:
 			if _, err := ssr.TakeFullSnapshotAndResetTimer(false); err != nil {
+				ssr.PrevFullSnapshotSucceeded = false
 				return err
 			}
+			ssr.PrevFullSnapshotSucceeded = true
 			if ssr.HealthConfig.SnapshotLeaseRenewalEnabled {
 				ssr.FullSnapshotLeaseUpdateTimer.Stop()
 				ssr.FullSnapshotLeaseUpdateTimer.Reset(time.Nanosecond)
@@ -764,7 +770,7 @@ func (ssr *Snapshotter) hasSnapStoreSecretUpdated() (bool, error) {
 
 // IsFullSnapshotRequiredAtStartup checks whether to take a full snapshot or not during the startup of backup-restore.
 func (ssr *Snapshotter) IsFullSnapshotRequiredAtStartup(timeWindow float64) bool {
-	if ssr.PrevFullSnapshot == nil || ssr.PrevFullSnapshot.IsFinal || time.Since(ssr.PrevFullSnapshot.CreatedOn).Hours() > timeWindow {
+	if ssr.PrevFullSnapshot == nil || ssr.PrevFullSnapshot.IsFinal || time.Since(ssr.PrevFullSnapshot.CreatedOn).Hours() > timeWindow || !ssr.PrevFullSnapshotSucceeded {
 		return true
 	}
 

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -790,6 +790,22 @@ var _ = Describe("Snapshotter", func() {
 				})
 			})
 
+			Context("Previous full snapshot was not successful", func() {
+				It("should return true", func() {
+					snapshotterConfig := &brtypes.SnapshotterConfig{
+						FullSnapshotSchedule: fmt.Sprintf("%d %d * * *", (currentMin+1)%60, (currentHour+2)%24),
+					}
+
+					ssr, err = NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					// previous full snapshot wasn't successful
+					ssr.PrevFullSnapshotSucceeded = false
+					isFullSnapMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
+					Expect(isFullSnapMissed).Should(BeTrue())
+				})
+			})
+
 			Context("Previous full snapshot was taken exactly at scheduled snapshot time, no FullSnapshot was missed", func() {
 				It("should return false", func() {
 					snapshotterConfig := &brtypes.SnapshotterConfig{
@@ -803,6 +819,7 @@ var _ = Describe("Snapshotter", func() {
 					ssr.PrevFullSnapshot = &brtypes.Snapshot{
 						CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day()-1, (currentHour+2)%24, (currentMin+1)%60, 0, 0, time.Local),
 					}
+					ssr.PrevFullSnapshotSucceeded = true
 
 					isFullSnapMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
 					Expect(isFullSnapMissed).Should(BeFalse())
@@ -823,6 +840,7 @@ var _ = Describe("Snapshotter", func() {
 					ssr.PrevFullSnapshot = &brtypes.Snapshot{
 						CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), (currentHour-4)%24, (currentMin-10)%60, 0, 0, time.Local),
 					}
+					ssr.PrevFullSnapshotSucceeded = true
 					isFullSnapCanBeMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
 					Expect(isFullSnapCanBeMissed).Should(BeFalse())
 				})
@@ -842,6 +860,7 @@ var _ = Describe("Snapshotter", func() {
 					ssr.PrevFullSnapshot = &brtypes.Snapshot{
 						CreatedOn: time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), (currentHour-18)%24, (currentMin)%60, 0, 0, time.Local),
 					}
+					ssr.PrevFullSnapshotSucceeded = true
 					isFullSnapCanBeMissed := ssr.IsFullSnapshotRequiredAtStartup(fullSnapshotTimeWindow)
 					Expect(isFullSnapCanBeMissed).Should(BeTrue())
 				})


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick PR : https://github.com/gardener/etcd-backup-restore/pull/765

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Retry to take full snapshot if the previous full snapshot operation fails.
```
