### PR TITLE
[rel-v0.30] Backup-restore now restart the etcd member incase of etcd's advertise peerURL found to be updated.

### DIFF
--- a/example/00-backup-restore-server-config.yaml
+++ b/example/00-backup-restore-server-config.yaml
@@ -47,6 +47,7 @@ restorationConfig:
   autoCompactionRetention: "30m"
 
 defragmentationSchedule: "0 0 */3 * *"
+useEtcdWrapper: false
 
 compressionConfig:
    enabled: true

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -69,6 +69,9 @@ type Control interface {
 
 	// IsLearnerPresent checks for the learner(non-voting) member in a cluster.
 	IsLearnerPresent(context.Context) (bool, error)
+
+	// GetPeerURLs returns the list of current peer URLs of the etcd cluster member.
+	GetPeerURLs(context.Context, etcdClient.ClusterCloser) ([]string, error)
 }
 
 // memberControl holds the configuration for the mechanism of adding a new member to the cluster.
@@ -113,7 +116,7 @@ func NewMemberControl(etcdConnConfig *brtypes.EtcdConnectionConfig) Control {
 // AddMemberAsLearner add a member as a learner to the etcd cluster
 func (m *memberControl) AddMemberAsLearner(ctx context.Context) error {
 	//Add member as learner to cluster
-	memberURL, err := getMemberPeerURL(m.configFile, m.podName)
+	memberURL, err := miscellaneous.GetMemberPeerURL(m.configFile, m.podName)
 	if err != nil {
 		m.logger.Fatalf("Error fetching etcd member URL : %v", err)
 	}
@@ -198,28 +201,12 @@ func (m *memberControl) IsMemberInCluster(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-func getMemberPeerURL(configFile string, podName string) (string, error) {
-	config, err := miscellaneous.ReadConfigFileAsMap(configFile)
-	if err != nil {
-		return "", err
-	}
-	initAdPeerURL := config["initial-advertise-peer-urls"]
-	if initAdPeerURL == nil {
-		return "", errors.New("initial-advertise-peer-urls must be set in etcd config")
-	}
-	peerURL, err := miscellaneous.ParsePeerURL(initAdPeerURL.(string), podName)
-	if err != nil {
-		return "", fmt.Errorf("could not parse peer URL from the config file : %v", err)
-	}
-	return peerURL, nil
-}
-
 // doUpdateMemberPeerAddress updated the peer address of a specified etcd member
 func (m *memberControl) doUpdateMemberPeerAddress(ctx context.Context, cli etcdClient.ClusterCloser, id uint64) error {
 	// Already existing clusters or cluster after restoration have `http://localhost:2380` as the peer address. This needs to explicitly updated to the correct peer address.
 	m.logger.Infof("Updating member peer URL for %s", m.podName)
 
-	memberPeerURL, err := getMemberPeerURL(m.configFile, m.podName)
+	memberPeerURL, err := miscellaneous.GetMemberPeerURL(m.configFile, m.podName)
 	if err != nil {
 		return fmt.Errorf("could not fetch member URL : %v", err)
 	}
@@ -350,6 +337,33 @@ func (m *memberControl) IsClusterScaledUp(ctx context.Context, clientSet client.
 		}
 	}
 	return false, nil
+}
+
+// GetPeerURLs returns the list of current peer URLs of the etcd cluster member.
+func (m *memberControl) GetPeerURLs(ctx context.Context, closer etcdClient.ClusterCloser) ([]string, error) {
+	var (
+		etcdMemberList *clientv3.MemberListResponse
+		err            error
+	)
+	backoff := miscellaneous.CreateBackoff(RetryPeriod, RetrySteps)
+
+	// List all members in etcd cluster
+	if err = retry.OnError(backoff, func(err error) bool {
+		return err != nil
+	}, func() error {
+		memListCtx, cancel := context.WithTimeout(ctx, EtcdTimeout)
+		defer cancel()
+		etcdMemberList, err = closer.MemberList(memListCtx)
+		return err
+	}); err != nil {
+		return nil, fmt.Errorf("could not list any etcd members %w", err)
+	}
+	for _, member := range etcdMemberList.Members {
+		if member.GetName() == m.podName {
+			return member.GetPeerURLs(), nil
+		}
+	}
+	return []string{}, nil
 }
 
 // WasMemberInCluster checks the whether etcd member was part of etcd cluster.

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -30,6 +30,7 @@ func NewBackupRestoreComponentConfig() *BackupRestoreComponentConfig {
 		HealthConfig:             brtypes.NewHealthConfig(),
 		LeaderElectionConfig:     brtypes.NewLeaderElectionConfig(),
 		ExponentialBackoffConfig: brtypes.NewExponentialBackOffConfig(),
+		UseEtcdWrapper:           usageOfEtcdWrapperEnabled,
 	}
 }
 
@@ -47,6 +48,7 @@ func (c *BackupRestoreComponentConfig) AddFlags(fs *flag.FlagSet) {
 
 	// Miscellaneous
 	fs.StringVar(&c.DefragmentationSchedule, "defragmentation-schedule", c.DefragmentationSchedule, "schedule to defragment etcd data directory")
+	fs.BoolVar(&c.UseEtcdWrapper, "use-etcd-wrapper", c.UseEtcdWrapper, "to enable backup-restore to use etcd-wrapper related functionality. Note: enable this flag only if etcd-wrapper is deployed.")
 }
 
 // Validate validates the config.

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -12,6 +12,8 @@ import (
 const (
 	defaultServerPort              = 8080
 	defaultDefragmentationSchedule = "0 0 */3 * *"
+	// to enable backup-restore to use etcd-wrapper related functionality.
+	usageOfEtcdWrapperEnabled = false
 )
 
 // BackupRestoreComponentConfig holds the component configuration.
@@ -26,6 +28,7 @@ type BackupRestoreComponentConfig struct {
 	HealthConfig             *brtypes.HealthConfig             `json:"healthConfig,omitempty"`
 	LeaderElectionConfig     *brtypes.Config                   `json:"leaderElectionConfig,omitempty"`
 	ExponentialBackoffConfig *brtypes.ExponentialBackoffConfig `json:"exponentialBackoffConfig,omitempty"`
+	UseEtcdWrapper           bool                              `json:"useEtcdWrapper,omitempty"`
 }
 
 // latestSnapshotMetadata holds snapshot details of latest full and delta snapshots

--- a/pkg/types/etcdconnection.go
+++ b/pkg/types/etcdconnection.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultEtcdConnectionEndpoint string = "127.0.0.1:2379"
+	defaultEtcdConnectionEndpoint string = "http://127.0.0.1:2379"
 
 	// DefaultEtcdConnectionTimeout defines default timeout duration for etcd client connection.
 	DefaultEtcdConnectionTimeout time.Duration = 30 * time.Second

--- a/test/e2e/integration/cloud_backup_test.go
+++ b/test/e2e/integration/cloud_backup_test.go
@@ -129,7 +129,7 @@ enable-v2: false
 quota-backend-bytes: 1073741824
 listen-client-urls: http://0.0.0.0:2379
 advertise-client-urls: http://0.0.0.0:2379
-initial-advertise-peer-urls: http@etcd-main-peer@default@2380
+initial-advertise-peer-urls: http://0.0.0.0:2380
 initial-cluster: etcd1=http://0.0.0.0:2380
 initial-cluster-token: new
 initial-cluster-state: new


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick PR of https://github.com/gardener/etcd-backup-restore/pull/788

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
etcd-backup-restore now triggers a restart of the etcd member after updating etcd's advertise peer URLs if found updated.
```

```noteworthy user
Introduced a CLI flag `--use-etcd-wrapper` (default: false) to enable/disable the backup-restore to use etcd-wrapper related functionality. Note: enable this flag only if etcd-wrapper is deployed.
```
