### PR TITLE
Set `controller-runtime` logger to `log.NullLogSink{}`

### DIFF
--- a/cmd/compact.go
+++ b/cmd/compact.go
@@ -11,10 +11,12 @@ import (
 	"github.com/gardener/etcd-backup-restore/pkg/compactor"
 	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"go.etcd.io/etcd/mvcc"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // NewCompactCommand compacts the ETCD instance
@@ -33,6 +35,7 @@ func NewCompactCommand(ctx context.Context) *cobra.Command {
 			- Save the snapshot
 			*/
 			logger := logrus.New()
+			runtimelog.SetLogger(logr.New(runtimelog.NullLogSink{}))
 			if err := opts.validate(); err != nil {
 				logger.Fatalf("failed to validate the options: %v", err)
 				return

--- a/cmd/compact.go
+++ b/cmd/compact.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gardener/etcd-backup-restore/pkg/compactor"
 	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/copier"
 
+	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // NewCopyCommand creates a cobra command for copy.
@@ -23,6 +25,7 @@ func NewCopyCommand(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			printVersionInfo()
 			logger := logrus.NewEntry(logrus.New())
+			runtimelog.SetLogger(logr.New(runtimelog.NullLogSink{}))
 			if err := opts.validate(); err != nil {
 				logger.Fatalf("failed to validate the options: %v", err)
 			}

--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -10,9 +10,11 @@ import (
 	"github.com/gardener/etcd-backup-restore/pkg/initializer"
 	"github.com/gardener/etcd-backup-restore/pkg/initializer/validator"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"go.etcd.io/etcd/pkg/types"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // NewInitializeCommand returns the command to initialize etcd by validating the data
@@ -26,6 +28,7 @@ func NewInitializeCommand(ctx context.Context) *cobra.Command {
 		Long:  `Initializes an etcd instance. Data directory is checked for corruption and restored in case of corruption.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			logger := logrus.New()
+			runtimelog.SetLogger(logr.New(runtimelog.NullLogSink{}))
 			if err := opts.validate(); err != nil {
 				logger.Fatalf("failed to validate the options: %v", err)
 				return

--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gardener/etcd-backup-restore/pkg/initializer"
 	"github.com/gardener/etcd-backup-restore/pkg/initializer/validator"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -10,18 +10,17 @@ import (
 	"os"
 
 	"github.com/gardener/etcd-backup-restore/pkg/compressor"
-	"github.com/go-logr/logr"
-
 	"github.com/gardener/etcd-backup-restore/pkg/initializer/validator"
 	"github.com/gardener/etcd-backup-restore/pkg/server"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/snapshotter"
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 	"github.com/gardener/etcd-backup-restore/pkg/wrappers"
-	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 )
 

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/gardener/etcd-backup-restore/pkg/compressor"
+	"github.com/go-logr/logr"
 
 	"github.com/gardener/etcd-backup-restore/pkg/initializer/validator"
 	"github.com/gardener/etcd-backup-restore/pkg/server"
@@ -17,6 +18,7 @@ import (
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 	"github.com/gardener/etcd-backup-restore/pkg/wrappers"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
@@ -35,6 +37,7 @@ type serverOptions struct {
 func newServerOptions() *serverOptions {
 	logger := logrus.New()
 	logger.SetLevel(logrus.InfoLevel)
+	runtimelog.SetLogger(logr.New(runtimelog.NullLogSink{}))
 
 	return &serverOptions{
 		LogLevel: 4,

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -8,8 +8,10 @@ import (
 	"context"
 
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/restorer"
+	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // NewRestoreCommand returns the command to restore
@@ -26,6 +28,7 @@ func NewRestoreCommand(ctx context.Context) *cobra.Command {
 			- Restore etcd data diretory from full snapshot.
 			*/
 			logger := logrus.New()
+			runtimelog.SetLogger(logr.New(runtimelog.NullLogSink{}))
 
 			options, store, err := BuildRestoreOptionsAndStore(opts)
 			if err != nil {

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/restorer"
+
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -7,16 +7,16 @@ package cmd
 import (
 	"context"
 
+	"github.com/gardener/etcd-backup-restore/pkg/defragmentor"
+	"github.com/gardener/etcd-backup-restore/pkg/snapshot/snapshotter"
+	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
+	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+
 	"github.com/go-logr/logr"
 	cron "github.com/robfig/cron/v3"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
-
-	"github.com/gardener/etcd-backup-restore/pkg/defragmentor"
-	"github.com/gardener/etcd-backup-restore/pkg/snapshot/snapshotter"
-	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
-	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 )
 
 // NewSnapshotCommand create cobra command for snapshot

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -7,14 +7,16 @@ package cmd
 import (
 	"context"
 
-	"github.com/gardener/etcd-backup-restore/pkg/defragmentor"
-	"github.com/gardener/etcd-backup-restore/pkg/snapshot/snapshotter"
-	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
-
-	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+	"github.com/go-logr/logr"
 	cron "github.com/robfig/cron/v3"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/gardener/etcd-backup-restore/pkg/defragmentor"
+	"github.com/gardener/etcd-backup-restore/pkg/snapshot/snapshotter"
+	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
+	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 )
 
 // NewSnapshotCommand create cobra command for snapshot
@@ -28,6 +30,7 @@ storing snapshots on various cloud storage providers as well as local disk locat
 		Run: func(cmd *cobra.Command, args []string) {
 			printVersionInfo()
 			logger := logrus.NewEntry(logrus.New())
+			runtimelog.SetLogger(logr.New(runtimelog.NullLogSink{}))
 			if err := opts.validate(); err != nil {
 				logger.Fatalf("failed to validate the options: %v", err)
 				return


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind bug

**What this PR does / why we need it**:

* Set `controller-runtime` logger to `log.NullLogSink{}` to avoid `[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.` logs from being printed.

This PR takes inspiration from https://github.com/rook/rook/pull/12448 for `log.NullLogSink{}`.

**Which issue(s) this PR fixes**:
Fixes #827 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
NONE
```