### PR TITLE
Update etcdbr image tag to latest in helm charts

### DIFF
--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -10,10 +10,9 @@ images:
     tag: latest
     pullPolicy: IfNotPresent
   # etcd-backup-restore image to use
-  # TODO: @anveshreddy18: use the latest tag for etcd-backup-restore once the v0.33.0 is released
   etcdBackupRestore:
-    repository: europe-docker.pkg.dev/gardener-project/snapshots/gardener/etcdbrctl
-    tag: v0.33.0-dev-e1690dd6ea14ca889d357307018ba2e53ced5203
+    repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
+    tag: latest
     pullPolicy: IfNotPresent
 
 resources:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind task

**What this PR does / why we need it**:

Switch `etcd-backup-restore` image & version to `europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl` & `latest` respectively in values.yaml of the helm charts

**Which issue(s) this PR fixes**:
Fixes #829 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
use etcdbr `latest` tagged image in the helm charts
```
