### PR TITLE
Backup-restore now restart the etcd member incase of etcd's advertise peerURL found to be updated.

### DIFF
--- a/example/00-backup-restore-server-config.yaml
+++ b/example/00-backup-restore-server-config.yaml
@@ -47,6 +47,7 @@ restorationConfig:
   autoCompactionRetention: "30m"
 
 defragmentationSchedule: "0 0 */3 * *"
+useEtcdWrapper: false
 
 compressionConfig:
    enabled: true

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -58,7 +58,7 @@ const (
 
 	https = "https"
 
-	// etcdWrapperPortNo defines the port no. used by etcd-wrapper.
+	// etcdWrapperPort defines the port no. used by etcd-wrapper.
 	etcdWrapperPort = "9095"
 )
 
@@ -677,5 +677,5 @@ func getEtcdWrapperEndpoint(etcdEndpoints []string) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("%s://%s:%s", etcdURL.Scheme, etcdURL.Hostname(), etcdWrapperPortNo), nil
+	return fmt.Sprintf("%s://%s:%s", etcdURL.Scheme, etcdURL.Hostname(), etcdWrapperPort), nil
 }

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -654,7 +654,7 @@ func RestartEtcdWrapper(ctx context.Context, tlsEnabled bool, etcdConnectionConf
 	httpCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(httpCtx, http.MethodPost, etcdWrapperURL, nil)
+	req, err := http.NewRequestWithContext(httpCtx, http.MethodPost, fmt.Sprintf("%s/%s", etcdWrapperURL, "stop"), nil)
 	if err != nil {
 		return err
 	}
@@ -663,7 +663,6 @@ func RestartEtcdWrapper(ctx context.Context, tlsEnabled bool, etcdConnectionConf
 		return err
 	}
 	defer response.Body.Close()
-	fmt.Printf("Response from stop endpoint: %s\n", response.Status)
 
 	return nil
 }

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -59,7 +59,7 @@ const (
 	https = "https"
 
 	// etcdWrapperPortNo defines the port no. used by etcd-wrapper.
-	etcdWrapperPortNo = "9095"
+	etcdWrapperPort = "9095"
 )
 
 // GetLatestFullSnapshotAndDeltaSnapList returns the latest snapshot

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -346,7 +346,7 @@ func (b *BackupRestoreServer) updatePeerURLIfChanged(ctx context.Context, tlsEna
 		}); err != nil {
 			return err
 		}
-		if err := miscellaneous.RestartEtcdWrapper(ctx, tlsEnabled); err != nil {
+		if err := miscellaneous.RestartEtcdWrapper(ctx, tlsEnabled, b.config.EtcdConnectionConfig); err != nil {
 			b.logger.Fatalf("failed to restart the etcd: %v", err)
 		}
 	} else {

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -30,6 +30,7 @@ func NewBackupRestoreComponentConfig() *BackupRestoreComponentConfig {
 		HealthConfig:             brtypes.NewHealthConfig(),
 		LeaderElectionConfig:     brtypes.NewLeaderElectionConfig(),
 		ExponentialBackoffConfig: brtypes.NewExponentialBackOffConfig(),
+		UseEtcdWrapper:           usageOfEtcdWrapperEnabled,
 	}
 }
 
@@ -47,6 +48,7 @@ func (c *BackupRestoreComponentConfig) AddFlags(fs *flag.FlagSet) {
 
 	// Miscellaneous
 	fs.StringVar(&c.DefragmentationSchedule, "defragmentation-schedule", c.DefragmentationSchedule, "schedule to defragment etcd data directory")
+	fs.BoolVar(&c.UseEtcdWrapper, "use-etcd-wrapper", c.UseEtcdWrapper, "to enable backup-restore to use etcd-wrapper related functionality. Note: enable this flag only if etcd-wrapper is deployed.")
 }
 
 // Validate validates the config.

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -12,6 +12,8 @@ import (
 const (
 	defaultServerPort              = 8080
 	defaultDefragmentationSchedule = "0 0 */3 * *"
+	// to enable backup-restore to use etcd-wrapper related functionality.
+	usageOfEtcdWrapperEnabled = false
 )
 
 // BackupRestoreComponentConfig holds the component configuration.
@@ -26,6 +28,7 @@ type BackupRestoreComponentConfig struct {
 	HealthConfig             *brtypes.HealthConfig             `json:"healthConfig,omitempty"`
 	LeaderElectionConfig     *brtypes.Config                   `json:"leaderElectionConfig,omitempty"`
 	ExponentialBackoffConfig *brtypes.ExponentialBackoffConfig `json:"exponentialBackoffConfig,omitempty"`
+	UseEtcdWrapper           bool                              `json:"useEtcdWrapper,omitempty"`
 }
 
 // latestSnapshotMetadata holds snapshot details of latest full and delta snapshots

--- a/pkg/types/etcdconnection.go
+++ b/pkg/types/etcdconnection.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultEtcdConnectionEndpoint string = "127.0.0.1:2379"
+	defaultEtcdConnectionEndpoint string = "http://127.0.0.1:2379"
 
 	// DefaultEtcdConnectionTimeout defines default timeout duration for etcd client connection.
 	DefaultEtcdConnectionTimeout time.Duration = 30 * time.Second

--- a/test/e2e/integration/cloud_backup_test.go
+++ b/test/e2e/integration/cloud_backup_test.go
@@ -129,7 +129,7 @@ enable-v2: false
 quota-backend-bytes: 1073741824
 listen-client-urls: http://0.0.0.0:2379
 advertise-client-urls: http://0.0.0.0:2379
-initial-advertise-peer-urls: http@etcd-main-peer@default@2380
+initial-advertise-peer-urls: http://0.0.0.0:2380
 initial-cluster: etcd1=http://0.0.0.0:2380
 initial-cluster-token: new
 initial-cluster-state: new


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Backup-restore will now call [updateMemberPeerURL](https://github.com/etcd-io/etcd/blob/fe7d1904d256f9eef66244b67069e6e87e08a816/clientv3/cluster.go#L49) API call only when peerURL is found to be updated.
2. Backup-restpre will now restart it's corresponding etcd member after updating etcd's advertise peer URLs  if found to be updated.
3. Introduced a CLI flag `--use-etcd-wrapper`(default: false)  to enable/disable backup-restore to use etcd-wrapper related functionality.


**Which issue(s) this PR fixes**:
Fixes #787 

**Special notes for your reviewer**:
This PR needs to be tested  with PR of etcd-wrapper: https://github.com/gardener/etcd-wrapper/pull/31 where `/stop` endpoint is introduced with `--use-etcd-wrapper` set to `true` for backup-restore.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
etcd-backup-restore now triggers a restart of the etcd member after updating etcd's advertise peer URLs if found updated.
```

```noteworthy user
Introduced a CLI flag `--use-etcd-wrapper` (default: false) to enable/disable the backup-restore to use etcd-wrapper related functionality. Note: enable this flag only if etcd-wrapper is deployed.
```