### PR TITLE
Enhance the `check` make target to ensure the Go version adheres to `x.y.0`.

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -55,16 +55,12 @@ golint -set_exit_status ${LINT_FOLDERS}
 helm lint "${HELM_CHART_PATH}"
 
 echo "Checking Go version"
-while IFS= read -r line
-do
-  if [[ $line =~ ^go.*$ ]]; then
-    if [[ $line =~ ^go\ [0-9]+\.[0-9]+\.0$ ]]; then
-        # Go version is valid, adheres to x.y.0 version
-        exit 0
-    else
-        echo "Go version is invalid, please adhere to x.y.0 version"
-        echo "See https://github.com/gardener/etcd-backup-restore/pull/801"
-        exit 1
-    fi
-  fi
-done < "go.mod"
+GOVERSION=$(go list -f {{.GoVersion}} -m)
+if [[ $GOVERSION =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
+  # Go version is valid, adheres to x.y.0 version
+  exit 0
+else
+  echo "Go version is invalid, please adhere to x.y.0 version"
+  echo "See https://github.com/gardener/etcd-backup-restore/pull/801"
+  exit 1
+fi

--- a/.ci/check
+++ b/.ci/check
@@ -56,11 +56,10 @@ helm lint "${HELM_CHART_PATH}"
 
 echo "Checking Go version"
 GOVERSION=$(go list -f {{.GoVersion}} -m)
-if [[ $GOVERSION =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
-  # Go version is valid, adheres to x.y.0 version
-  exit 0
-else
+if [[ ! $GOVERSION =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
   echo "Go version is invalid, please adhere to x.y.0 version"
   echo "See https://github.com/gardener/etcd-backup-restore/pull/801"
   exit 1
 fi
+
+echo "All checks successful"

--- a/.ci/check
+++ b/.ci/check
@@ -53,3 +53,18 @@ golint -set_exit_status ${LINT_FOLDERS}
 
 # Execute lint checks on helm chart.
 helm lint "${HELM_CHART_PATH}"
+
+echo "Checking Go version"
+while IFS= read -r line
+do
+  if [[ $line =~ ^go.*$ ]]; then
+    if [[ $line =~ ^go\ [0-9]+\.[0-9]+\.0$ ]]; then
+        # Go version is valid, adheres to x.y.0 version
+        exit 0
+    else
+        echo "Go version is invalid, please adhere to x.y.0 version"
+        echo "See https://github.com/gardener/etcd-backup-restore/pull/801"
+        exit 1
+    fi
+  fi
+done < "go.mod"

--- a/pkg/mock/etcd/clientv3/mocks.go
+++ b/pkg/mock/etcd/clientv3/mocks.go
@@ -8,8 +8,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	"go.uber.org/mock/gomock"
 	clientv3 "go.etcd.io/etcd/clientv3"
+	"go.uber.org/mock/gomock"
 )
 
 // MockWatcher is a mock of Watcher interface.

--- a/pkg/mock/etcdutil/client/mocks.go
+++ b/pkg/mock/etcdutil/client/mocks.go
@@ -10,8 +10,8 @@ import (
 	reflect "reflect"
 
 	client "github.com/gardener/etcd-backup-restore/pkg/etcdutil/client"
-	"go.uber.org/mock/gomock"
 	clientv3 "go.etcd.io/etcd/clientv3"
+	"go.uber.org/mock/gomock"
 )
 
 // MockFactory is a mock of Factory interface.


### PR DESCRIPTION
**What this PR does / why we need it**:

Enhance the `check` make target to ensure the Go version adheres to `x.y.0`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The diff in the `mocks.go` file is just an import order rearrange that automatically happened after running `make check`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Enhanced the `check` make target to ensure the Go version adheres to `x.y.0`.
```
