### PR TITLE
Introduce `gosec` for Static Application Security Testing (SAST)

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -54,7 +54,7 @@ golint -set_exit_status ${LINT_FOLDERS}
 # Execute lint checks on helm chart.
 helm lint "${HELM_CHART_PATH}"
 
-echo "Checking Go version"
+echo "> Checking Go version"
 GOVERSION=$(go list -f {{.GoVersion}} -m)
 if [[ ! $GOVERSION =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
   echo "Go version is invalid, please adhere to x.y.0 version"
@@ -62,4 +62,8 @@ if [[ ! $GOVERSION =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
   exit 1
 fi
 
-echo "All checks successful"
+# Run Static Application Security Testing (SAST) using gosec
+echo "> Running SAST checks..."
+make sast-report
+
+echo -e "\nAll checks successful"

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -18,6 +18,13 @@ etcd-backup-restore:
       - --set=projectNamespace=garden-it
 
   base_definition:
+    repo:
+      source_labels:
+        - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1
+          value:
+            policy: skip
+            comment: |
+              we use gosec for sast scanning. See attached log.
     traits:
       version:
         preprocess: 'inject-commit-hash'
@@ -84,6 +91,16 @@ etcd-backup-restore:
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/etcdbrctl
         release:
           nextversion: 'bump_minor'
+          assets:
+            - type: build-step-log
+              step_name: check
+              purposes:
+                - lint
+                - sast
+                - gosec
+              comment: |
+                we use gosec (linter) for SAST scans
+                see: https://github.com/securego/gosec
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ compctedsnap.bkp*
 tmp
 dev
 *.DS_Store
+
+# gosec
+gosec-report.sarif

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ IMG                 ?= ${IMAGE_REPOSITORY}:${IMAGE_TAG}
 
 .DEFAULT_GOAL := build-local
 
+include hack/tools.mk
+
 .PHONY: revendor
 revendor:
 	@env go mod tidy -v
@@ -51,6 +53,14 @@ verify: check test
 .PHONY: check
 check:
 	@.ci/check
+
+.PHONY: sast
+sast: $(GOSEC)
+	@./hack/sast.sh
+
+.PHONY: sast-report
+sast-report: $(GOSEC)
+	@./hack/sast.sh --gosec-report true
 
 .PHONY: test
 test:

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+
+gosec_report="false"
+gosec_report_parse_flags=""
+
+parse_flags() {
+  while test $# -gt 1; do
+    case "$1" in
+      --gosec-report)
+        shift; gosec_report="$1"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_flags "$@"
+
+echo "> Running gosec"
+gosec --version
+if [[ "$gosec_report" != "false" ]]; then
+  echo "Exporting report to $root_dir/gosec-report.sarif"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
+fi
+
+# exclude generated code, hack directory (where hack scripts reside)
+# and tmp directory (where temporary mod files are downloaded)
+# shellcheck disable=SC2086
+gosec -exclude-generated -exclude-dir=hack -exclude-dir=tmp $gosec_report_parse_flags ./...

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TOOLS_DIR     := hack/tools
+TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
+
+export TOOLS_BIN_DIR := $(TOOLS_BIN_DIR)
+export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)
+
+# Tool Binaries
+GOSEC := $(TOOLS_BIN_DIR)/gosec
+
+# Tool Versions
+GOSEC_VERSION ?= v2.21.4
+
+#########################################
+# Tools                                 #
+#########################################
+
+$(GOSEC): $(call tool_version_file,$(GOSEC),$(GOSEC_VERSION))
+	@GOSEC_VERSION=$(GOSEC_VERSION) $(TOOLS_DIR)/install-gosec.sh

--- a/hack/tools/install-gosec.sh
+++ b/hack/tools/install-gosec.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+echo "> Installing gosec"
+
+TOOLS_BIN_DIR=${TOOLS_BIN_DIR:-$(dirname $0)/bin}
+if [[ ! -d $TOOLS_BIN_DIR ]]; then
+  mkdir -p $TOOLS_BIN_DIR
+fi
+
+platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+version=$GOSEC_VERSION
+echo "gosec version:$GOSEC_VERSION"
+case $(uname -m) in
+  aarch64 | arm64)
+    arch="arm64"
+    ;;
+  x86_64)
+    arch="amd64"
+    ;;
+  *)
+    echo "Unknown architecture"
+    exit 1
+    ;;
+esac
+
+archive_name="gosec_${version#v}_${platform}_${arch}"
+file_name="${archive_name}.tar.gz"
+
+temp_dir="$(mktemp -d)"
+function cleanup {
+  rm -rf "${temp_dir}"
+}
+trap cleanup EXIT ERR INT TERM
+echo "Downloading from: https://github.com/securego/gosec/releases/download/${version}/${file_name}"
+curl -L -o ${temp_dir}/${file_name} "https://github.com/securego/gosec/releases/download/${version}/${file_name}"
+
+tar -xzm -C "${temp_dir}" -f "${temp_dir}/${file_name}"
+mv "${temp_dir}/gosec" $TOOLS_BIN_DIR
+chmod +x $TOOLS_BIN_DIR/gosec

--- a/pkg/backoff/exponentialbackoff.go
+++ b/pkg/backoff/exponentialbackoff.go
@@ -64,7 +64,7 @@ func (e *ExponentialBackoff) GetNextBackoffTime() time.Duration {
 	}
 
 	e.currentAttempt++
-	e.currentBackoffTime *= time.Duration(e.multiplier)
+	e.currentBackoffTime *= time.Duration(e.multiplier) // #nosec G115 -- validated for size to be lesser than MaxInt64.
 	return e.currentBackoffTime
 }
 

--- a/pkg/etcdutil/etcdutil.go
+++ b/pkg/etcdutil/etcdutil.go
@@ -114,7 +114,7 @@ func GetTLSClientForEtcd(tlsConfig *brtypes.EtcdConnectionConfig, options *clien
 	// should still setup an empty tls configuration for gRPC to setup
 	// secure connection.
 	if cfg.TLS == nil && !tlsConfig.InsecureTransport {
-		cfg.TLS = &tls.Config{}
+		cfg.TLS = &tls.Config{} // #nosec G402 -- cfg.TLS.MinVersion=1.2 by default.
 	}
 
 	// If the user wants to skip TLS verification then we should set

--- a/pkg/health/membergarbagecollector/membergarbagecollector.go
+++ b/pkg/health/membergarbagecollector/membergarbagecollector.go
@@ -132,7 +132,7 @@ func (mgc *MemberGarbageCollector) RemoveSuperfluousMembers(ctx context.Context,
 		}
 	}
 
-	if sts.Generation != sts.Status.ObservedGeneration && stsSpecReplicas != sts.Status.UpdatedReplicas && stsSpecReplicas >= int32(len(etcdMemberListResponse.Members)) {
+	if sts.Generation != sts.Status.ObservedGeneration && stsSpecReplicas != sts.Status.UpdatedReplicas && int(stsSpecReplicas) >= len(etcdMemberListResponse.Members) {
 		//Return if number of replicas in sts and etcd cluster match or cluster is in scale-up scenario
 		return nil
 	}

--- a/pkg/initializer/validator/datavalidator.go
+++ b/pkg/initializer/validator/datavalidator.go
@@ -101,7 +101,7 @@ func (d *DataValidator) sanityCheck(failBelowRevision int64) (DataDirStatus, err
 		}
 
 		// read the content of the file safe_guard and match it with the environment variable
-		content, err := os.ReadFile(path)
+		content, err := os.ReadFile(path) // #nosec G304 -- this is a trusted safe_guard file written to by etcdbr.
 		if err != nil {
 			return WrongVolumeMounted, fmt.Errorf("can't read the content of the `safe_guard` file to determine if a wrong volume is mounted: %v", err)
 		}
@@ -441,8 +441,7 @@ func getLatestEtcdRevision(path string) (int64, error) {
 			rev = 1
 			return nil
 		}
-		rev = int64(binary.BigEndian.Uint64(k[0:8]))
-
+		rev = int64(binary.BigEndian.Uint64(k[0:8])) // #nosec G115 -- only the first 8 bytes are used for integer conversion, so no overflow is possible.
 		return nil
 	})
 

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -401,7 +401,9 @@ func AddLearnerWithRetry(ctx context.Context, m Control, retrySteps int, dataDir
 		}
 		if err := m.AddMemberAsLearner(ctx); err != nil {
 			if errors.Is(err, rpctypes.Error(rpctypes.ErrGRPCTooManyLearners)) {
-				miscellaneous.SleepWithContext(ctx, EtcdTimeout)
+				if err1 := miscellaneous.SleepWithContext(ctx, EtcdTimeout); err != nil {
+					return errors.Join(err, err1)
+				}
 			}
 			return err
 		}

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -401,7 +401,7 @@ func AddLearnerWithRetry(ctx context.Context, m Control, retrySteps int, dataDir
 		}
 		if err := m.AddMemberAsLearner(ctx); err != nil {
 			if errors.Is(err, rpctypes.Error(rpctypes.ErrGRPCTooManyLearners)) {
-				if err1 := miscellaneous.SleepWithContext(ctx, EtcdTimeout); err != nil {
+				if err1 := miscellaneous.SleepWithContext(ctx, EtcdTimeout); err1 != nil {
 					return errors.Join(err, err1)
 				}
 			}

--- a/pkg/metrics/network_linux.go
+++ b/pkg/metrics/network_linux.go
@@ -36,7 +36,7 @@ func getNetworkUsageBytes(mode networkMode) float64 {
 
 	pid := os.Getpid()
 	fileName := fmt.Sprintf("/proc/%d/net/dev", pid)
-	fd, err := os.Open(fileName)
+	fd, err := os.Open(fileName) // #nosec #G304 -- trusted file to read network usage stats.
 	if err != nil {
 		fmt.Printf("failed to readfile: %s", fileName)
 		return math.NaN()

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -369,7 +369,7 @@ func GetClusterSize(cluster string) (int, error) {
 func IsMultiNode(logger *logrus.Entry) bool {
 	inputFileName := GetConfigFilePath()
 
-	configYML, err := os.ReadFile(inputFileName)
+	configYML, err := os.ReadFile(inputFileName) // #nosec G304 -- this is a trusted etcd config file.
 	if err != nil {
 		return false
 	}
@@ -528,7 +528,7 @@ func RemoveMemberFromCluster(ctx context.Context, cli etcdClient.ClusterCloser, 
 
 // ReadConfigFileAsMap reads the config file given a path and converts it into a map[string]interface{}
 func ReadConfigFileAsMap(path string) (map[string]interface{}, error) {
-	configYML, err := os.ReadFile(path)
+	configYML, err := os.ReadFile(path) // #nosec G304 -- this is a trusted etcd config file.
 	if err != nil {
 		return nil, fmt.Errorf("unable to read etcd config file at path: %s : %v", path, err)
 	}
@@ -540,10 +540,10 @@ func ReadConfigFileAsMap(path string) (map[string]interface{}, error) {
 	return c, nil
 }
 
-// parseAdvertiseURLsConfig reads and parses the config file and returns the advertise URLs config.
+// parseAdvertiseURLsConfig reads and parses the config file and returns the advertise-urls config.
 func parseAdvertiseURLsConfig(configFile string) (*advertiseURLsConfig, error) {
 	var advURLsConfig advertiseURLsConfig
-	config, err := os.ReadFile(configFile)
+	config, err := os.ReadFile(configFile) // #nosec G304 -- this is a trusted advertise-urls config file.
 	if err != nil {
 		return nil, fmt.Errorf("unable to read etcd config file at path: %s : %w", configFile, err)
 	}
@@ -679,7 +679,7 @@ func RestartEtcdWrapper(ctx context.Context, tlsEnabled bool, etcdConnectionConf
 		}
 		caCertPool.AppendCertsFromPEM(caCert)
 		client.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
+			TLSClientConfig: &tls.Config{ // #nosec G402 -- TLSClientConfig.MinVersion=1.2 by default.
 				RootCAs: caCertPool,
 			},
 		}

--- a/pkg/snapshot/snapshotter/garbagecollector.go
+++ b/pkg/snapshot/snapshotter/garbagecollector.go
@@ -178,6 +178,7 @@ func (ssr *Snapshotter) RunGarbageCollector(stopCh <-chan struct{}) {
 					if err != nil {
 						continue
 					}
+					// #nosec G115 -- validated for size to be lesser than MaxInt.
 					if fullSnapshotIndex < len(fullSnapshotIndexList)-int(ssr.config.MaxBackups) {
 						snap := snapList[fullSnapshotIndexList[fullSnapshotIndex]]
 						snapPath := path.Join(snap.SnapDir, snap.SnapName)

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -610,6 +610,7 @@ func (ssr *Snapshotter) handleDeltaWatchEvents(wr clientv3.WatchResponse) error 
 		metrics.SnapshotRequired.With(prometheus.Labels{metrics.LabelKind: brtypes.SnapshotKindDelta}).Set(1)
 	}
 	ssr.logger.Debugf("Added events till revision: %d", ssr.lastEventRevision)
+	// #nosec G115 -- validated for size to be lesser than MaxInt.
 	if len(ssr.events) >= int(ssr.config.DeltaSnapshotMemoryLimit) {
 		ssr.logger.Infof("Delta events memory crossed the memory limit: %d Bytes", len(ssr.events))
 		_, err := ssr.takeDeltaSnapshotAndResetTimer()

--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -34,8 +35,8 @@ import (
 )
 
 const (
-	absCredentialDirectory = "AZURE_APPLICATION_CREDENTIALS"
-	absCredentialJSONFile  = "AZURE_APPLICATION_CREDENTIALS_JSON"
+	absCredentialDirectory = "AZURE_APPLICATION_CREDENTIALS"      // #nosec G101 -- This is not a hardcoded password, but only a path to the credentials.
+	absCredentialJSONFile  = "AZURE_APPLICATION_CREDENTIALS_JSON" // #nosec G101 -- This is not a hardcoded password, but only a path to the credentials.
 	// AzuriteEndpoint is the environment variable which indicates the endpoint at which the Azurite emulator is hosted
 	AzuriteEndpoint = "AZURE_STORAGE_API_ENDPOINT"
 )
@@ -203,7 +204,7 @@ func getCredentials(prefixString string) (*absCredentials, error) {
 }
 
 func readABSCredentialsJSON(filename string) (*absCredentials, error) {
-	jsonData, err := os.ReadFile(filename)
+	jsonData, err := os.ReadFile(filename) // #nosec G304 -- this is a trusted file, obtained via user input.
 	if err != nil {
 		return nil, err
 	}
@@ -230,19 +231,19 @@ func readABSCredentialFiles(dirname string) (*absCredentials, error) {
 
 	for _, file := range files {
 		if file.Name() == "storageAccount" {
-			data, err := os.ReadFile(path.Join(dirname, file.Name()))
+			data, err := os.ReadFile(path.Join(dirname, file.Name())) // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {
 				return nil, err
 			}
 			absConfig.StorageAccount = string(data)
 		} else if file.Name() == "storageKey" {
-			data, err := os.ReadFile(path.Join(dirname, file.Name()))
+			data, err := os.ReadFile(path.Join(dirname, file.Name())) // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {
 				return nil, err
 			}
 			absConfig.StorageKey = string(data)
 		} else if file.Name() == "domain" {
-			data, err := os.ReadFile(path.Join(dirname, file.Name()))
+			data, err := os.ReadFile(path.Join(dirname, file.Name())) // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {
 				return nil, err
 			}
@@ -338,22 +339,24 @@ func (a *ABSSnapStore) List(includeAll bool) (brtypes.SnapList, error) {
 }
 
 // Save will write the snapshot to store
-func (a *ABSSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
-	// Save it locally
-	tmpfile, err := os.CreateTemp(a.tempDir, tmpBackupFilePrefix)
+func (a *ABSSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) (err error) {
+	tempFile, size, err := writeSnapshotToTempFile(a.tempDir, rc)
 	if err != nil {
-		rc.Close()
-		return fmt.Errorf("failed to create snapshot tempfile: %w", err)
+		return err
 	}
 	defer func() {
-		tmpfile.Close()
-		os.Remove(tmpfile.Name())
+		err1 := tempFile.Close()
+		if err1 != nil {
+			err1 = fmt.Errorf("failed to close snapshot tempfile: %v", err1)
+		}
+		err2 := os.Remove(tempFile.Name())
+		if err2 != nil {
+			err2 = fmt.Errorf("failed to remove snapshot tempfile: %v", err2)
+		}
+		if err1 != nil || err2 != nil {
+			err = errors.Join(err1, err2)
+		}
 	}()
-	size, err := io.Copy(tmpfile, rc)
-	rc.Close()
-	if err != nil {
-		return fmt.Errorf("failed to save snapshot to tmpfile: %w", err)
-	}
 
 	var (
 		chunkSize  = a.minChunkSize
@@ -372,7 +375,7 @@ func (a *ABSSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
 
 	for i := uint(0); i < a.maxParallelChunkUploads; i++ {
 		wg.Add(1)
-		go a.blockUploader(&wg, cancelCh, &snap, tmpfile, chunkUploadCh, resCh)
+		go a.blockUploader(&wg, cancelCh, &snap, tempFile, chunkUploadCh, resCh)
 	}
 	logrus.Infof("Uploading snapshot of size: %d, chunkSize: %d, noOfChunks: %d", size, chunkSize, noOfChunks)
 	for offset, index := int64(0), 1; offset < size; offset += int64(chunkSize) {

--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -353,9 +353,7 @@ func (a *ABSSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) (err error)
 		if err2 != nil {
 			err2 = fmt.Errorf("failed to remove snapshot tempfile: %v", err2)
 		}
-		if err1 != nil || err2 != nil {
-			err = errors.Join(err1, err2)
-		}
+		err = errors.Join(err, err1, err2)
 	}()
 
 	var (

--- a/pkg/snapstore/ecs_s3_snapstore.go
+++ b/pkg/snapstore/ecs_s3_snapstore.go
@@ -16,7 +16,7 @@ const (
 	ecsDisableSSL         string = "ECS_DISABLE_SSL"
 	ecsInsecureSkipVerify string = "ECS_INSECURE_SKIP_VERIFY"
 	ecsAccessKeyID        string = "ECS_ACCESS_KEY_ID"
-	ecsSecretAccessKey    string = "ECS_SECRET_ACCESS_KEY"
+	ecsSecretAccessKey    string = "ECS_SECRET_ACCESS_KEY" // #nosec G101 -- This is not a hardcoded password, but only the environment variable to the credentials.
 )
 
 // NewECSSnapStore creates a new S3SnapStore from shared configuration with the specified bucket.

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -178,9 +178,7 @@ func (s *GCSSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) (err error)
 		if err2 != nil {
 			err2 = fmt.Errorf("failed to remove snapshot tempfile: %v", err2)
 		}
-		if err1 != nil || err2 != nil {
-			err = errors.Join(err1, err2)
-		}
+		err = errors.Join(err, err1, err2)
 	}()
 
 	var (

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -6,6 +6,7 @@ package snapstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -27,7 +28,7 @@ import (
 )
 
 const (
-	envStoreCredentials       = "GOOGLE_APPLICATION_CREDENTIALS"
+	envStoreCredentials       = "GOOGLE_APPLICATION_CREDENTIALS" // #nosec G101 -- This is not a hardcoded password, but only the environment variable to the credentials.
 	envStorageAPIEndpoint     = "GOOGLE_STORAGE_API_ENDPOINT"
 	envSourceStoreCredentials = "SOURCE_GOOGLE_APPLICATION_CREDENTIALS"
 
@@ -105,7 +106,7 @@ func NewGCSSnapStore(config *brtypes.SnapstoreConfig) (*GCSSnapStore, error) {
 
 func getGCSStorageAPIEndpoint(path string) (string, error) {
 	if _, err := os.Stat(path); err == nil {
-		data, err := os.ReadFile(path)
+		data, err := os.ReadFile(path) // #nosec G304 -- this is a trusted file, obtained via user input.
 		if err != nil {
 			return "", err
 		}
@@ -163,21 +164,24 @@ func (s *GCSSnapStore) Fetch(snap brtypes.Snapshot) (io.ReadCloser, error) {
 }
 
 // Save will write the snapshot to store.
-func (s *GCSSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
-	tmpfile, err := os.CreateTemp(s.tempDir, tmpBackupFilePrefix)
+func (s *GCSSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) (err error) {
+	tempFile, size, err := writeSnapshotToTempFile(s.tempDir, rc)
 	if err != nil {
-		rc.Close()
-		return fmt.Errorf("failed to create snapshot tempfile: %v", err)
+		return err
 	}
 	defer func() {
-		tmpfile.Close()
-		os.Remove(tmpfile.Name())
+		err1 := tempFile.Close()
+		if err1 != nil {
+			err1 = fmt.Errorf("failed to close snapshot tempfile: %v", err1)
+		}
+		err2 := os.Remove(tempFile.Name())
+		if err2 != nil {
+			err2 = fmt.Errorf("failed to remove snapshot tempfile: %v", err2)
+		}
+		if err1 != nil || err2 != nil {
+			err = errors.Join(err1, err2)
+		}
 	}()
-	size, err := io.Copy(tmpfile, rc)
-	rc.Close()
-	if err != nil {
-		return fmt.Errorf("failed to save snapshot to tmpfile: %v", err)
-	}
 
 	var (
 		chunkSize  = int64(math.Max(float64(s.minChunkSize), float64(size/gcsNoOfChunk)))
@@ -196,7 +200,7 @@ func (s *GCSSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
 
 	for i := uint(0); i < s.maxParallelChunkUploads; i++ {
 		wg.Add(1)
-		go s.componentUploader(&wg, cancelCh, &snap, tmpfile, chunkUploadCh, resCh)
+		go s.componentUploader(&wg, cancelCh, &snap, tempFile, chunkUploadCh, resCh)
 	}
 
 	logrus.Infof("Uploading snapshot of size: %d, chunkSize: %d, noOfChunks: %d", size, chunkSize, noOfChunks)
@@ -257,7 +261,9 @@ func (s *GCSSnapStore) uploadComponent(snap *brtypes.Snapshot, file *os.File, of
 	defer cancel()
 	w := obj.NewWriter(ctx)
 	if _, err := io.Copy(w, sr); err != nil {
-		w.Close()
+		if err1 := w.Close(); err1 != nil {
+			return errors.Join(err, err1)
+		}
 		return err
 	}
 	return w.Close()

--- a/pkg/snapstore/generic_s3_snapstore.go
+++ b/pkg/snapstore/generic_s3_snapstore.go
@@ -30,7 +30,7 @@ func newGenericS3FromAuthOpt(bucket, prefix, tempDir string, maxParallelChunkUpl
 	httpClient := http.DefaultClient
 	if !ao.disableSSL {
 		httpClient.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: ao.insecureSkipVerify},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: ao.insecureSkipVerify}, // #nosec G402 -- InsecureSkipVerify is set by user input, and can be allowed to be set to true based on user's requirement.
 		}
 	}
 

--- a/pkg/snapstore/ocs_s3_snapstore.go
+++ b/pkg/snapstore/ocs_s3_snapstore.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	ocsCredentialDirectory string = "OPENSHIFT_APPLICATION_CREDENTIALS"
-	ocsCredentialJSONFile  string = "OPENSHIFT_APPLICATION_CREDENTIALS_JSON"
+	ocsCredentialDirectory string = "OPENSHIFT_APPLICATION_CREDENTIALS"      // #nosec G101 -- This is not a hardcoded password, but only a path to the credentials.
+	ocsCredentialJSONFile  string = "OPENSHIFT_APPLICATION_CREDENTIALS_JSON" // #nosec G101 -- This is not a hardcoded password, but only a path to the credentials.
 )
 
 type ocsAuthOptions struct {
@@ -88,7 +88,7 @@ func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
 		switch file.Name() {
 		case "endpoint":
 			{
-				data, err := os.ReadFile(dirname + "/endpoint")
+				data, err := os.ReadFile(dirname + "/endpoint") // #nosec G304 -- this is a trusted file, obtained via user input.
 				if err != nil {
 					return nil, err
 				}
@@ -96,7 +96,7 @@ func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
 			}
 		case "accessKeyID":
 			{
-				data, err := os.ReadFile(dirname + "/accessKeyID")
+				data, err := os.ReadFile(dirname + "/accessKeyID") // #nosec G304 -- this is a trusted file, obtained via user input.
 				if err != nil {
 					return nil, err
 				}
@@ -104,7 +104,7 @@ func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
 			}
 		case "secretAccessKey":
 			{
-				data, err := os.ReadFile(dirname + "/secretAccessKey")
+				data, err := os.ReadFile(dirname + "/secretAccessKey") // #nosec G304 -- this is a trusted file, obtained via user input.
 				if err != nil {
 					return nil, err
 				}
@@ -112,7 +112,7 @@ func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
 			}
 		case "region":
 			{
-				data, err := os.ReadFile(dirname + "/region")
+				data, err := os.ReadFile(dirname + "/region") // #nosec G304 -- this is a trusted file, obtained via user input.
 				if err != nil {
 					return nil, err
 				}
@@ -120,7 +120,7 @@ func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
 			}
 		case "disableSSL":
 			{
-				data, err := os.ReadFile(dirname + "/disableSSL")
+				data, err := os.ReadFile(dirname + "/disableSSL") // #nosec G304 -- this is a trusted file, obtained via user input.
 				if err != nil {
 					return nil, err
 				}
@@ -131,7 +131,7 @@ func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
 			}
 		case "insecureSkipVerify":
 			{
-				data, err := os.ReadFile(dirname + "/insecureSkipVerify")
+				data, err := os.ReadFile(dirname + "/insecureSkipVerify") // #nosec G304 -- this is a trusted file, obtained via user input.
 				if err != nil {
 					return nil, err
 				}
@@ -150,7 +150,7 @@ func readOCSCredentialFromDir(dirname string) (*ocsAuthOptions, error) {
 }
 
 func readOCSCredentialsJSON(filename string) (*ocsAuthOptions, error) {
-	jsonData, err := os.ReadFile(filename)
+	jsonData, err := os.ReadFile(filename) // #nosec G304 -- this is a trusted file, obtained via user input.
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/snapstore/oss_snapstore.go
+++ b/pkg/snapstore/oss_snapstore.go
@@ -117,9 +117,7 @@ func (s *OSSSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) (err error)
 		if err2 != nil {
 			err2 = fmt.Errorf("failed to remove snapshot tempfile: %v", err2)
 		}
-		if err1 != nil || err2 != nil {
-			err = errors.Join(err1, err2)
-		}
+		err = errors.Join(err, err1, err2)
 	}()
 
 	_, err = tempFile.Seek(0, io.SeekStart)

--- a/pkg/snapstore/oss_snapstore.go
+++ b/pkg/snapstore/oss_snapstore.go
@@ -6,6 +6,7 @@ package snapstore
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -37,8 +38,8 @@ type OSSBucket interface {
 const (
 	// Total number of chunks to be uploaded must be one less than maximum limit allowed.
 	ossNoOfChunk           int64 = 9999
-	aliCredentialDirectory       = "ALICLOUD_APPLICATION_CREDENTIALS"
-	aliCredentialJSONFile        = "ALICLOUD_APPLICATION_CREDENTIALS_JSON"
+	aliCredentialDirectory       = "ALICLOUD_APPLICATION_CREDENTIALS"      // #nosec G101 -- This is not a hardcoded password, but only a path to the credentials.
+	aliCredentialJSONFile        = "ALICLOUD_APPLICATION_CREDENTIALS_JSON" // #nosec G101 -- This is not a hardcoded password, but only a path to the credentials.
 )
 
 type authOptions struct {
@@ -102,23 +103,26 @@ func (s *OSSSnapStore) Fetch(snap brtypes.Snapshot) (io.ReadCloser, error) {
 }
 
 // Save will write the snapshot to store
-func (s *OSSSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
-	tmpfile, err := os.CreateTemp(s.tempDir, tmpBackupFilePrefix)
+func (s *OSSSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) (err error) {
+	tempFile, size, err := writeSnapshotToTempFile(s.tempDir, rc)
 	if err != nil {
-		rc.Close()
-		return fmt.Errorf("failed to create snapshot tempfile: %v", err)
+		return err
 	}
 	defer func() {
-		tmpfile.Close()
-		os.Remove(tmpfile.Name())
+		err1 := tempFile.Close()
+		if err1 != nil {
+			err1 = fmt.Errorf("failed to close snapshot tempfile: %v", err1)
+		}
+		err2 := os.Remove(tempFile.Name())
+		if err2 != nil {
+			err2 = fmt.Errorf("failed to remove snapshot tempfile: %v", err2)
+		}
+		if err1 != nil || err2 != nil {
+			err = errors.Join(err1, err2)
+		}
 	}()
 
-	size, err := io.Copy(tmpfile, rc)
-	rc.Close()
-	if err != nil {
-		return fmt.Errorf("failed to save snapshot to tmpfile: %v", err)
-	}
-	_, err = tmpfile.Seek(0, io.SeekStart)
+	_, err = tempFile.Seek(0, io.SeekStart)
 	if err != nil {
 		return err
 	}
@@ -131,7 +135,7 @@ func (s *OSSSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
 		noOfChunks++
 	}
 
-	ossChunks, err := oss.SplitFileByPartNum(tmpfile.Name(), int(noOfChunks))
+	ossChunks, err := oss.SplitFileByPartNum(tempFile.Name(), int(noOfChunks))
 	if err != nil {
 		return err
 	}
@@ -151,17 +155,17 @@ func (s *OSSSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
 
 	for i := uint(0); i < s.maxParallelChunkUploads; i++ {
 		wg.Add(1)
-		go s.partUploader(&wg, imur, tmpfile, completedParts, chunkUploadCh, cancelCh, resCh)
+		go s.partUploader(&wg, imur, tempFile, completedParts, chunkUploadCh, cancelCh, resCh)
 	}
 
 	for _, ossChunk := range ossChunks {
-		chunk := chunk{
+		c := chunk{
 			offset: ossChunk.Offset,
 			size:   ossChunk.Size,
 			id:     ossChunk.Number,
 		}
-		logrus.Debugf("Triggering chunk upload for offset: %d", chunk.offset)
-		chunkUploadCh <- chunk
+		logrus.Debugf("Triggering chunk upload for offset: %d", c.offset)
+		chunkUploadCh <- c
 	}
 
 	logrus.Infof("Triggered chunk upload for all chunks, total: %d", noOfChunks)
@@ -295,7 +299,7 @@ func getAuthOptions(prefix string) (*authOptions, error) {
 }
 
 func readALICredentialsJSON(filename string) (*authOptions, error) {
-	jsonData, err := os.ReadFile(filename)
+	jsonData, err := os.ReadFile(filename) // #nosec G304 -- this is a trusted file, obtained via user input.
 	if err != nil {
 		return nil, err
 	}
@@ -323,19 +327,19 @@ func readALICredentialFiles(dirname string) (*authOptions, error) {
 
 	for _, file := range files {
 		if file.Name() == "storageEndpoint" {
-			data, err := os.ReadFile(dirname + "/storageEndpoint")
+			data, err := os.ReadFile(dirname + "/storageEndpoint") // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {
 				return nil, err
 			}
 			aliConfig.Endpoint = string(data)
 		} else if file.Name() == "accessKeySecret" {
-			data, err := os.ReadFile(dirname + "/accessKeySecret")
+			data, err := os.ReadFile(dirname + "/accessKeySecret") // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {
 				return nil, err
 			}
 			aliConfig.AccessKey = string(data)
 		} else if file.Name() == "accessKeyID" {
-			data, err := os.ReadFile(dirname + "/accessKeyID")
+			data, err := os.ReadFile(dirname + "/accessKeyID") // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -353,9 +353,7 @@ func (s *S3SnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) (err error) 
 		if err2 != nil {
 			err2 = fmt.Errorf("failed to remove snapshot tempfile: %v", err2)
 		}
-		if err1 != nil || err2 != nil {
-			err = errors.Join(err1, err2)
-		}
+		err = errors.Join(err, err1, err2)
 	}()
 
 	_, err = tempFile.Seek(0, io.SeekStart)

--- a/pkg/snapstore/swift_snapstore.go
+++ b/pkg/snapstore/swift_snapstore.go
@@ -357,9 +357,7 @@ func (s *SwiftSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) (err erro
 		if err2 != nil {
 			err2 = fmt.Errorf("failed to remove snapshot tempfile: %v", err2)
 		}
-		if err1 != nil || err2 != nil {
-			err = errors.Join(err1, err2)
-		}
+		err = errors.Join(err, err1, err2)
 	}()
 
 	var (

--- a/pkg/snapstore/swift_snapstore.go
+++ b/pkg/snapstore/swift_snapstore.go
@@ -34,8 +34,8 @@ const (
 	envPrefixSource                 = "SOURCE_OS_"
 	authTypePassword                = "password"
 	authTypeV3ApplicationCredential = "v3applicationcredential"
-	swiftCredentialDirectory        = "OPENSTACK_APPLICATION_CREDENTIALS"
-	swiftCredentialJSONFile         = "OPENSTACK_APPLICATION_CREDENTIALS_JSON"
+	swiftCredentialDirectory        = "OPENSTACK_APPLICATION_CREDENTIALS"      // #nosec G101 -- This is not a hardcoded password, but only a path to the credentials.
+	swiftCredentialJSONFile         = "OPENSTACK_APPLICATION_CREDENTIALS_JSON" // #nosec G101 -- This is not a hardcoded password, but only a path to the credentials.
 )
 
 // SwiftSnapStore is snapstore with Openstack Swift as backend
@@ -143,7 +143,7 @@ func getClientOpts(isSource bool) (*clientconfig.ClientOpts, error) {
 	}
 
 	// If a neither a swiftCredentialFile nor a swiftCredentialJSONFile was found, fall back to
-	// retreiving credentials from environment variables.
+	// retrieving credentials from environment variables.
 	// If the snapstore is used as source during a copy operation all environment variables have a SOURCE_OS_ prefix.
 	if isSource {
 		return &clientconfig.ClientOpts{EnvPrefix: envPrefixSource}, nil
@@ -161,7 +161,9 @@ func readSwiftCredentialsJSON(filename string) (*clientconfig.ClientOpts, error)
 		return &clientconfig.ClientOpts{}, err
 	}
 
-	os.Setenv("OS_TENANT_NAME", cred.TenantName)
+	if err := os.Setenv("OS_TENANT_NAME", cred.TenantName); err != nil {
+		return nil, fmt.Errorf("error setting tenant name: %w", err)
+	}
 
 	if cred.AuthType == authTypeV3ApplicationCredential {
 		return &clientconfig.ClientOpts{
@@ -192,7 +194,7 @@ func readSwiftCredentialsJSON(filename string) (*clientconfig.ClientOpts, error)
 // swiftCredentialsFromJSON obtains Swift credentials from a JSON value.
 func swiftCredentialsFromJSON(filename string) (*swiftCredentials, error) {
 	cred := &swiftCredentials{}
-	jsonData, err := os.ReadFile(filename)
+	jsonData, err := os.ReadFile(filename) // #nosec G304 -- this is a trusted file, obtained via user input.
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +216,9 @@ func readSwiftCredentialFiles(dirname string) (*clientconfig.ClientOpts, error) 
 		return nil, err
 	}
 
-	os.Setenv("OS_TENANT_NAME", cred.TenantName)
+	if err := os.Setenv("OS_TENANT_NAME", cred.TenantName); err != nil {
+		return nil, fmt.Errorf("error setting tenant name: %w", err)
+	}
 
 	if cred.AuthType == authTypeV3ApplicationCredential {
 		return &clientconfig.ClientOpts{
@@ -256,56 +260,56 @@ func readSwiftCredentialDir(dirName string) (*swiftCredentials, error) {
 	for _, file := range files {
 		switch file.Name() {
 		case "authURL":
-			data, err := os.ReadFile(dirName + "/authURL")
+			data, err := os.ReadFile(dirName + "/authURL") // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {
 				return nil, err
 			}
 			cred.AuthURL = string(data)
 
 		case "domainName":
-			data, err := os.ReadFile(dirName + "/domainName")
+			data, err := os.ReadFile(dirName + "/domainName") // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {
 				return nil, err
 			}
 			cred.DomainName = string(data)
 		case "password":
-			data, err := os.ReadFile(dirName + "/password")
+			data, err := os.ReadFile(dirName + "/password") // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {
 				return nil, err
 			}
 			cred.Password = string(data)
 		case "region":
-			data, err := os.ReadFile(dirName + "/region")
+			data, err := os.ReadFile(dirName + "/region") // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {
 				return nil, err
 			}
 			cred.Region = string(data)
 		case "tenantName":
-			data, err := os.ReadFile(dirName + "/tenantName")
+			data, err := os.ReadFile(dirName + "/tenantName") // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {
 				return nil, err
 			}
 			cred.TenantName = string(data)
 		case "username":
-			data, err := os.ReadFile(dirName + "/username")
+			data, err := os.ReadFile(dirName + "/username") // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {
 				return nil, err
 			}
 			cred.Username = string(data)
 		case "applicationCredentialID":
-			data, err := os.ReadFile(dirName + "/applicationCredentialID")
+			data, err := os.ReadFile(dirName + "/applicationCredentialID") // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {
 				return nil, err
 			}
 			cred.ApplicationCredentialID = string(data)
 		case "applicationCredentialName":
-			data, err := os.ReadFile(dirName + "/applicationCredentialName")
+			data, err := os.ReadFile(dirName + "/applicationCredentialName") // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {
 				return nil, err
 			}
 			cred.ApplicationCredentialName = string(data)
 		case "applicationCredentialSecret":
-			data, err := os.ReadFile(dirName + "/applicationCredentialSecret")
+			data, err := os.ReadFile(dirName + "/applicationCredentialSecret") // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {
 				return nil, err
 			}
@@ -339,22 +343,24 @@ func (s *SwiftSnapStore) Fetch(snap brtypes.Snapshot) (io.ReadCloser, error) {
 
 // Save will write the snapshot to store, as a DLO (dynamic large object), as described
 // in https://docs.openstack.org/swift/latest/overview_large_objects.html
-func (s *SwiftSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
-	// Save it locally
-	tempFile, err := os.CreateTemp(s.tempDir, tmpBackupFilePrefix)
+func (s *SwiftSnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) (err error) {
+	tempFile, size, err := writeSnapshotToTempFile(s.tempDir, rc)
 	if err != nil {
-		rc.Close()
-		return fmt.Errorf("failed to create snapshot tempfile: %v", err)
+		return err
 	}
 	defer func() {
-		tempFile.Close()
-		os.Remove(tempFile.Name())
+		err1 := tempFile.Close()
+		if err1 != nil {
+			err1 = fmt.Errorf("failed to close snapshot tempfile: %v", err1)
+		}
+		err2 := os.Remove(tempFile.Name())
+		if err2 != nil {
+			err2 = fmt.Errorf("failed to remove snapshot tempfile: %v", err2)
+		}
+		if err1 != nil || err2 != nil {
+			err = errors.Join(err1, err2)
+		}
 	}()
-	size, err := io.Copy(tempFile, rc)
-	rc.Close()
-	if err != nil {
-		return fmt.Errorf("failed to save snapshot to tempFile: %v", err)
-	}
 
 	var (
 		chunkSize  = int64(math.Max(float64(s.minChunkSize), float64(size/swiftNoOfChunk)))

--- a/pkg/snapstore/utils.go
+++ b/pkg/snapstore/utils.go
@@ -5,6 +5,7 @@
 package snapstore
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -256,7 +257,7 @@ func getJSONCredentialModifiedTime(dir string) (time.Time, error) {
 func writeSnapshotToTempFile(tempDir string, rc io.ReadCloser) (tempFile *os.File, written int64, err error) {
 	defer func() {
 		if err1 := rc.Close(); err1 != nil {
-			err = fmt.Errorf("failed to close snapshot reader: %v", err1)
+			err = errors.Join(err, fmt.Errorf("failed to close snapshot reader: %v", err1))
 		}
 	}()
 

--- a/pkg/types/exponentialbackoff.go
+++ b/pkg/types/exponentialbackoff.go
@@ -6,6 +6,7 @@ package types
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/gardener/etcd-backup-restore/pkg/wrappers"
@@ -51,6 +52,8 @@ func (e *ExponentialBackoffConfig) AddFlags(fs *flag.FlagSet) {
 func (e *ExponentialBackoffConfig) Validate() error {
 	if e.Multiplier <= 0 {
 		return fmt.Errorf("multiplicative factor for backoff mechanism can't be less than zero")
+	} else if e.Multiplier > math.MaxInt64 {
+		return fmt.Errorf("multiplicative factor for backoff mechanism can't be more than %d", math.MaxInt64)
 	}
 	if e.AttemptLimit <= 0 {
 		return fmt.Errorf("backoff attempt-limit can't be less than zero")

--- a/pkg/types/restorer.go
+++ b/pkg/types/restorer.go
@@ -164,7 +164,7 @@ type InitIndex int
 
 // ConsistentIndex gets the index
 func (i *InitIndex) ConsistentIndex() uint64 {
-	return uint64(*i)
+	return uint64(*i) // #nosec G115 -- size of InitIndex (int) is lesser than or equal to size of uint64, so no overflow is possible.
 }
 
 // Event is wrapper over etcd event to keep track of time of event

--- a/pkg/types/snapshotter.go
+++ b/pkg/types/snapshotter.go
@@ -6,6 +6,7 @@ package types
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/gardener/etcd-backup-restore/pkg/wrappers"
@@ -77,6 +78,9 @@ func (c *SnapshotterConfig) Validate() error {
 	if c.GarbageCollectionPolicy == GarbageCollectionPolicyLimitBased && c.MaxBackups <= 0 {
 		return fmt.Errorf("max backups should be greather than zero for garbage collection policy set to limit based")
 	}
+	if c.MaxBackups > math.MaxInt {
+		return fmt.Errorf("max backups %d is greater than %d", c.MaxBackups, math.MaxInt)
+	}
 
 	if c.DeltaSnapshotPeriod.Duration < DeltaSnapshotIntervalThreshold {
 		logrus.Infof("Found delta snapshot interval %s less than 1 second. Disabling delta snapshotting. ", c.DeltaSnapshotPeriod)
@@ -85,6 +89,8 @@ func (c *SnapshotterConfig) Validate() error {
 	if c.DeltaSnapshotMemoryLimit < 1 {
 		logrus.Infof("Found delta snapshot memory limit %d bytes less than 1 byte. Setting it to default: %d ", c.DeltaSnapshotMemoryLimit, DefaultDeltaSnapMemoryLimit)
 		c.DeltaSnapshotMemoryLimit = DefaultDeltaSnapMemoryLimit
+	} else if c.DeltaSnapshotMemoryLimit > math.MaxInt {
+		return fmt.Errorf("delta snapshot memory limit %d bytes is greater than %d bytes", c.DeltaSnapshotMemoryLimit, math.MaxInt)
 	}
 	return nil
 }

--- a/test/e2e/integration/utils.go
+++ b/test/e2e/integration/utils.go
@@ -33,7 +33,6 @@ func (cmd *Cmd) StopProcess() {
 
 // RunCmdWithFlags creates a process out of the  Cmd object.
 func (cmd *Cmd) RunCmdWithFlags() error {
-	var err error
 	cmd.process = exec.Command(cmd.Task, cmd.Flags...) // #nosec G204 -- only used by integration tests.
 	file, err := os.Create(cmd.Logfile)
 	if err != nil {
@@ -101,7 +100,7 @@ func (cmd *Cmd) RunCmdWithFlags() error {
 	if err = cmd.process.Wait(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			cmd.Logger.Infof("command execution stopped (signal: %s)", exitErr.Error())
+			cmd.Logger.Errorf("command execution stopped (signal: %s)", exitErr.Error())
 		}
 	}
 	return nil

--- a/test/e2e/integration/utils.go
+++ b/test/e2e/integration/utils.go
@@ -6,6 +6,7 @@ package integration
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -25,18 +26,24 @@ type Cmd struct {
 
 // StopProcess is used to signal SIGTERM to the running process.
 func (cmd *Cmd) StopProcess() {
-	cmd.process.Process.Signal(os.Interrupt)
+	if err := cmd.process.Process.Signal(os.Interrupt); err != nil {
+		cmd.Logger.Errorf("failed to stop process %s: %v", cmd.Task, err)
+	}
 }
 
 // RunCmdWithFlags creates a process out of the  Cmd object.
 func (cmd *Cmd) RunCmdWithFlags() error {
-	cmd.process = exec.Command(cmd.Task, cmd.Flags...)
+	cmd.process = exec.Command(cmd.Task, cmd.Flags...) // #nosec G204 -- only used by integration tests.
 	file, err := os.Create(cmd.Logfile)
 	if err != nil {
 		cmd.Logger.Errorf("failed to create log file for command %s: %v", cmd.Task, err)
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		if err1 := file.Close(); err1 != nil {
+			cmd.Logger.Errorf("failed to close log file for command %s: %v", cmd.Task, err1)
+		}
+	}()
 	cmd.Logger.Infof("%v %v", cmd.Task, cmd.Flags)
 	logWriter := bufio.NewWriter(file)
 	stderr, err := cmd.process.StderrPipe()
@@ -62,8 +69,12 @@ func (cmd *Cmd) RunCmdWithFlags() error {
 				break
 			}
 			if len(line) > 0 {
-				logWriter.WriteString(fmt.Sprintf("%s\n", line))
-				logWriter.Flush()
+				if _, err1 := logWriter.WriteString(fmt.Sprintf("%s\n", line)); err1 != nil {
+					cmd.Logger.Errorf("failed to write to log file for command %s: %v", cmd.Task, err1)
+				}
+				if err1 := logWriter.Flush(); err1 != nil {
+					cmd.Logger.Errorf("failed to flush log file for command %s: %v", cmd.Task, err1)
+				}
 			}
 		}
 	}()
@@ -76,18 +87,20 @@ func (cmd *Cmd) RunCmdWithFlags() error {
 				break
 			}
 			if len(line) > 0 {
-				logWriter.WriteString(fmt.Sprintf("%s\n", line))
-				logWriter.Flush()
+				if _, err1 := logWriter.WriteString(fmt.Sprintf("%s\n", line)); err1 != nil {
+					cmd.Logger.Errorf("failed to write to log file for command %s: %v", cmd.Task, err1)
+				}
+				if err1 := logWriter.Flush(); err1 != nil {
+					cmd.Logger.Errorf("failed to flush log file for command %s: %v", cmd.Task, err1)
+				}
 			}
 		}
 	}()
 
-	if err := cmd.process.Wait(); err != nil {
-		if exiterr, ok := err.(*exec.ExitError); ok {
-			cmd.Logger.Infof("command execution stopped (signal: %s)", exiterr.Error())
-		} else if err != nil {
-			cmd.Logger.Errorf("command %s failed with error: %v", cmd.Task, err)
-			return err
+	if err1 := cmd.process.Wait(); err1 != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err1, &exitErr) {
+			cmd.Logger.Infof("command execution stopped (signal: %s)", exitErr.Error())
 		}
 	}
 	return nil

--- a/test/e2e/integration/utils.go
+++ b/test/e2e/integration/utils.go
@@ -33,6 +33,7 @@ func (cmd *Cmd) StopProcess() {
 
 // RunCmdWithFlags creates a process out of the  Cmd object.
 func (cmd *Cmd) RunCmdWithFlags() error {
+	var err error
 	cmd.process = exec.Command(cmd.Task, cmd.Flags...) // #nosec G204 -- only used by integration tests.
 	file, err := os.Create(cmd.Logfile)
 	if err != nil {
@@ -40,8 +41,8 @@ func (cmd *Cmd) RunCmdWithFlags() error {
 		return err
 	}
 	defer func() {
-		if err1 := file.Close(); err1 != nil {
-			cmd.Logger.Errorf("failed to close log file for command %s: %v", cmd.Task, err1)
+		if err = file.Close(); err != nil {
+			cmd.Logger.Errorf("failed to close log file for command %s: %v", cmd.Task, err)
 		}
 	}()
 	cmd.Logger.Infof("%v %v", cmd.Task, cmd.Flags)
@@ -69,11 +70,11 @@ func (cmd *Cmd) RunCmdWithFlags() error {
 				break
 			}
 			if len(line) > 0 {
-				if _, err1 := logWriter.WriteString(fmt.Sprintf("%s\n", line)); err1 != nil {
-					cmd.Logger.Errorf("failed to write to log file for command %s: %v", cmd.Task, err1)
+				if _, err = logWriter.WriteString(fmt.Sprintf("%s\n", line)); err != nil {
+					cmd.Logger.Errorf("failed to write to log file for command %s: %v", cmd.Task, err)
 				}
-				if err1 := logWriter.Flush(); err1 != nil {
-					cmd.Logger.Errorf("failed to flush log file for command %s: %v", cmd.Task, err1)
+				if err = logWriter.Flush(); err != nil {
+					cmd.Logger.Errorf("failed to flush log file for command %s: %v", cmd.Task, err)
 				}
 			}
 		}
@@ -87,19 +88,19 @@ func (cmd *Cmd) RunCmdWithFlags() error {
 				break
 			}
 			if len(line) > 0 {
-				if _, err1 := logWriter.WriteString(fmt.Sprintf("%s\n", line)); err1 != nil {
-					cmd.Logger.Errorf("failed to write to log file for command %s: %v", cmd.Task, err1)
+				if _, err = logWriter.WriteString(fmt.Sprintf("%s\n", line)); err != nil {
+					cmd.Logger.Errorf("failed to write to log file for command %s: %v", cmd.Task, err)
 				}
-				if err1 := logWriter.Flush(); err1 != nil {
-					cmd.Logger.Errorf("failed to flush log file for command %s: %v", cmd.Task, err1)
+				if err = logWriter.Flush(); err != nil {
+					cmd.Logger.Errorf("failed to flush log file for command %s: %v", cmd.Task, err)
 				}
 			}
 		}
 	}()
 
-	if err1 := cmd.process.Wait(); err1 != nil {
+	if err = cmd.process.Wait(); err != nil {
 		var exitErr *exec.ExitError
-		if errors.As(err1, &exitErr) {
+		if errors.As(err, &exitErr) {
 			cmd.Logger.Infof("command execution stopped (signal: %s)", exitErr.Error())
 		}
 	}


### PR DESCRIPTION
/area security
/kind enhancement

**What this PR does / why we need it**:
Introduce `gosec` for Static Application Security Testing (SAST) for etcd-backup-restore.

**Which issue(s) this PR fixes**:
Fixes #812 

**Special notes for your reviewer**:
/invite @ashwani2k @ishan16696 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Introduce `gosec` for Static Application Security Testing (SAST) via `make sast` and `make sast-report`.
```
