### PR TITLE
[Cherry-pick #765] Retry to take full snapshot if prev full snapshot fails due to any reason.

### DIFF
--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -412,14 +412,17 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 			if !initialDeltaSnapshotTaken {
 				// need to take a full snapshot here
 				// if initial deltaSnapshot is not taken
+				// or previous full snapshot wasn't successful
 				var snapshot *brtypes.Snapshot
 				metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: brtypes.SnapshotKindDelta}).Set(0)
 				metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: brtypes.SnapshotKindFull}).Set(1)
 				if snapshot, err = ssr.TakeFullSnapshotAndResetTimer(false); err != nil {
 					metrics.SnapshotterOperationFailure.With(prometheus.Labels{metrics.LabelError: err.Error()}).Inc()
-					b.logger.Errorf("Failed to take substitute first full snapshot: %v", err)
+					ssr.PrevFullSnapshotSucceeded = false
+					b.logger.Errorf("Failed to take substitute full snapshot: %v", err)
 					continue
 				}
+				ssr.PrevFullSnapshotSucceeded = true
 				if b.config.HealthConfig.SnapshotLeaseRenewalEnabled {
 					leaseUpdatectx, cancel := context.WithTimeout(ctx, brtypes.LeaseUpdateTimeoutDuration)
 					defer cancel()


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick PR : https://github.com/gardener/etcd-backup-restore/pull/765

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Retry to take full snapshot if the previous full snapshot operation fails.
```
