### PR TITLE
Improved error handling in deletion of delta snapshots during snapshot garbage collection

### DIFF
--- a/pkg/snapshot/snapshotter/garbagecollector.go
+++ b/pkg/snapshot/snapshotter/garbagecollector.go
@@ -6,7 +6,6 @@ package snapshotter
 
 import (
 	"errors"
-	"fmt"
 	"math"
 	"path"
 	"time"
@@ -72,7 +71,6 @@ func (ssr *Snapshotter) RunGarbageCollector(stopCh <-chan struct{}) {
 			}
 
 			fullSnapshotIndexList := getFullSnapshotIndexList(snapList)
-			fmt.Println(fullSnapshotIndexList)
 			switch ssr.config.GarbageCollectionPolicy {
 			case brtypes.GarbageCollectionPolicyExponential:
 				// Overall policy:

--- a/pkg/snapshot/snapshotter/garbagecollector.go
+++ b/pkg/snapshot/snapshotter/garbagecollector.go
@@ -6,7 +6,6 @@ package snapshotter
 
 import (
 	"errors"
-	// "fmt"
 	"math"
 	"path"
 	"time"
@@ -18,7 +17,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// DeltaSnapshotGCErrorThreshold represents the threshold value for the number of individual errors that can occur while deleting delta snapshots.
 const DeltaSnapshotGCErrorThreshold = 5
+
 // RunGarbageCollector basically consider the older backups as garbage and deletes it
 func (ssr *Snapshotter) RunGarbageCollector(stopCh <-chan struct{}) {
 	if ssr.config.GarbageCollectionPeriod.Duration <= time.Second {
@@ -91,7 +92,7 @@ func (ssr *Snapshotter) RunGarbageCollector(stopCh <-chan struct{}) {
 				)
 				// Here we start processing from second last snapstream, because we want to keep last snapstream
 				// including delta snapshots in it.
-				for fullSnapshotIndex := len(fullSnapshotIndexList) - 1; fullSnapshotIndex > 0; fullSnapshotIndex--{
+				for fullSnapshotIndex := len(fullSnapshotIndexList) - 1; fullSnapshotIndex > 0; fullSnapshotIndex-- {
 					snap := snapList[fullSnapshotIndexList[fullSnapshotIndex]]
 					nextSnap := snapList[fullSnapshotIndexList[fullSnapshotIndex-1]]
 
@@ -259,7 +260,7 @@ func (ssr *Snapshotter) GarbageCollectDeltaSnapshots(snapStream brtypes.SnapList
 	totalDeleted := 0
 	cutoffTime := time.Now().UTC().Add(-ssr.config.DeltaSnapshotRetentionPeriod.Duration)
 	var finalError error
-	for i , errorCount:= len(snapStream) - 1 , 0; i >= 0; i-- {
+	for i, errorCount := len(snapStream)-1, 0; i >= 0; i-- {
 		if (*snapStream[i]).Kind == brtypes.SnapshotKindDelta && snapStream[i].CreatedOn.Before(cutoffTime) {
 
 			snapPath := path.Join(snapStream[i].SnapDir, snapStream[i].SnapName)
@@ -277,7 +278,7 @@ func (ssr *Snapshotter) GarbageCollectDeltaSnapshots(snapStream brtypes.SnapList
 				if errorCount == DeltaSnapshotGCErrorThreshold {
 					return totalDeleted, finalError
 				}
-			} else { 
+			} else {
 				metrics.GCSnapshotCounter.With(prometheus.Labels{metrics.LabelKind: brtypes.SnapshotKindDelta, metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Inc()
 				totalDeleted++
 			}

--- a/pkg/snapshot/snapshotter/garbagecollector.go
+++ b/pkg/snapshot/snapshotter/garbagecollector.go
@@ -71,6 +71,7 @@ func (ssr *Snapshotter) RunGarbageCollector(stopCh <-chan struct{}) {
 			}
 
 			fullSnapshotIndexList := getFullSnapshotIndexList(snapList)
+			// snapStream indicates the list of snapshot, where first snapshot is base/full snapshot followed by list of incremental snapshots based on it.
 			switch ssr.config.GarbageCollectionPolicy {
 			case brtypes.GarbageCollectionPolicyExponential:
 				// Overall policy:
@@ -86,7 +87,6 @@ func (ssr *Snapshotter) RunGarbageCollector(stopCh <-chan struct{}) {
 					eod          = now.Truncate(24 * time.Hour).Add(23 * time.Hour).Add(59 * time.Minute).Add(59 * time.Second)
 					trackingWeek = 0
 				)
-				// snapStream indicates the list of snapshot, where first snapshot is base/full snapshot followed by list of incremental snapshots based on it.
 				// Here we start processing from second last snapstream, because we want to keep last snapstream
 				// including delta snapshots in it.
 				for fullSnapshotIndex := len(fullSnapshotIndexList) - 1; fullSnapshotIndex > 0; fullSnapshotIndex-- {

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -528,6 +528,21 @@ var _ = Describe("Snapshotter", func() {
 						Expect(len(list)).Should(Equal(3))
 					})
 				})
+				Context("When no error occurs while deletion of delta snapshots", func() {
+					It("Should have no errors and all the snapshots should get deleted", func() {
+						store := prepareStoreWithDeltaSnapshots(testDir, 10)
+						list, err := store.List(false)
+						Expect(err).ShouldNot(HaveOccurred())
+						Expect(len(list)).Should(Equal(10))
+
+						ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
+						Expect(err).ShouldNot(HaveOccurred())	
+						
+						deleted, err := ssr.GarbageCollectDeltaSnapshots(list)
+						Expect(deleted).Should(Equal(10))
+						Expect(err).ShouldNot(HaveOccurred())
+					})
+				})
 				Context("When an error occurs while deletion of delta snapshot and number of errors are lesser than the threshold(5)", func() {
 					It("should continue with the deletion while joining the errors", func() {
 						store := prepareStoreWithDeltaSnapshots(testDir, 10)
@@ -550,7 +565,7 @@ var _ = Describe("Snapshotter", func() {
 						Expect(err).Should(HaveOccurred())
 					})
 				})
-				Context("When the number of errors while deleting are greater than the threshold", func() {
+				Context("When the number of errors while deleting are greater than or equal to the threshold", func() {
 					It("Should halt the process and return", func() {
 						store := prepareStoreWithDeltaSnapshots(testDir, 15)
 						list, err := store.List(false)

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -539,22 +539,15 @@ var _ = Describe("Snapshotter", func() {
 						Expect(err).ShouldNot(HaveOccurred())
 						
 						// delete a few snapshots in between to induce an error
-						err = os.Remove(path.Join(list[7].Prefix,list[7].SnapName))
-						Expect(err).ShouldNot(HaveOccurred())
-
-						err = os.Remove(path.Join(list[5].Prefix, list[5].SnapName))
-						Expect(err).ShouldNot(HaveOccurred())
-
-						err = os.Remove(path.Join(list[3].Prefix, list[3].SnapName))
-						Expect(err).ShouldNot(HaveOccurred())
-						
-						err = os.Remove(path.Join(list[2].Prefix, list[2].SnapName))
-						Expect(err).ShouldNot(HaveOccurred())
+						snapshotsToBeDeleted := []int{7, 5, 3, 2}
+						for _, i := range snapshotsToBeDeleted {
+							err := os.Remove(path.Join(list[i].Prefix, list[i].SnapName))
+							Expect(err).ShouldNot(HaveOccurred())
+						}
 
 						deleted, err := ssr.GarbageCollectDeltaSnapshots(list)
-						Expect(deleted).ToNot(BeZero())
 						Expect(deleted).Should(Equal(6))
-						Expect(err).ToNot(BeNil())
+						Expect(err).Should(HaveOccurred())
 					})
 				})
 				Context("When the number of errors while deleting are greater than the threshold", func() {
@@ -569,14 +562,14 @@ var _ = Describe("Snapshotter", func() {
 
 
 						// Threshold is set as 5
-						for i := len(list)-3 ; i > len(list)-9 ; i-- { // first 2 are deleted and next 5 return error while deleting
+						for i := len(list)-3 ; i > len(list)-9 ; i-- { // 5 snapshots from the list of snapshots to be deleted, are removed before passing it to the function ssr.GarbageCollectDeltaSnapshots. This will cause an error when the function tries to delete them.
 							err = os.Remove(path.Join(list[i].Prefix, list[i].SnapName))
 							Expect(err).ShouldNot(HaveOccurred())
 						}
 
 						deleted, err := ssr.GarbageCollectDeltaSnapshots(list)
 						Expect(deleted).Should(Equal(2)) 
-						Expect(err).To(HaveOccurred())
+						Expect(err).Should(HaveOccurred())
 
 					})
 				})

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -576,8 +576,7 @@ var _ = Describe("Snapshotter", func() {
 						Expect(err).ShouldNot(HaveOccurred())
 
 
-						// Threshold is set as 5
-						for i := len(list)-3 ; i > len(list)-9 ; i-- { // 5 snapshots from the list of snapshots to be deleted, are removed before passing it to the function ssr.GarbageCollectDeltaSnapshots. This will cause an error when the function tries to delete them.
+						for i := len(list)-3 ; i > len(list)- 3 - ErrorThreshold-1 ; i-- { // 5 snapshots from the list of snapshots to be deleted, are removed before passing it to the function ssr.GarbageCollectDeltaSnapshots. This will cause an error when the function tries to delete them.
 							err = os.Remove(path.Join(list[i].Prefix, list[i].SnapName))
 							Expect(err).ShouldNot(HaveOccurred())
 						}

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -575,8 +575,10 @@ var _ = Describe("Snapshotter", func() {
 						ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
 						Expect(err).ShouldNot(HaveOccurred())
 
-
-						for i := len(list)-3 ; i > len(list)- 3 - ErrorThreshold-1 ; i-- { // 5 snapshots from the list of snapshots to be deleted, are removed before passing it to the function ssr.GarbageCollectDeltaSnapshots. This will cause an error when the function tries to delete them.
+						// This below loop deletes snapshots until the number of deletions reaches the threshold.
+						// This will cause an error when passed into ssr.GarbageCollectDeltaSnapshots for deletion.
+						// Once the count of these individual errors is greater than or equal to the threshold, it errors out.
+						for i := len(list) - 3; i > len(list)-3-DeltaSnapshotGCErrorThreshold-1; i-- {
 							err = os.Remove(path.Join(list[i].Prefix, list[i].SnapName))
 							Expect(err).ShouldNot(HaveOccurred())
 						}

--- a/pkg/snapshot/snapshotter/snapshotter_test.go
+++ b/pkg/snapshot/snapshotter/snapshotter_test.go
@@ -536,8 +536,8 @@ var _ = Describe("Snapshotter", func() {
 						Expect(len(list)).Should(Equal(10))
 
 						ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
-						Expect(err).ShouldNot(HaveOccurred())	
-						
+						Expect(err).ShouldNot(HaveOccurred())
+
 						deleted, err := ssr.GarbageCollectDeltaSnapshots(list)
 						Expect(deleted).Should(Equal(10))
 						Expect(err).ShouldNot(HaveOccurred())
@@ -552,7 +552,7 @@ var _ = Describe("Snapshotter", func() {
 
 						ssr, err := NewSnapshotter(logger, snapshotterConfig, store, etcdConnectionConfig, compressionConfig, healthConfig, snapstoreConfig)
 						Expect(err).ShouldNot(HaveOccurred())
-						
+
 						// delete a few snapshots in between to induce an error
 						snapshotsToBeDeleted := []int{7, 5, 3, 2}
 						for _, i := range snapshotsToBeDeleted {
@@ -584,7 +584,7 @@ var _ = Describe("Snapshotter", func() {
 						}
 
 						deleted, err := ssr.GarbageCollectDeltaSnapshots(list)
-						Expect(deleted).Should(Equal(2)) 
+						Expect(deleted).Should(Equal(2))
 						Expect(err).Should(HaveOccurred())
 
 					})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the error handling for deletion of delta snapshots by replacing the current implementation with concatenation of errors using the errors.Join() method upto a threshold of 5. The process of continues with the deletion of the rest of the "deletable" delta snapshots even when an error is encountered, instead of halting the process. When the number of errors becomes greater than the threshold, it errors out for the current cycle.

**Which issue(s) this PR fixes**:
Fixes #652 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improved error handling in deletion of delta snapshots during snapshot garbage collection.
```