### PR TITLE
Tag docker images built via pipeline release process as `latest`

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -89,6 +89,7 @@ etcd-backup-restore:
           dockerimages:
             etcdbrctl:
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/etcdbrctl
+              tag_as_latest: True
         release:
           nextversion: 'bump_minor'
           assets:


### PR DESCRIPTION
/area usability
/kind enhancement

**What this PR does / why we need it**:
Tag docker images built via pipeline release process as `latest`, to allow users to use the latest version of etcdbrctl as `europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl:latest`, without needing to specify the latest released version of the component.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @renormalize @anveshreddy18 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Tag docker images built via pipeline release process as `latest`.
```
