### PR TITLE
Read `emulatorEnabled` value for storage emulators from mounted secret instead of environment variables

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -191,25 +191,9 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-etcd-backup
               key: "storageKey"
-  {{- if .Values.backup.abs.emulatorEnabled }}
-        - name: "AZURE_EMULATOR_ENABLED"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-etcd-backup
-              key: "emulatorEnabled"
-              optional: true
-  {{- end }}
 {{- else if eq .Values.backup.storageProvider "GCS" }}
         - name: "GOOGLE_APPLICATION_CREDENTIALS"
           value: "/root/.gcp/serviceaccount.json"
-  {{- if .Values.backup.gcs.emulatorEnabled }}
-        - name: "GOOGLE_EMULATOR_ENABLED"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-etcd-backup
-              key: "emulatorEnabled"
-              optional: true
-  {{- end }}
 {{- else if eq .Values.backup.storageProvider "Swift" }}
         - name: "OS_AUTH_URL"
           valueFrom:

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -74,6 +74,11 @@ func NewGCSSnapStore(config *brtypes.SnapstoreConfig) (*GCSSnapStore, error) {
 		if emulatorConfig.enabled {
 			emulatorConfig.endpoint = endpoint
 		}
+	} else {
+		// if emulator is enabled, but custom storage API endpoint for the emulator is not provided, throw error
+		if emulatorConfig.enabled {
+			return nil, fmt.Errorf("emulator enabled, but `storageAPIEndpoint` not provided")
+		}
 	}
 
 	var chunkDirSuffix string

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -64,7 +64,7 @@ func NewGCSSnapStore(config *brtypes.SnapstoreConfig) (*GCSSnapStore, error) {
 
 	var opts []option.ClientOption // no need to explicitly set store credentials here since the Google SDK picks it up from the standard environment variable
 	var emulatorConfig gcsEmulatorConfig
-	emulatorConfig.enabled = isEmulatorEnabled(config)
+	emulatorConfig.enabled = config.IsEmulatorEnabled || isEmulatorEnabled(config)
 	endpoint, err := getGCSStorageAPIEndpoint(config)
 	if err != nil {
 		return nil, err
@@ -104,6 +104,10 @@ func NewGCSSnapStore(config *brtypes.SnapstoreConfig) (*GCSSnapStore, error) {
 func getGCSStorageAPIEndpoint(config *brtypes.SnapstoreConfig) (string, error) {
 	if gcsApplicationCredentialsPath, isSet := os.LookupEnv(getEnvPrefixString(config.IsSource) + envStoreCredentials); isSet {
 		storageAPIEndpointFilePath := path.Join(path.Dir(gcsApplicationCredentialsPath), fileNameStorageAPIEndpoint)
+		if _, err := os.Stat(storageAPIEndpointFilePath); err != nil {
+			// if the file does not exist, then there is no override for the storage API endpoint
+			return "", nil
+		}
 		endpoint, err := os.ReadFile(storageAPIEndpointFilePath) // #nosec G304 -- this is a trusted file, obtained from mounted secret.
 		if err != nil {
 			return "", fmt.Errorf("error getting storage API endpoint from %v", storageAPIEndpointFilePath)

--- a/pkg/snapstore/snapstore.go
+++ b/pkg/snapstore/snapstore.go
@@ -21,10 +21,6 @@ const (
 
 	backupVersionV1 = "v1"
 	backupVersionV2 = "v2"
-	// EnvAzureEmulatorEnabled is the environment variable which indicates whether the Azurite emulator is enabled
-	EnvAzureEmulatorEnabled = "AZURE_EMULATOR_ENABLED"
-	// EnvGCSEmulatorEnabled is the environment variable which indicates whether the GCS emulator is enabled
-	EnvGCSEmulatorEnabled = "GOOGLE_EMULATOR_ENABLED"
 )
 
 type chunk struct {

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -569,7 +569,7 @@ var _ = Describe("Blob Service URL construction for Azure", func() {
 		It("should return the Azurite blob service URL with HTTP scheme", func() {
 			blobServiceURL, err := ConstructBlobServiceURL(credentials.AccountName(), domain, true)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(blobServiceURL).Should(Equal(fmt.Sprintf("http://%s.%s", credentials.AccountName(), domain)))
+			Expect(blobServiceURL).Should(Equal(fmt.Sprintf("http://%s/%s", domain, credentials.AccountName())))
 		})
 	})
 })

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -558,34 +558,18 @@ var _ = Describe("Blob Service URL construction for Azure", func() {
 		credentials, err = container.NewSharedKeyCredential(storageAccount, storageKey)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
-	Context(fmt.Sprintf("when the environment variable %q is not set", EnvAzureEmulatorEnabled), func() {
-		It("should return the default blob service URL", func() {
-			blobServiceURL, err := ConstructBlobServiceURL(credentials.AccountName(), domain)
+	Context("when emulatorEnabled field is not set or set to false", func() {
+		It("should return the default blob service URL with HTTPS scheme", func() {
+			blobServiceURL, err := ConstructBlobServiceURL(credentials.AccountName(), domain, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(blobServiceURL).Should(Equal(fmt.Sprintf("https://%s.%s", credentials.AccountName(), domain)))
 		})
 	})
-	Context(fmt.Sprintf("when the environment variable %q is set", EnvAzureEmulatorEnabled), func() {
-		Context("to values which are not \"true\"", func() {
-			It("should error when the environment variable is not \"true\" or \"false\"", func() {
-				GinkgoT().Setenv(EnvAzureEmulatorEnabled, "")
-				_, err := ConstructBlobServiceURL(credentials.AccountName(), domain)
-				Expect(err).Should(HaveOccurred())
-			})
-			It("should return the default blob service URL when the environment variable is set to \"false\"", func() {
-				GinkgoT().Setenv(EnvAzureEmulatorEnabled, "false")
-				blobServiceURL, err := ConstructBlobServiceURL(credentials.AccountName(), domain)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(blobServiceURL).Should(Equal(fmt.Sprintf("https://%s.%s", credentials.AccountName(), domain)))
-			})
-		})
-		Context("to \"true\"", func() {
-			It("should return the Azurite blob service URL with HTTP scheme", func() {
-				GinkgoT().Setenv(EnvAzureEmulatorEnabled, "true")
-				blobServiceURL, err := ConstructBlobServiceURL(credentials.AccountName(), domain)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(blobServiceURL).Should(Equal(fmt.Sprintf("http://%s.%s", credentials.AccountName(), domain)))
-			})
+	Context("when emulatorEnabled field is set to true", func() {
+		It("should return the Azurite blob service URL with HTTP scheme", func() {
+			blobServiceURL, err := ConstructBlobServiceURL(credentials.AccountName(), domain, true)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(blobServiceURL).Should(Equal(fmt.Sprintf("http://%s.%s", credentials.AccountName(), domain)))
 		})
 	})
 })

--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -194,6 +194,8 @@ type SnapstoreConfig struct {
 	TempDir string `json:"tempDir,omitempty"`
 	// IsSource determines if this SnapStore is the source for a copy operation
 	IsSource bool `json:"isSource,omitempty"`
+	// IsEmulatorEnabled indicates whether a storage emulator is being used for the snapstore.
+	IsEmulatorEnabled bool `json:"isEmulatorEnabled,omitempty"`
 }
 
 // AddFlags adds the flags to flagset.


### PR DESCRIPTION
/area compliance security
/kind task

**What this PR does / why we need it**:
Read `emulatorEnabled` value for storage emulators from mounted secret instead of environment variables, to avoid mounting and exposing data from secrets as environment variables, even if they are non-credential fields.
Changes in this PR:
- [x] Read `emulatorEnabled` fields for providers Azure ABS and Google GCS from mounted secret files/JSON, instead of from environment variables
- [x] Refactor provider GCS snapstore construction code
- [x] Remove usage of env var `GOOGLE_EMULATOR_ENABLED`
- [x] Remove usage of env var `AZURE_EMULATOR_ENABLED`
- [x] Add `IsEmulatorEnabled` to `SnapstoreConfig` struct, to allow programatic downstream users of etcdbr code to set emulator enablement when creating `SnapstoreConfig`. For instance, etcd-druid can set this value to true when running local e2e tests against Azurite emulator.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @anveshreddy18 @renormalize 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Remove usage of environment variables to determine whether storage emulators are enabled.
```
