### PR TITLE
Update golang version to 1.23.5

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -60,13 +60,13 @@ etcd-backup-restore:
                 teamname: 'gardener/etcd-druid-maintainers'
     steps:
       check:
-        image: 'golang:1.23.4'
+        image: 'golang:1.23.5'
       unit_test:
-        image: 'golang:1.23.4'
+        image: 'golang:1.23.5'
       integration_test:
-        image: 'golang:1.23.4'
+        image: 'golang:1.23.5'
       build:
-        image: 'golang:1.23.4'
+        image: 'golang:1.23.5'
         output_dir: 'binary'
 
   jobs:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.23.4 as builder
+FROM golang:1.23.5 as builder
 
 WORKDIR /go/src/github.com/gardener/backup-restore
 COPY . .


### PR DESCRIPTION
/area security compliance quality
/kind task

**What this PR does / why we need it**:
Update golang version to `1.23.5` which brings [security fixes](https://go.dev/doc/devel/release#go1.23.5).

**Release note**:
```other dependency
Update golang version to `1.23.5`.
```
