### PR TITLE
Enhance the `docker-build` make target to build for multiple platforms.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ REGISTRY            ?= europe-docker.pkg.dev/gardener-project/snapshots
 IMAGE_REPOSITORY    := $(REGISTRY)/gardener/etcdbrctl
 IMAGE_TAG           := $(VERSION)
 BUILD_DIR           := build
+PLATFORM            ?= $(shell docker info --format '{{.OSType}}/{{.Architecture}}')
 BIN_DIR             := bin
 COVERPROFILE        := test/output/coverprofile.out
-
-IMG ?= ${IMAGE_REPOSITORY}:${IMAGE_TAG}
+IMG                 ?= ${IMAGE_REPOSITORY}:${IMAGE_TAG}
 
 .DEFAULT_GOAL := build-local
 
@@ -34,7 +34,7 @@ build-local:
 
 .PHONY: docker-build
 docker-build:
-	@docker build -t ${IMG} -f $(BUILD_DIR)/Dockerfile --rm .
+	docker buildx build --platform=$(PLATFORM) --tag $(IMG) -f $(BUILD_DIR)/Dockerfile --rm .
 
 .PHONY: docker-push
 docker-push:


### PR DESCRIPTION
**What this PR does / why we need it**:

* The `docker-build` make target builds the image for the architecture of the host machine (same behavior as before).

* The platform can be overridden by passing this variable directly to the make command like `PLATFORM=linux/arm64 make docker-build`, `PLATFORM=linux/amd64 make docker-build`.

**Release note**:

```improvement developer
Builds for non-native platforms can now be done using the `docker-build` make target instead of having to invoke the `docker buildx` command. The platform can be specified using the `PLATFORM` variable which is passed while invoking make.
```