### PR TITLE
Minimise the impact of flaky unit tests in the `defragmentor` pkg by making it fail fast

### DIFF
--- a/.ci/unit_test
+++ b/.ci/unit_test
@@ -28,31 +28,76 @@ test_with_coverage() {
   local output_dir=test/output
   local coverprofile_file=coverprofile.out
   mkdir -p "${output_dir}"
+
   ginkgo "${GINKGO_COMMON_FLAGS[@]}" -gcflags=all=-d=checkptr=0 --coverprofile "${coverprofile_file}" -covermode=set -outputdir "${output_dir}" ${TEST_PACKAGES}
   sed -i='' '/mode: set/d' "${output_dir}/${coverprofile_file}"
   { echo "mode: set"; cat "${output_dir}/${coverprofile_file}"; } > "${output_dir}/${coverprofile_file}.temp"
   mv "${output_dir}/${coverprofile_file}.temp" "${output_dir}/${coverprofile_file}"
+
   go tool cover -func "${output_dir}/${coverprofile_file}"
 }
 
 ################################################################################
 
 # To run a specific package, run TEST_PACKAGES=<PATH_TO_PACKAGE> make test
-TEST_PACKAGES="${TEST_PACKAGES:-"cmd pkg"}"
+# If the TEST_PACKAGES is not set, then define a list of packages to run.
+TEST_PACKAGES="${TEST_PACKAGES:-"
+./pkg/backoff \
+./pkg/compactor \
+./pkg/defragmentor \
+./pkg/health/heartbeat \
+./pkg/health/membergarbagecollector \
+./pkg/initializer/validator \
+./pkg/leaderelection \
+./pkg/member \
+./pkg/metrics \
+./pkg/miscellaneous \
+./pkg/server \
+./pkg/snapshot/copier \
+./pkg/snapshot/restorer \
+./pkg/snapshot/snapshotter \
+./pkg/snapstore"
+}"
+
 
 RUN_NEGATIVE="${RUN_NEGATIVE:-"true"}"
 
 GINKGO_COMMON_FLAGS="-r -timeout=1h0m0s --show-node-events --fail-on-pending -mod=vendor"
 
+# First run the `pkg/defragmentor` tests to fail fast as it has flaky tests.
+# TODO: Remove this once the flaky tests are fixed.
+FIRST_PACKAGE_TO_RUN="./pkg/defragmentor"
+
+# Check if the FIRST_PACKAGE_TO_RUN is part of the TEST_PACKAGES
+IS_FIRST_PACKAGE_PRESENT=false
+if [[ " ${TEST_PACKAGES} " == *" ${FIRST_PACKAGE_TO_RUN} "* ]]; then
+  IS_FIRST_PACKAGE_PRESENT=true
+  # Remove FIRST_PACKAGE_TO_RUN from TEST_PACKAGES
+  TEST_PACKAGES=$(echo "${TEST_PACKAGES}" | sed "s|${FIRST_PACKAGE_TO_RUN}||")
+fi
+
 if [[ "${COVER:-false}" == "false" ]]; then
   echo "[INFO] Test coverage is disabled."
 
-  # Run all non-negative scenarios with randomize-all parameters.
+  # If the FIRST_PACKAGE_TO_RUN is present, run non-negative tests on it first.
+  if [[ "${IS_FIRST_PACKAGE_PRESENT}" == "true" ]]; then
+    echo "[INFO] Running tests for the first package: ${FIRST_PACKAGE_TO_RUN}"
+    ginkgo -race -trace $GINKGO_COMMON_FLAGS -gcflags=all=-d=checkptr=0 --randomize-all --skip="NEGATIVE\:.*" ${FIRST_PACKAGE_TO_RUN}
+  fi
+
+  # Run the non-negative scenarios for remaining packages with randomize-all parameters.
   ginkgo -race -trace $GINKGO_COMMON_FLAGS -gcflags=all=-d=checkptr=0 --randomize-all --randomize-suites --skip="NEGATIVE\:.*" $TEST_PACKAGES
 
   if [[ "${RUN_NEGATIVE}" == "true" ]]; then
     echo "[INFO] Running negative tests now..."
-    # Run negative scenarios sequentially (removed failOnPending as one spec in restore test is marked as 'X' for excluding)
+
+    # If the FIRST_PACKAGE_TO_RUN is present, run negative tests on it first.
+    if [[ "${IS_FIRST_PACKAGE_PRESENT}" == "true" ]]; then
+      echo "[INFO] Running negative tests for the first package: ${FIRST_PACKAGE_TO_RUN}"
+      ginkgo -race -trace $GINKGO_COMMON_FLAGS -gcflags=all=-d=checkptr=0 --focus="NEGATIVE\:.*" ${FIRST_PACKAGE_TO_RUN}
+    fi
+
+    # Run negative scenarios sequentially for remaining packages (removed failOnPending as one spec in restore test is marked as 'X' for excluding)
     ginkgo -race -trace $GINKGO_COMMON_FLAGS -gcflags=all=-d=checkptr=0 --focus="NEGATIVE\:.*" ${TEST_PACKAGES}
   fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR attempts to run the `pkg/defragmentor` unit test pkg before running remaining packages, this is done to reduce the waiting time to see the error & retry tests in case of a flaky test failure in the `defragmentor` suite. With the randomisation of test suites in the current setup, this flaky test could end up running near the end and failing. This only causes delays in review or getting the PR merged.

**Which issue(s) this PR fixes**:
Fixes #798 

**Special notes for your reviewer**:

This is just a dirty fix for now, a proper solution would be to fix the flaky tests. We can remove this extra handling once that gets fixed. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
run the `pkg/defragmentor` test package first before running remaining pkgs, to fail-fast incase of flaky tests
```
