### PR TITLE
Add `Bucket Lock` immutable object support for Google Cloud Storage.

### DIFF
--- a/docs/usage/immutable_snapshots.md
+++ b/docs/usage/immutable_snapshots.md
@@ -1,0 +1,29 @@
+# Immutable Snapshots
+
+## Overview of Immutable Objects
+
+Several cloud providers offer functionality to create immutable objects within their storage services. Once an object is uploaded, it cannot be modified or deleted for a set period, known as the **immutability period**. These are referred to as **immutable objects**.
+
+Currently, etcd-backup-restore enables the use of immutable objects on the following cloud platforms:
+
+- Google Cloud Storage  (currently supported)
+
+## Enabling and Using Immutable Snapshots with etcd-backup-restore
+
+Etcd-backup-restore supports immutable objects, typically at what cloud providers call the "bucket level." During the creation of a bucket, it is configured to render objects immutable for a specific duration from the moment of their upload. This feature can be enabled through:
+
+- **Google Cloud Storage**: [Bucket Lock](https://cloud.google.com/storage/docs/bucket-lock)
+
+It is also possible to enable immutability retroactively by making appropriate API calls to your cloud provider, allowing the immutable snapshots feature to be used with existing buckets. For information on such configurations, please refer to your cloud provider's documentation.
+
+The behavior of objects uploaded before a bucket is set to immutable varies among providers. Etcd-backup-restore manages these objects and will perform garbage collection according to the configured policy and the object's immutability expiry.
+
+## Current Capabilities
+
+Etcd-backup-restore does not require configurations regarding the immutability period of an object since this is inherited from the bucket’s immutability settings. The tool also checks the immutability expiry of an object before initiating its garbage collection.
+
+Therefore, it is advisable to configure your garbage collection policies based on the duration you want your objects to remain immutable.
+
+## Storage Considerations
+
+Making objects immutable for extended periods can increase storage costs since these objects cannot be removed once uploaded. Storing outdated snapshots beyond their utility does not significantly enhance recovery capabilities. Therefore, consider all factors before enabling immutability for buckets, as this feature is irreversible once set by cloud providers.

--- a/docs/usage/immutable_snapshots.md
+++ b/docs/usage/immutable_snapshots.md
@@ -4,11 +4,11 @@
 
 Several cloud providers offer functionality to create immutable objects within their storage services. Once an object is uploaded, it cannot be modified or deleted for a set period, known as the **immutability period**. These are referred to as **immutable objects**.
 
-Currently, etcd-backup-restore enables the use of immutable objects on the following cloud platforms:
+Currently, etcd-backup-restore supports the use of immutable objects on the following cloud platforms:
 
 - Google Cloud Storage  (currently supported)
 
-## Enabling and Using Immutable Snapshots with etcd-backup-restore
+## Enabling and using Immutable Snapshots with etcd-backup-restore
 
 Etcd-backup-restore supports immutable objects, typically at what cloud providers call the "bucket level." During the creation of a bucket, it is configured to render objects immutable for a specific duration from the moment of their upload. This feature can be enabled through:
 
@@ -16,11 +16,13 @@ Etcd-backup-restore supports immutable objects, typically at what cloud provider
 
 It is also possible to enable immutability retroactively by making appropriate API calls to your cloud provider, allowing the immutable snapshots feature to be used with existing buckets. For information on such configurations, please refer to your cloud provider's documentation.
 
-The behavior of objects uploaded before a bucket is set to immutable varies among providers. Etcd-backup-restore manages these objects and will perform garbage collection according to the configured policy and the object's immutability expiry.
+The behaviour of bucket's objects uploaded before a bucket is set to immutable varies among storage providers. Etcd-backup-restore manages these objects and will perform garbage collection according to the configured garbage collection policy and the object's immutability expiry.
+
+> Note: If immutable snapshots are not enabled then the object's immutability expiry will be considered as zero, hence causing no effect on current functionality.
 
 ## Current Capabilities
 
-Etcd-backup-restore does not require configurations regarding the immutability period of an object since this is inherited from the bucket’s immutability settings. The tool also checks the immutability expiry of an object before initiating its garbage collection.
+Etcd-backup-restore does not require configurations related to the immutability period of bucket's objects as this information is derived from the bucket's existing immutability settings. The etcd-backup-restore process also verifies the immutability expiry time of an object prior to initiating its garbage collection.
 
 Therefore, it is advisable to configure your garbage collection policies based on the duration you want your objects to remain immutable.
 

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Running Compactor", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				// Check if the compacted full snapshot is really present
-				snapList, err := store.List()
+				snapList, err := store.List(false)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				compactedSnapshot = snapList[len(snapList)-1]
@@ -210,7 +210,7 @@ var _ = Describe("Running Compactor", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				// Check if the compacted full snapshot is really present
-				snapList, err := store.List()
+				snapList, err := store.List(false)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				compactedSnapshot = snapList[len(snapList)-1]

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -62,7 +62,7 @@ func GetLatestFullSnapshotAndDeltaSnapList(store brtypes.SnapStore) (*brtypes.Sn
 		fullSnapshot  *brtypes.Snapshot
 		deltaSnapList brtypes.SnapList
 	)
-	snapList, err := store.List()
+	snapList, err := store.List(false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -97,7 +97,7 @@ type backup struct {
 // GetFilteredBackups returns sorted by date (new -> old) SnapList. It will also filter the snapshots that should be included or not using the filter function.
 // If the filter is nil it will return all snapshots. Also, maxBackups can be used to target only the last N snapshots (-1 = all).
 func GetFilteredBackups(store brtypes.SnapStore, maxBackups int, filter func(snaps brtypes.Snapshot) bool) (brtypes.SnapList, error) {
-	snapList, err := store.List()
+	snapList, err := store.List(false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -817,7 +817,7 @@ func NewDummyStore(snapList brtypes.SnapList) DummyStore {
 	return DummyStore{SnapList: snapList}
 }
 
-func (ds *DummyStore) List() (brtypes.SnapList, error) {
+func (ds *DummyStore) List(_ bool) (brtypes.SnapList, error) {
 	return ds.SnapList, nil
 }
 

--- a/pkg/snapshot/copier/copier.go
+++ b/pkg/snapshot/copier/copier.go
@@ -123,7 +123,7 @@ func (c *Copier) copyBackups() error {
 
 	// Get destination snapshots and build a map keyed by name
 	c.logger.Info("Getting destination snapshots...")
-	destSnapshots, err := c.destSnapStore.List()
+	destSnapshots, err := c.destSnapStore.List(false)
 	if err != nil {
 		return fmt.Errorf("could not get destination snapshots: %v", err)
 	}

--- a/pkg/snapshot/snapshotter/garbagecollector.go
+++ b/pkg/snapshot/snapshotter/garbagecollector.go
@@ -140,7 +140,7 @@ func (ssr *Snapshotter) RunGarbageCollector(stopCh <-chan struct{}) {
 					}
 
 					if deleteSnap {
-						if nextSnap.IsImmutable() {
+						if !nextSnap.IsDeletable() {
 							ssr.logger.Infof("GC: Skipping : %s, since it is immutable", nextSnap.SnapName)
 							continue
 						}
@@ -253,7 +253,7 @@ func (ssr *Snapshotter) GarbageCollectDeltaSnapshots(snapStream brtypes.SnapList
 
 			snapPath := path.Join(snapStream[i].SnapDir, snapStream[i].SnapName)
 			ssr.logger.Infof("GC: Deleting old delta snapshot: %s", snapPath)
-			if snapStream[i].IsImmutable() {
+			if !snapStream[i].IsDeletable() {
 				ssr.logger.Infof("GC: Skipping : %s, since it is immutable", snapPath)
 				continue
 			}

--- a/pkg/snapshot/snapshotter/garbagecollector.go
+++ b/pkg/snapshot/snapshotter/garbagecollector.go
@@ -41,7 +41,8 @@ func (ssr *Snapshotter) RunGarbageCollector(stopCh <-chan struct{}) {
 
 			total := 0
 			ssr.logger.Info("GC: Executing garbage collection...")
-			snapList, err := ssr.store.List()
+			// List the tagged snapshots to garbage collect them
+			snapList, err := ssr.store.List(true)
 			if err != nil {
 				metrics.SnapshotterOperationFailure.With(prometheus.Labels{metrics.LabelError: err.Error()}).Inc()
 				ssr.logger.Warnf("GC: Failed to list snapshots: %v", err)

--- a/pkg/snapshot/snapshotter/garbagecollector.go
+++ b/pkg/snapshot/snapshotter/garbagecollector.go
@@ -143,7 +143,7 @@ func (ssr *Snapshotter) RunGarbageCollector(stopCh <-chan struct{}) {
 
 					if deleteSnap {
 						if !nextSnap.IsDeletable() {
-							ssr.logger.Infof("GC: Skipping the snapshot: %s, since its retention period hasn't expired yet", nextSnap.SnapName)
+							ssr.logger.Infof("GC: Skipping the snapshot: %s, since its immutability period hasn't expired yet", nextSnap.SnapName)
 							continue
 						}
 						ssr.logger.Infof("GC: Deleting old full snapshot: %s %v", nextSnap.CreatedOn.UTC(), deleteSnap)
@@ -223,7 +223,7 @@ func (ssr *Snapshotter) GarbageCollectChunks(snapList brtypes.SnapList) (int, br
 		// delete the chunk object
 		snapPath := path.Join(snap.SnapDir, snap.SnapName)
 		if !snap.IsDeletable() {
-			ssr.logger.Infof("GC: Skipping : %s, since it is immutable", snap.SnapName)
+			ssr.logger.Infof("GC: Skipping the snapshot: %s, since its immutability period hasn't expired yet", snap.SnapName)
 			continue
 		}
 		ssr.logger.Infof("GC: Deleting chunk for old snapshot: %s", snapPath)
@@ -260,7 +260,7 @@ func (ssr *Snapshotter) GarbageCollectDeltaSnapshots(snapStream brtypes.SnapList
 			snapPath := path.Join(snapStream[i].SnapDir, snapStream[i].SnapName)
 			ssr.logger.Infof("GC: Deleting old delta snapshot: %s", snapPath)
 			if !snapStream[i].IsDeletable() {
-				ssr.logger.Infof("GC: Skipping : %s, since it is immutable", snapPath)
+				ssr.logger.Infof("GC: Skipping the snapshot: %s, since its immutability period hasn't expired yet", snapPath)
 				continue
 			}
 			if err := ssr.store.Delete(*snapStream[i]); err != nil {

--- a/pkg/snapshot/snapshotter/garbagecollector.go
+++ b/pkg/snapshot/snapshotter/garbagecollector.go
@@ -41,7 +41,7 @@ func (ssr *Snapshotter) RunGarbageCollector(stopCh <-chan struct{}) {
 
 			total := 0
 			ssr.logger.Info("GC: Executing garbage collection...")
-			// List the tagged snapshots to garbage collect them
+			// List all (tagged and untagged) snapshots to garbage collect them according to the garbage collection policy.
 			snapList, err := ssr.store.List(true)
 			if err != nil {
 				metrics.SnapshotterOperationFailure.With(prometheus.Labels{metrics.LabelError: err.Error()}).Inc()
@@ -63,7 +63,7 @@ func (ssr *Snapshotter) RunGarbageCollector(stopCh <-chan struct{}) {
 			} else {
 				// chunksDeleted stores the no of chunks deleted in the current iteration of GC.
 				var chunksDeleted int
-				// GarbageCollectChunks returns a filtered SnapList which does not contain chunks
+				// GarbageCollectChunks returns a filtered SnapList which does not contain chunks.
 				chunksDeleted, snapList = ssr.GarbageCollectChunks(snapList)
 				ssr.logger.Infof("GC: Total number garbage collected chunks: %d", chunksDeleted)
 			}
@@ -143,7 +143,7 @@ func (ssr *Snapshotter) RunGarbageCollector(stopCh <-chan struct{}) {
 
 					if deleteSnap {
 						if !nextSnap.IsDeletable() {
-							ssr.logger.Infof("GC: Skipping : %s, since it is immutable", nextSnap.SnapName)
+							ssr.logger.Infof("GC: Skipping the snapshot: %s, since its retention period hasn't expired yet", nextSnap.SnapName)
 							continue
 						}
 						ssr.logger.Infof("GC: Deleting old full snapshot: %s %v", nextSnap.CreatedOn.UTC(), deleteSnap)

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Snapshotter", func() {
 				defer cancel()
 				err = ssr.Run(ctx.Done(), true)
 				Expect(err).Should(HaveOccurred())
-				list, err := store.List()
+				list, err := store.List(false)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(len(list)).Should(BeZero())
 			})
@@ -172,7 +172,7 @@ var _ = Describe("Snapshotter", func() {
 				})
 
 				It("should not take any snapshot", func() {
-					list, err := store.List()
+					list, err := store.List(false)
 					count := 0
 					for _, snap := range list {
 						if snap.Kind == brtypes.SnapshotKindFull {
@@ -225,7 +225,7 @@ var _ = Describe("Snapshotter", func() {
 						defer cancel()
 						err = ssr.Run(ctx.Done(), true)
 						Expect(err).ShouldNot(HaveOccurred())
-						list, err := store.List()
+						list, err := store.List(false)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(len(list)).ShouldNot(BeZero())
 						for _, snapshot := range list {
@@ -286,7 +286,7 @@ var _ = Describe("Snapshotter", func() {
 							ssrCtx := utils.ContextWithWaitGroup(testCtx, wg)
 							err = ssr.Run(ssrCtx.Done(), false)
 							Expect(err).ShouldNot(HaveOccurred())
-							list, err := store.List()
+							list, err := store.List(false)
 							Expect(err).ShouldNot(HaveOccurred())
 							Expect(len(list)).ShouldNot(BeZero())
 							Expect(list[0].Kind).Should(Equal(brtypes.SnapshotKindDelta))
@@ -320,7 +320,7 @@ var _ = Describe("Snapshotter", func() {
 							err = ssr.Run(ssrCtx.Done(), true)
 
 							Expect(err).ShouldNot(HaveOccurred())
-							list, err := store.List()
+							list, err := store.List(false)
 							Expect(err).ShouldNot(HaveOccurred())
 							Expect(len(list)).ShouldNot(BeZero())
 							Expect(list[0].Kind).Should(Equal(brtypes.SnapshotKindFull))
@@ -373,7 +373,7 @@ var _ = Describe("Snapshotter", func() {
 				defer cancel()
 				ssr.RunGarbageCollector(gcCtx.Done())
 
-				list, err := store.List()
+				list, err := store.List(false)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(len(list)).Should(Equal(len(expectedSnapList)))
 
@@ -403,7 +403,7 @@ var _ = Describe("Snapshotter", func() {
 				defer cancel()
 				ssr.RunGarbageCollector(gcCtx.Done())
 
-				list, err := store.List()
+				list, err := store.List(false)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				incr := false
@@ -449,7 +449,7 @@ var _ = Describe("Snapshotter", func() {
 				Context("with all delta snapshots older than retention period", func() {
 					It("should delete all delta snapshots", func() {
 						store := prepareStoreWithDeltaSnapshots(testDir, deltaSnapshotCount)
-						list, err := store.List()
+						list, err := store.List(false)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(len(list)).Should(Equal(deltaSnapshotCount))
 
@@ -460,7 +460,7 @@ var _ = Describe("Snapshotter", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(deleted).To(Equal(deltaSnapshotCount))
 
-						list, err = store.List()
+						list, err = store.List(false)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(len(list)).Should(BeZero())
 					})
@@ -469,7 +469,7 @@ var _ = Describe("Snapshotter", func() {
 				Context("with no delta snapshots", func() {
 					It("should not delete any snapshots", func() {
 						store := prepareStoreWithDeltaSnapshots(testDir, 0)
-						list, err := store.List()
+						list, err := store.List(false)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(len(list)).Should(BeZero())
 
@@ -481,7 +481,7 @@ var _ = Describe("Snapshotter", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(deleted).Should(BeZero())
 
-						list, err = store.List()
+						list, err = store.List(false)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(len(list)).Should(BeZero())
 					})
@@ -490,7 +490,7 @@ var _ = Describe("Snapshotter", func() {
 				Context("with all delta snapshots younger than retention period", func() {
 					It("should not delete any snapshots", func() {
 						store := prepareStoreWithDeltaSnapshots(testDir, deltaSnapshotCount)
-						list, err := store.List()
+						list, err := store.List(false)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(len(list)).Should(Equal(6))
 
@@ -502,7 +502,7 @@ var _ = Describe("Snapshotter", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(deleted).Should(BeZero())
 
-						list, err = store.List()
+						list, err = store.List(false)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(len(list)).Should(Equal(deltaSnapshotCount))
 					})
@@ -511,7 +511,7 @@ var _ = Describe("Snapshotter", func() {
 				Context("with a mix of delta snapshots, some older and some younger than retention period", func() {
 					It("should delete only the delta snapshots older than the retention period", func() {
 						store := prepareStoreWithDeltaSnapshots(testDir, deltaSnapshotCount)
-						list, err := store.List()
+						list, err := store.List(false)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(len(list)).Should(Equal(6))
 
@@ -523,7 +523,7 @@ var _ = Describe("Snapshotter", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(deleted).To(Equal(3))
 
-						list, err = store.List()
+						list, err = store.List(false)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(len(list)).Should(Equal(3))
 					})
@@ -565,7 +565,7 @@ var _ = Describe("Snapshotter", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(chunkCount).To(BeZero())
 
-						list, err := store.List()
+						list, err := store.List(false)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(len(list)).To(BeZero())
 
@@ -585,7 +585,7 @@ var _ = Describe("Snapshotter", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(chunkCount).To(Equal(4))
 
-						list, err := store.List()
+						list, err := store.List(false)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(len(list)).To(Equal(4))
 
@@ -621,7 +621,7 @@ var _ = Describe("Snapshotter", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(chunkCount).To(Equal(9))
 
-						list, err := store.List()
+						list, err := store.List(false)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(len(list)).To(Equal(10))
 
@@ -658,7 +658,7 @@ var _ = Describe("Snapshotter", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(chunkCount).To(Equal(9))
 
-						list, err := store.List()
+						list, err := store.List(false)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(len(list)).To(Equal(10))
 
@@ -695,7 +695,7 @@ var _ = Describe("Snapshotter", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(chunkCount).To(BeZero())
 
-						list, err := store.List()
+						list, err := store.List(false)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(len(list)).To(Equal(3))
 
@@ -1266,7 +1266,7 @@ func addObjectsToStore(store brtypes.SnapStore, objectType string, kind string, 
 
 // getObjectCount returns counts of chunk and composite objects in the store
 func getObjectCount(store brtypes.SnapStore) (int, int, error) {
-	list, err := store.List()
+	list, err := store.List(false)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -308,7 +308,6 @@ func (a *ABSSnapStore) List(_ bool) (brtypes.SnapList, error) {
 				if err != nil {
 					logrus.Warnf("Invalid snapshot found. Ignoring it:%s\n", *blobItem.Name)
 				} else {
-					// a := blob.BlobTags.BlobTagSet[0].Key
 					snapList = append(snapList, s)
 				}
 			}

--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -284,7 +284,7 @@ func (a *ABSSnapStore) Fetch(snap brtypes.Snapshot) (io.ReadCloser, error) {
 }
 
 // List will return sorted list with all snapshot files on store.
-func (a *ABSSnapStore) List() (brtypes.SnapList, error) {
+func (a *ABSSnapStore) List(_ bool) (brtypes.SnapList, error) {
 	prefixTokens := strings.Split(a.prefix, "/")
 	// Last element of the tokens is backup version
 	// Consider the parent of the backup version level (Required for Backward Compatibility)

--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -308,6 +308,7 @@ func (a *ABSSnapStore) List() (brtypes.SnapList, error) {
 				if err != nil {
 					logrus.Warnf("Invalid snapshot found. Ignoring it:%s\n", *blobItem.Name)
 				} else {
+					// a := blob.BlobTags.BlobTagSet[0].Key
 					snapList = append(snapList, s)
 				}
 			}

--- a/pkg/snapstore/failed_snapstore.go
+++ b/pkg/snapstore/failed_snapstore.go
@@ -32,7 +32,7 @@ func (f *FailedSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
 }
 
 // List will list the snapshots from store
-func (f *FailedSnapStore) List() (brtypes.SnapList, error) {
+func (f *FailedSnapStore) List(_ bool) (brtypes.SnapList, error) {
 	var snapList brtypes.SnapList
 	return snapList, fmt.Errorf("failed to list the snapshots")
 }

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -305,7 +305,7 @@ func (s *GCSSnapStore) List(includeAll bool) (brtypes.SnapList, error) {
 
 		// Check if the snapshot should be ignored
 		if !includeAll && attr.Metadata[brtypes.ExcludeSnapshotMetadataKey] == "true" {
-			logrus.Infof("Ignoring snapshot due to exclude metadata: %s", attr.Name)
+			logrus.Infof("Ignoring snapshot due to exclude tag %q present in metadata on snapshot: %s", brtypes.ExcludeSnapshotMetadataKey, attr.Name)
 			continue
 		}
 		attrs = append(attrs, attr)

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -303,8 +303,8 @@ func (s *GCSSnapStore) List(includeTagged bool) (brtypes.SnapList, error) {
 			return nil, err
 		}
 
-		// Check if the snapshot should be ignored.
-		if attr.Metadata[brtypes.ExcludeSnapshotMetadataKey] == "true" {
+		// Check if the snapshot should be ignored
+		if !includeTagged && attr.Metadata[brtypes.ExcludeSnapshotMetadataKey] == "true" {
 			logrus.Infof("Ignoring snapshot due to exclude metadata: %s", attr.Name)
 			continue
 		}

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -319,7 +319,7 @@ func (s *GCSSnapStore) List(includeAll bool) (brtypes.SnapList, error) {
 				logrus.Warnf("Invalid snapshot %s found, ignoring it: %v", v.Name, err)
 				continue
 			}
-			snap.RetentionExpiry = v.RetentionExpirationTime
+			snap.ImmutabilityExpiryTime = v.RetentionExpirationTime
 			snapList = append(snapList, snap)
 		}
 	}

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -283,7 +283,7 @@ func (s *GCSSnapStore) componentUploader(wg *sync.WaitGroup, stopCh <-chan struc
 	}
 }
 
-// List will return a sorted list with all snapshot files on store, excluding those marked with x-ignore-etcd-snapshot-exclude. Tagged snapshots can be included in the List call by passing true as the argument.
+// List returns a sorted list of all snapshot files in the object store, excluding those snapshots tagged with `x-ignore-etcd-snapshot-exclude` in their object metadata/tags. To include these tagged snapshots in the List output, pass `true` as the argument.
 func (s *GCSSnapStore) List(includeAll bool) (brtypes.SnapList, error) {
 	prefixTokens := strings.Split(s.prefix, "/")
 	// Consider the parent of the last element for backward compatibility.

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -283,8 +283,8 @@ func (s *GCSSnapStore) componentUploader(wg *sync.WaitGroup, stopCh <-chan struc
 	}
 }
 
-// List will return a sorted list with all snapshot files on store, excluding those marked with x-etcd-snapshot-exclude.
-func (s *GCSSnapStore) List(includeTagged bool) (brtypes.SnapList, error) {
+// List will return a sorted list with all snapshot files on store, excluding those marked with x-ignore-etcd-snapshot-exclude. Tagged snapshots can be included in the List call by passing true as the argument.
+func (s *GCSSnapStore) List(includeAll bool) (brtypes.SnapList, error) {
 	prefixTokens := strings.Split(s.prefix, "/")
 	// Consider the parent of the last element for backward compatibility.
 	prefix := path.Join(strings.Join(prefixTokens[:len(prefixTokens)-1], "/"))
@@ -304,7 +304,7 @@ func (s *GCSSnapStore) List(includeTagged bool) (brtypes.SnapList, error) {
 		}
 
 		// Check if the snapshot should be ignored
-		if !includeTagged && attr.Metadata[brtypes.ExcludeSnapshotMetadataKey] == "true" {
+		if !includeAll && attr.Metadata[brtypes.ExcludeSnapshotMetadataKey] == "true" {
 			logrus.Infof("Ignoring snapshot due to exclude metadata: %s", attr.Name)
 			continue
 		}

--- a/pkg/snapstore/gcs_snapstore_test.go
+++ b/pkg/snapstore/gcs_snapstore_test.go
@@ -30,11 +30,11 @@ func (m *mockGCSClient) Bucket(name string) stiface.BucketHandle {
 	return &mockBucketHandle{bucket: name, client: m}
 }
 
-func (m *mockGCSClient) setTag(taggedSnapshotName string, tagMap map[string]string) {
-	m.objectTags[taggedSnapshotName] = map[string]string{"x-etcd-snapshot-exclude": "true"}
+func (m *mockGCSClient) setTags(taggedSnapshotName string, tagMap map[string]string) {
+	m.objectTags[taggedSnapshotName] = tagMap
 }
 
-func (m *mockGCSClient) deleteTag(taggedSnapshotName string) {
+func (m *mockGCSClient) deleteTags(taggedSnapshotName string) {
 	delete(m.objectTags, taggedSnapshotName)
 }
 

--- a/pkg/snapstore/gcs_snapstore_test.go
+++ b/pkg/snapstore/gcs_snapstore_test.go
@@ -20,14 +20,22 @@ import (
 // mockGCSClient is a mock client to be used in unit tests.
 type mockGCSClient struct {
 	stiface.Client
-	objects        map[string]*[]byte
-	prefix         string
-	objectMetadata map[string]map[string]string
-	objectMutex    sync.Mutex
+	objects     map[string]*[]byte
+	prefix      string
+	objectTags  map[string]map[string]string
+	objectMutex sync.Mutex
 }
 
 func (m *mockGCSClient) Bucket(name string) stiface.BucketHandle {
 	return &mockBucketHandle{bucket: name, client: m}
+}
+
+func (m *mockGCSClient) setTag(taggedSnapshotName string, tagMap map[string]string) {
+	m.objectTags[taggedSnapshotName] = map[string]string{"x-etcd-snapshot-exclude": "true"}
+}
+
+func (m *mockGCSClient) deleteTag(taggedSnapshotName string) {
+	delete(m.objectTags, taggedSnapshotName)
 }
 
 type mockBucketHandle struct {
@@ -48,7 +56,7 @@ func (m *mockBucketHandle) Objects(context.Context, *storage.Query) stiface.Obje
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	return &mockObjectIterator{keys: keys, metadata: m.client.objectMetadata}
+	return &mockObjectIterator{keys: keys, tags: m.client.objectTags}
 }
 
 type mockObjectHandle struct {
@@ -83,7 +91,7 @@ func (m *mockObjectHandle) Delete(context.Context) error {
 	defer m.client.objectMutex.Unlock()
 	if _, ok := m.client.objects[m.object]; ok {
 		delete(m.client.objects, m.object)
-		delete(m.client.objectMetadata, m.object)
+		delete(m.client.objectTags, m.object)
 		return nil
 	}
 	return fmt.Errorf("object %s not found", m.object)
@@ -93,7 +101,7 @@ type mockObjectIterator struct {
 	stiface.ObjectIterator
 	currentIndex int
 	keys         []string
-	metadata     map[string]map[string]string
+	tags         map[string]map[string]string
 }
 
 func (m *mockObjectIterator) Next() (*storage.ObjectAttrs, error) {
@@ -101,7 +109,7 @@ func (m *mockObjectIterator) Next() (*storage.ObjectAttrs, error) {
 		name := m.keys[m.currentIndex]
 		obj := &storage.ObjectAttrs{
 			Name:     name,
-			Metadata: m.metadata[name],
+			Metadata: m.tags[name],
 		}
 		m.currentIndex++
 		return obj, nil

--- a/pkg/snapstore/local_snapstore.go
+++ b/pkg/snapstore/local_snapstore.go
@@ -68,7 +68,7 @@ func (s *LocalSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
 }
 
 // List will return sorted list with all snapshot files on store.
-func (s *LocalSnapStore) List() (brtypes.SnapList, error) {
+func (s *LocalSnapStore) List(_ bool) (brtypes.SnapList, error) {
 	prefixTokens := strings.Split(s.prefix, "/")
 	// Last element of the tokens is backup version
 	// Consider the parent of the backup version level (Required for Backward Compatibility)

--- a/pkg/snapstore/oss_snapstore.go
+++ b/pkg/snapstore/oss_snapstore.go
@@ -216,7 +216,7 @@ func (s *OSSSnapStore) uploadPart(imur oss.InitiateMultipartUploadResult, file *
 }
 
 // List will return sorted list with all snapshot files on store.
-func (s *OSSSnapStore) List() (brtypes.SnapList, error) {
+func (s *OSSSnapStore) List(_ bool) (brtypes.SnapList, error) {
 	prefixTokens := strings.Split(s.prefix, "/")
 	// Last element of the tokens is backup version
 	// Consider the parent of the backup version level (Required for Backward Compatibility)

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -511,7 +511,7 @@ func (s *S3SnapStore) partUploader(wg *sync.WaitGroup, stopCh <-chan struct{}, s
 }
 
 // List will return sorted list with all snapshot files on store.
-func (s *S3SnapStore) List() (brtypes.SnapList, error) {
+func (s *S3SnapStore) List(_ bool) (brtypes.SnapList, error) {
 	prefixTokens := strings.Split(s.prefix, "/")
 	// Last element of the tokens is backup version
 	// Consider the parent of the backup version level (Required for Backward Compatibility)

--- a/pkg/snapstore/snapshot_test.go
+++ b/pkg/snapstore/snapshot_test.go
@@ -328,7 +328,6 @@ var _ = Describe("Snapshot", func() {
 				Kind:          brtypes.SnapshotKindDelta,
 				SnapDir:       snapdir,
 			}
-
 		})
 		It("should be deletable when its retention period is not set", func() {
 			// do not set the retention period

--- a/pkg/snapstore/snapshot_test.go
+++ b/pkg/snapstore/snapshot_test.go
@@ -323,7 +323,7 @@ var _ = Describe("Snapshot", func() {
 			}
 			snap2 = brtypes.Snapshot{
 				CreatedOn:     now,
-				StartRevision: 2088,
+				StartRevision: 2089,
 				LastRevision:  3088,
 				Kind:          brtypes.SnapshotKindDelta,
 				SnapDir:       snapdir,

--- a/pkg/snapstore/snapshot_test.go
+++ b/pkg/snapstore/snapshot_test.go
@@ -323,8 +323,8 @@ var _ = Describe("Snapshot", func() {
 			}
 			snap2 = brtypes.Snapshot{
 				CreatedOn:     now,
-				StartRevision: 1201,
-				LastRevision:  1500,
+				StartRevision: 2088,
+				LastRevision:  3088,
 				Kind:          brtypes.SnapshotKindDelta,
 				SnapDir:       snapdir,
 			}
@@ -336,8 +336,8 @@ var _ = Describe("Snapshot", func() {
 		})
 		It("should be deletable when its retention period has expired", func() {
 			// Setting expiry time to be a short time after creation
-			snap1.RetentionExpiry = snap1.CreatedOn.Add(time.Microsecond)
-			snap2.RetentionExpiry = snap2.CreatedOn.Add(time.Microsecond)
+			snap1.RetentionExpiry = snap1.CreatedOn.Add(time.Nanosecond)
+			snap2.RetentionExpiry = snap2.CreatedOn.Add(time.Nanosecond)
 			Expect(snap1.IsDeletable()).To(BeTrue())
 			Expect(snap2.IsDeletable()).To(BeTrue())
 		})

--- a/pkg/snapstore/snapshot_test.go
+++ b/pkg/snapstore/snapshot_test.go
@@ -306,7 +306,7 @@ var _ = Describe("Snapshot", func() {
 		})
 	})
 
-	Context("when provided with retention time periods", func() {
+	Context("when provided with immutability time periods", func() {
 		var (
 			snap1 brtypes.Snapshot
 			snap2 brtypes.Snapshot
@@ -329,22 +329,22 @@ var _ = Describe("Snapshot", func() {
 				SnapDir:       snapdir,
 			}
 		})
-		It("should be deletable when its retention period is not set", func() {
-			// do not set the retention period
+		It("should be deletable when its immutability period is not set", func() {
+			// do not set the immutability period
 			Expect(snap1.IsDeletable()).Should(BeTrue())
 			Expect(snap2.IsDeletable()).Should(BeTrue())
 		})
-		It("should be deletable when its retention period has expired", func() {
+		It("should be deletable when its immutability period has expired", func() {
 			// Setting expiry time to be a short time after creation
-			snap1.RetentionExpiry = snap1.CreatedOn.Add(time.Nanosecond)
-			snap2.RetentionExpiry = snap2.CreatedOn.Add(time.Nanosecond)
+			snap1.ImmutabilityExpiryTime = snap1.CreatedOn.Add(time.Nanosecond)
+			snap2.ImmutabilityExpiryTime = snap2.CreatedOn.Add(time.Nanosecond)
 			Expect(snap1.IsDeletable()).To(BeTrue())
 			Expect(snap2.IsDeletable()).To(BeTrue())
 		})
-		It("should not be deletable when its retention period has not expired", func() {
+		It("should not be deletable when its immutability period has not expired", func() {
 			// Setting the expiry time to be a long time after the creation
-			snap1.RetentionExpiry = snap1.CreatedOn.Add(time.Hour)
-			snap2.RetentionExpiry = snap2.CreatedOn.Add(time.Hour)
+			snap1.ImmutabilityExpiryTime = snap1.CreatedOn.Add(time.Hour)
+			snap2.ImmutabilityExpiryTime = snap2.CreatedOn.Add(time.Hour)
 			Expect(snap1.IsDeletable()).To(BeFalse())
 			Expect(snap2.IsDeletable()).To(BeFalse())
 		})

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -176,7 +176,7 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 				logrus.Infof("Running mock tests for %s when only v1 is present", provider)
 
 				// List snap1 and snap2
-				snapList, err := snapStore.List()
+				snapList, err := snapStore.List(false)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(snapList.Len()).To(Equal(numberSnapshotsInObjectMap * snapStore.objectCountPerSnapshot))
 				Expect(snapList[0].SnapName).To(Equal(snap2.SnapName))
@@ -196,7 +196,7 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 				prevLen := len(objectMap)
 				err = snapStore.Delete(*snapList[secondSnapshotIndex])
 				Expect(err).ShouldNot(HaveOccurred())
-				snapList, err = snapStore.List()
+				snapList, err = snapStore.List(false)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(snapList.Len()).To(Equal(prevLen - 1*snapStore.objectCountPerSnapshot))
 
@@ -228,7 +228,7 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 				logrus.Infof("Running mock tests for %s when both v1 and v2 are present", provider)
 
 				// List snap1, snap4, snap5
-				snapList, err := snapStore.List()
+				snapList, err := snapStore.List(false)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(snapList.Len()).To(Equal(numberSnapshotsInObjectMap * snapStore.objectCountPerSnapshot))
 				Expect(snapList[0].SnapName).To(Equal(snap1.SnapName))
@@ -297,7 +297,7 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 				logrus.Infof("Running mock tests for %s when only v2 is present", provider)
 
 				// List snap4 and snap5
-				snapList, err := snapStore.List()
+				snapList, err := snapStore.List(false)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(snapList.Len()).To(Equal(numberSnapshotsInObjectMap * snapStore.objectCountPerSnapshot))
 				Expect(snapList[0].SnapName).To(Equal(snap4.SnapName))
@@ -317,7 +317,7 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 				prevLen := len(objectMap)
 				err = snapStore.Delete(*snapList[0])
 				Expect(err).ShouldNot(HaveOccurred())
-				snapList, err = snapStore.List()
+				snapList, err = snapStore.List(false)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(snapList.Len()).To(Equal(prevLen - snapStore.objectCountPerSnapshot))
 

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -315,7 +315,8 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 				Expect(snapList[0].SnapName).To(Equal(snap4.SnapName))
 				Expect(snapList[secondSnapshotIndex].SnapName).To(Equal(snap5.SnapName))
 
-				// List tests with false and true as arguments only implemented with GCS for now
+				// The List method implemented for SnapStores which support immutable objects is tested for tagged and untagged snapshots.
+				// TODO @renormalize: ABS, S3
 				var tag tagger
 				switch provider {
 				case "GCS":

--- a/pkg/snapstore/swift_snapstore.go
+++ b/pkg/snapstore/swift_snapstore.go
@@ -451,7 +451,7 @@ func (s *SwiftSnapStore) chunkUploader(wg *sync.WaitGroup, stopCh <-chan struct{
 }
 
 // List will return sorted list with all snapshot files on store.
-func (s *SwiftSnapStore) List() (brtypes.SnapList, error) {
+func (s *SwiftSnapStore) List(_ bool) (brtypes.SnapList, error) {
 	prefixTokens := strings.Split(s.prefix, "/")
 	// Last element of the tokens is backup version
 	// Consider the parent of the backup version level (Required for Backward Compatibility)
@@ -494,7 +494,7 @@ func (s *SwiftSnapStore) List() (brtypes.SnapList, error) {
 }
 
 func (s *SwiftSnapStore) getSnapshotChunks(snapshot brtypes.Snapshot) (brtypes.SnapList, error) {
-	snaps, err := s.List()
+	snaps, err := s.List(false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -68,8 +68,10 @@ const (
 type SnapStore interface {
 	// Fetch should open reader for the snapshot file from store.
 	Fetch(Snapshot) (io.ReadCloser, error)
-	// List will return sorted list with all snapshot files on store. Snapshots tagged with ExcludeSnapshotMetadataKey can be included in the List call by passing true.
-	List(bool) (SnapList, error)
+	// List returns a sorted list of all snapshots in the store.
+	// includeAll specifies whether to include all snapshots while listing, including those with exclude tags.
+	// Snapshots with exclude tags are not listed unless includeAll is set to true.
+	List(includeAll bool) (SnapList, error)
 	// Save will write the snapshot to store.
 	Save(Snapshot, io.ReadCloser) error
 	// Delete should delete the snapshot file from store.

--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -57,6 +57,7 @@ const (
 	// MinChunkSize is set to 5Mib since it is lower chunk size limit for AWS.
 	MinChunkSize int64 = 5 * (1 << 20) //5 MiB
 
+	// ExcludeSnapshotMetadataKey is the tag that is to be added on snapshots in the object store if they are not to be included in restoration
 	ExcludeSnapshotMetadataKey = "x-etcd-snapshot-exclude"
 )
 
@@ -67,8 +68,8 @@ const (
 type SnapStore interface {
 	// Fetch should open reader for the snapshot file from store.
 	Fetch(Snapshot) (io.ReadCloser, error)
-	// List will return sorted list with all snapshot files on store.
-	List() (SnapList, error)
+	// List will return sorted list with all snapshot files on store. Snapshots tagged with ExcludeSnapshotMetadataKey can be included in the List call by passing true.
+	List(bool) (SnapList, error)
 	// Save will write the snapshot to store.
 	Save(Snapshot, io.ReadCloser) error
 	// Delete should delete the snapshot file from store.

--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -57,7 +57,7 @@ const (
 	// MinChunkSize is set to 5Mib since it is lower chunk size limit for AWS.
 	MinChunkSize int64 = 5 * (1 << 20) //5 MiB
 
-	// ExcludeSnapshotMetadataKey is the tag that is to be added on snapshots in the object store if they are not to be included in restoration
+	// ExcludeSnapshotMetadataKey is the tag that is to be added on snapshots in the object store if they are not to be included in SnapStore's List output.
 	ExcludeSnapshotMetadataKey = "x-etcd-snapshot-exclude"
 )
 
@@ -68,7 +68,7 @@ const (
 type SnapStore interface {
 	// Fetch should open reader for the snapshot file from store.
 	Fetch(Snapshot) (io.ReadCloser, error)
-	// List returns a sorted list of all snapshots in the store.
+	// List returns a sorted list (based on the last revision, ascending) of all snapshots in the store.
 	// includeAll specifies whether to include all snapshots while listing, including those with exclude tags.
 	// Snapshots with exclude tags are not listed unless includeAll is set to true.
 	List(includeAll bool) (SnapList, error)
@@ -97,8 +97,8 @@ type Snapshot struct {
 // It checks if the retention expiry time is set and whether the current time is after the retention expiry time.
 func (s *Snapshot) IsDeletable() bool {
 	// Check if RetentionExpiry is the zero value of time.Time, which means it is not set.
+	// If RetentionExpiry is not set, assume the snapshot can be deleted.
 	if s.RetentionExpiry.IsZero() {
-		// If RetentionExpiry is not set, assume the snapshot can be deleted.
 		return true
 	}
 	// Otherwise, check if the current time is after the retention expiry time.

--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -80,29 +80,29 @@ type SnapStore interface {
 
 // Snapshot structure represents the metadata of snapshot.
 type Snapshot struct {
-	Kind              string    `json:"kind"` // incr:incremental, full:full
-	StartRevision     int64     `json:"startRevision"`
-	LastRevision      int64     `json:"lastRevision"` // latest revision on snapshot
-	CreatedOn         time.Time `json:"createdOn"`
-	SnapDir           string    `json:"snapDir"`
-	SnapName          string    `json:"snapName"`
-	IsChunk           bool      `json:"isChunk"`
-	Prefix            string    `json:"prefix"`            // Points to correct prefix of a snapshot in snapstore (Required for Backward Compatibility)
-	CompressionSuffix string    `json:"compressionSuffix"` // CompressionSuffix depends on compression policy
-	IsFinal           bool      `json:"isFinal"`
-	RetentionExpiry   time.Time `json:"retentionExpiry"`
+	Kind                   string    `json:"kind"` // incr:incremental, full:full
+	StartRevision          int64     `json:"startRevision"`
+	LastRevision           int64     `json:"lastRevision"` // latest revision on snapshot
+	CreatedOn              time.Time `json:"createdOn"`
+	SnapDir                string    `json:"snapDir"`
+	SnapName               string    `json:"snapName"`
+	IsChunk                bool      `json:"isChunk"`
+	Prefix                 string    `json:"prefix"`            // Points to correct prefix of a snapshot in snapstore (Required for Backward Compatibility)
+	CompressionSuffix      string    `json:"compressionSuffix"` // CompressionSuffix depends on compression policy
+	IsFinal                bool      `json:"isFinal"`
+	ImmutabilityExpiryTime time.Time `json:"immutabilityExpriyTime"`
 }
 
 // IsDeletable determines if the snapshot can be deleted.
-// It checks if the retention expiry time is set and whether the current time is after the retention expiry time.
+// It checks if the immutability expiry time is set and whether the current time is after the immutability expiry time.
 func (s *Snapshot) IsDeletable() bool {
-	// Check if RetentionExpiry is the zero value of time.Time, which means it is not set.
-	// If RetentionExpiry is not set, assume the snapshot can be deleted.
-	if s.RetentionExpiry.IsZero() {
+	// Check if ImmutabilityExpiryTime is the zero value of time.Time, which means it is not set.
+	// If ImmutabilityExpiryTime is not set, assume the snapshot can be deleted.
+	if s.ImmutabilityExpiryTime.IsZero() {
 		return true
 	}
-	// Otherwise, check if the current time is after the retention expiry time.
-	return time.Now().After(s.RetentionExpiry)
+	// Otherwise, check if the current time is after the immutability expiry time.
+	return time.Now().After(s.ImmutabilityExpiryTime)
 }
 
 // GenerateSnapshotName prepares the snapshot name from metadata

--- a/test/e2e/integration/cloud_backup_test.go
+++ b/test/e2e/integration/cloud_backup_test.go
@@ -155,7 +155,7 @@ auto-compaction-retention: 30m`
 			store, err = snapstore.GetSnapstore(snapstoreConfig)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			snapList, err := store.List()
+			snapList, err := store.List(false)
 			Expect(err).ShouldNot(HaveOccurred())
 			for _, snap := range snapList {
 				Expect(store.Delete(*snap)).To(Succeed())
@@ -176,13 +176,13 @@ auto-compaction-retention: 30m`
 
 		Context("taken at 1 minute interval", func() {
 			It("should take periodic backups.", func() {
-				snaplist, err := store.List()
+				snaplist, err := store.List(false)
 				Expect(snaplist).Should(BeEmpty())
 				Expect(err).ShouldNot(HaveOccurred())
 
 				time.Sleep(70 * time.Second)
 
-				snaplist, err = store.List()
+				snaplist, err = store.List(false)
 				Expect(snaplist).ShouldNot(BeEmpty())
 				Expect(err).ShouldNot(HaveOccurred())
 			})
@@ -190,13 +190,13 @@ auto-compaction-retention: 30m`
 
 		Context("taken at 1 minute interval", func() {
 			It("should take periodic backups and limit based garbage collect backups over maxBackups configured", func() {
-				snaplist, err := store.List()
+				snaplist, err := store.List(false)
 				Expect(snaplist).Should(BeEmpty())
 				Expect(err).ShouldNot(HaveOccurred())
 
 				time.Sleep(190 * time.Second)
 
-				snaplist, err = store.List()
+				snaplist, err = store.List(false)
 				Expect(err).ShouldNot(HaveOccurred())
 				count := 0
 				for _, snap := range snaplist {

--- a/test/e2e/integrationcluster/backup_test.go
+++ b/test/e2e/integrationcluster/backup_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Backup", func() {
 
 	Describe("Snapshotter", func() {
 		It("should take full and delta snapshot", func() {
-			snapList, err := store.List()
+			snapList, err := store.List(false)
 			Expect(err).ShouldNot(HaveOccurred())
 			numFulls, numDeltas := getTotalFullAndDeltaSnapshotCounts(snapList)
 			Expect(numFulls).Should(Equal(1))
@@ -89,7 +89,7 @@ var _ = Describe("Backup", func() {
 
 			cumulativeNumFulls, cumulativeNumDeltas := getTotalFullAndDeltaSnapshotCounts(cumulativeSnapList)
 
-			snapList, err := store.List()
+			snapList, err := store.List(false)
 			Expect(err).ShouldNot(HaveOccurred())
 			numFulls, numDeltas := getTotalFullAndDeltaSnapshotCounts(snapList)
 

--- a/test/e2e/integrationcluster/utils.go
+++ b/test/e2e/integrationcluster/utils.go
@@ -311,7 +311,7 @@ func getTotalFullAndDeltaSnapshotCounts(snapList brtypes.SnapList) (int, int) {
 }
 
 func purgeSnapstore(store brtypes.SnapStore) error {
-	snapList, err := store.List()
+	snapList, err := store.List(false)
 	if err != nil {
 		return err
 	}
@@ -373,7 +373,7 @@ func recordCumulativeSnapList(logger *logrus.Logger, stopCh <-chan struct{}, res
 			resultCh <- snapListResult
 			return
 		default:
-			snaps, err := store.List()
+			snaps, err := store.List(false)
 			if err != nil {
 				snapListResult.Error = err
 				resultCh <- snapListResult


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables etcd-backup-restore to handle immutable objects as provided by [bucket lock](https://cloud.google.com/storage/docs/bucket-lock) in Google Cloud Storage.

* A new method `IsDeletable()` is added to the `Snapshot` `struct`. This method returns a `bool` which informs the caller whether the `Snapshot` instance can be deleted from the object store. It internally checks the immutability expiration time of the object and returns `true` if it has expired.

* [Custom metadata](https://cloud.google.com/storage/docs/metadata#custom-metadata) can be added to objects in Google Cloud Storage. In case any particular object (snapshot) is to be excluded during restoration, custom metadata can be added to that object with the key `x-etcd-snapshot-exclude` and value `true`.

* The `List()` method of `SnapStore` interface is now enhanced. It takes a `bool`.
  - `false`: `List()` will only return the objects in the object store that *do not* have the custom metadata `x-etcd-snapshot-exclude` added to it.
  - `true`: `List()` will return *all* objects present in the object store. This variant is used in garbage collection.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/gardener/etcd-backup-restore/issues/777 only for GCS

**Special notes for your reviewer**:

This PR only adds support for GCS. Identical PRs adding support for other providers will be raised separately.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->

```noteworthy operator
etcd-backup-restore now supports immutable objects for storage provider: Google Cloud Storage, provided by the [Bucket Lock](https://cloud.google.com/storage/docs/bucket-lock) feature.
```

```noteworthy operator
Snapshots garbage collection performed by etcd-backup-restore(if enabled) is performed only when the objects immutability period expires.
```

```noteworthy operator
Support for Bucket lock in etcd-backup-restore is backward compatible. For more info please refer to this doc: https://github.com/gardener/etcd-backup-restore/blob/master/docs/usage/immutable_snapshots.md
```