### PR TITLE
[rel-v0.31] Use `x.y.0` versions of the Go Toolchain only (#801)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/etcd-backup-restore
 
-go 1.23.2
+go 1.23.0
 
 require (
 	cloud.google.com/go/iam v1.1.1


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry-pick of #801

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
`etcd-backup-restore` will henceforth stick to Go versions `x.y.0` only to be in line with gardener/gardener, kubernetes, controller-runtime.
```
