### PR TITLE
Removed useless error handling.

### DIFF
--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -45,11 +45,6 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 	start := time.Now()
 	memberHeartbeatPresent := false
 	ctx := context.Background()
-	var err error
-
-	if err != nil {
-		logger.Fatalf("Error reading POD_NAME env var : %v", err)
-	}
 
 	// Etcd cluster scale-up case
 	if miscellaneous.IsMultiNode(logger) {


### PR DESCRIPTION
**What this PR does / why we need it**:
I forgot to remove this err handling in this PR: https://github.com/gardener/etcd-backup-restore/pull/761

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
None
```
