### PR TITLE
Use the standard Go distribution image for integration tests in the pipeline instead of the testmachinery image.

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -57,7 +57,7 @@ etcd-backup-restore:
       unit_test:
         image: 'golang:1.23.2'
       integration_test:
-        image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/base-step:stable
+        image: 'golang:1.23.2'
       build:
         image: 'golang:1.23.2'
         output_dir: 'binary'


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the standard Go distribution image for integration tests in the pipeline instead of the testmachinery image.

This will improve build reproducibility for older branches, since it specifies a version instead of a `latest` or `stable` tag.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
