### PR TITLE
Prevent skipping scheduled full snapshots when there are no new updates

### DIFF
--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -344,8 +344,8 @@ func (ssr *Snapshotter) takeFullSnapshot(isFinal bool) (*brtypes.Snapshot, error
 		}
 	}
 	lastRevision := resp.Header.Revision
-	if ssr.PrevSnapshot.IsFinal == true {
-		ssr.logger.Infof("Previous snapshot was set as final, skipping full snapshot.")
+	if isFinal && ssr.PrevSnapshot.Kind == brtypes.SnapshotKindFull && ssr.PrevSnapshot.LastRevision == lastRevision && ssr.PrevSnapshot.IsFinal{
+		ssr.logger.Infof("There are no updates since final last snapshot, skipping final full snapshot.")
 	} else {
 		// Note: As FullSnapshot size can be very large, so to avoid context timeout use "SnapshotTimeout" in context.WithTimeout()
 		ctx, cancel = context.WithTimeout(context.TODO(), ssr.etcdConnectionConfig.SnapshotTimeout.Duration)

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -344,8 +344,8 @@ func (ssr *Snapshotter) takeFullSnapshot(isFinal bool) (*brtypes.Snapshot, error
 		}
 	}
 	lastRevision := resp.Header.Revision
-	if isFinal && ssr.PrevSnapshot.Kind == brtypes.SnapshotKindFull && ssr.PrevSnapshot.LastRevision == lastRevision && ssr.PrevSnapshot.IsFinal{
-		ssr.logger.Infof("There are no updates since final last snapshot, skipping final full snapshot.")
+	if isFinal && ssr.PrevSnapshot.IsFinal && ssr.PrevSnapshot.Kind == brtypes.SnapshotKindFull && ssr.PrevSnapshot.LastRevision == lastRevision {
+		ssr.logger.Infof("There are no new updates since previous final full snapshot, skipping new final full snapshot.")
 	} else {
 		// Note: As FullSnapshot size can be very large, so to avoid context timeout use "SnapshotTimeout" in context.WithTimeout()
 		ctx, cancel = context.WithTimeout(context.TODO(), ssr.etcdConnectionConfig.SnapshotTimeout.Duration)

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -344,9 +344,8 @@ func (ssr *Snapshotter) takeFullSnapshot(isFinal bool) (*brtypes.Snapshot, error
 		}
 	}
 	lastRevision := resp.Header.Revision
-
-	if ssr.PrevSnapshot.Kind == brtypes.SnapshotKindFull && ssr.PrevSnapshot.LastRevision == lastRevision && ssr.PrevSnapshot.IsFinal == isFinal {
-		ssr.logger.Infof("There are no updates since last snapshot, skipping full snapshot.")
+	if ssr.PrevSnapshot.IsFinal == true {
+		ssr.logger.Infof("Previous snapshot was set as final, skipping full snapshot.")
 	} else {
 		// Note: As FullSnapshot size can be very large, so to avoid context timeout use "SnapshotTimeout" in context.WithTimeout()
 		ctx, cancel = context.WithTimeout(context.TODO(), ssr.etcdConnectionConfig.SnapshotTimeout.Duration)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that the backup-restore process does not skip a scheduled full snapshot, even when no events occur during the interval between two full snapshot schedules.

**Which issue(s) this PR fixes**:
Fixes #797 

**Special notes for your reviewer**:
The current implementation allows for taking a full snapshot in all cases, except the case where the preceding full snapshot has been set as final.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Don't skip full snapshot, always trigger a full snapshot independent of new updates to etcd, preventing prometheus alerts of not taking a scheduled full snapshot.
```
