### PR TITLE
Moved some of the unit tests from `pkg/defragmentor_test` to `pkg/etcdutiil_test`

### DIFF
--- a/pkg/defragmentor/defrag_test.go
+++ b/pkg/defragmentor/defrag_test.go
@@ -11,13 +11,10 @@ import (
 	"time"
 
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
-	mockfactory "github.com/gardener/etcd-backup-restore/pkg/mock/etcdutil/client"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 	"github.com/gardener/etcd-backup-restore/test/utils"
 	cron "github.com/robfig/cron/v3"
 	"go.etcd.io/etcd/clientv3"
-	"go.etcd.io/etcd/etcdserver/etcdserverpb"
-	"go.uber.org/mock/gomock"
 
 	. "github.com/gardener/etcd-backup-restore/pkg/defragmentor"
 	. "github.com/onsi/ginkgo/v2"
@@ -29,11 +26,6 @@ var _ = Describe("Defrag", func() {
 		etcdConnectionConfig *brtypes.EtcdConnectionConfig
 		keyPrefix            = "/defrag/key-"
 		valuePrefix          = "val"
-
-		ctrl    *gomock.Controller
-		factory *mockfactory.MockFactory
-		cm      *mockfactory.MockMaintenanceCloser
-		cl      *mockfactory.MockClusterCloser
 	)
 
 	BeforeEach(func() {
@@ -43,164 +35,6 @@ var _ = Describe("Defrag", func() {
 		etcdConnectionConfig.SnapshotTimeout.Duration = 30 * time.Second
 		etcdConnectionConfig.DefragTimeout.Duration = 30 * time.Second
 
-		ctrl = gomock.NewController(GinkgoT())
-		factory = mockfactory.NewMockFactory(ctrl)
-		cm = mockfactory.NewMockMaintenanceCloser(ctrl)
-		cl = mockfactory.NewMockClusterCloser(ctrl)
-	})
-
-	Describe("With Etcd cluster", func() {
-		var (
-			dummyID              = uint64(1111)
-			dummyClientEndpoints = []string{"http://127.0.0.1:2379", "http://127.0.0.1:9090"}
-		)
-		BeforeEach(func() {
-			factory.EXPECT().NewMaintenance().Return(cm, nil)
-			factory.EXPECT().NewCluster().Return(cl, nil)
-		})
-
-		Context("MemberList API call fails", func() {
-			It("should return error", func() {
-				clientMaintenance, err := factory.NewMaintenance()
-				Expect(err).ShouldNot(HaveOccurred())
-
-				client, err := factory.NewCluster()
-				Expect(err).ShouldNot(HaveOccurred())
-
-				cl.EXPECT().MemberList(gomock.Any()).Return(nil, fmt.Errorf("failed to connect with the dummy etcd")).AnyTimes()
-
-				leaderEtcdEndpoints, followerEtcdEndpoints, err := etcdutil.GetEtcdEndPointsSorted(testCtx, clientMaintenance, client, dummyClientEndpoints, logger)
-				Expect(err).Should(HaveOccurred())
-				Expect(leaderEtcdEndpoints).Should(BeNil())
-				Expect(followerEtcdEndpoints).Should(BeNil())
-
-				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, dummyClientEndpoints, mockTimeout, logger)
-				Expect(err).Should(HaveOccurred())
-			})
-		})
-
-		Context("MemberList API call succeeds and Status API call fails", func() {
-			It("should return error", func() {
-				clientMaintenance, err := factory.NewMaintenance()
-				Expect(err).ShouldNot(HaveOccurred())
-
-				client, err := factory.NewCluster()
-				Expect(err).ShouldNot(HaveOccurred())
-
-				cl.EXPECT().MemberList(gomock.Any()).DoAndReturn(func(_ context.Context) (*clientv3.MemberListResponse, error) {
-					response := new(clientv3.MemberListResponse)
-					dummyMember1 := &etcdserverpb.Member{
-						ID:         dummyID,
-						ClientURLs: []string{dummyClientEndpoints[0]},
-					}
-					dummyMember2 := &etcdserverpb.Member{
-						ID:         dummyID + 1,
-						ClientURLs: []string{dummyClientEndpoints[1]},
-					}
-					response.Members = []*etcdserverpb.Member{dummyMember1, dummyMember2}
-					return response, nil
-				}).AnyTimes()
-
-				cm.EXPECT().Status(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("failed to connect to the dummy etcd")).AnyTimes()
-
-				leaderEtcdEndpoints, followerEtcdEndpoints, err := etcdutil.GetEtcdEndPointsSorted(testCtx, clientMaintenance, client, dummyClientEndpoints, logger)
-				Expect(err).Should(HaveOccurred())
-				Expect(leaderEtcdEndpoints).Should(BeNil())
-				Expect(followerEtcdEndpoints).Should(BeNil())
-
-				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, dummyClientEndpoints, mockTimeout, logger)
-				Expect(err).Should(HaveOccurred())
-			})
-		})
-
-		Context("Only Defragment API call fails", func() {
-			It("should return error and fail to perform defragmentation", func() {
-				clientMaintenance, err := factory.NewMaintenance()
-				Expect(err).ShouldNot(HaveOccurred())
-
-				client, err := factory.NewCluster()
-				Expect(err).ShouldNot(HaveOccurred())
-
-				cl.EXPECT().MemberList(gomock.Any()).DoAndReturn(func(_ context.Context) (*clientv3.MemberListResponse, error) {
-					response := new(clientv3.MemberListResponse)
-					// dummy etcd cluster leader
-					dummyMember1 := &etcdserverpb.Member{
-						ID:         dummyID,
-						ClientURLs: []string{dummyClientEndpoints[0]},
-					}
-					// dummy etcd cluster follower
-					dummyMember2 := &etcdserverpb.Member{
-						ID:         dummyID + 1,
-						ClientURLs: []string{dummyClientEndpoints[1]},
-					}
-					response.Members = []*etcdserverpb.Member{dummyMember1, dummyMember2}
-					return response, nil
-				}).AnyTimes()
-
-				cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
-					response := new(clientv3.StatusResponse)
-					response.Leader = dummyID
-					return response, nil
-				}).Times(2)
-
-				cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
-					response := new(clientv3.StatusResponse)
-					response.DbSize = 1
-					return response, nil
-				}).Times(1)
-
-				cm.EXPECT().Defragment(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("failed to defrag the etcd")).AnyTimes()
-
-				leaderEtcdEndpoints, followerEtcdEndpoints, err := etcdutil.GetEtcdEndPointsSorted(testCtx, clientMaintenance, client, dummyClientEndpoints, logger)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(leaderEtcdEndpoints).Should(Equal([]string{dummyClientEndpoints[0]}))
-				Expect(followerEtcdEndpoints).Should(Equal([]string{dummyClientEndpoints[1]}))
-
-				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, dummyClientEndpoints, mockTimeout, logger)
-				Expect(err).Should(HaveOccurred())
-			})
-		})
-
-		Context("All etcd client API call succeeds", func() {
-			It("should able to perform the defragmentation on etcd follower as well as on etcd leader", func() {
-				clientMaintenance, err := factory.NewMaintenance()
-				Expect(err).ShouldNot(HaveOccurred())
-
-				client, err := factory.NewCluster()
-				Expect(err).ShouldNot(HaveOccurred())
-
-				cl.EXPECT().MemberList(gomock.Any()).DoAndReturn(func(_ context.Context) (*clientv3.MemberListResponse, error) {
-					response := new(clientv3.MemberListResponse)
-					// etcd cluster leader
-					dummyMember1 := &etcdserverpb.Member{
-						ID:         dummyID,
-						ClientURLs: []string{dummyClientEndpoints[0]},
-					}
-					// etcd cluster follower
-					dummyMember2 := &etcdserverpb.Member{
-						ID:         dummyID + 1,
-						ClientURLs: []string{dummyClientEndpoints[1]},
-					}
-					response.Members = []*etcdserverpb.Member{dummyMember1, dummyMember2}
-					return response, nil
-				}).AnyTimes()
-
-				cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
-					response := new(clientv3.StatusResponse)
-					response.Leader = dummyID
-					response.DbSize = 10
-					return response, nil
-				}).AnyTimes()
-
-				cm.EXPECT().Defragment(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.DefragmentResponse, error) {
-					response := new(clientv3.DefragmentResponse)
-					return response, nil
-				}).AnyTimes()
-
-				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, dummyClientEndpoints, mockTimeout, logger)
-				Expect(err).ShouldNot(HaveOccurred())
-			})
-		})
 	})
 
 	Context("Defragmentation", func() {

--- a/pkg/defragmentor/defragmentor_suite_test.go
+++ b/pkg/defragmentor/defragmentor_suite_test.go
@@ -23,7 +23,6 @@ const (
 	etcdDir            = outputDir + "/default.etcd"
 	etcdDialTimeout    = time.Second * 30
 	embeddedEtcdPortNo = "9089"
-	mockTimeout        = time.Second * 5
 )
 
 var (

--- a/pkg/etcdutil/etcdutil_suite_test.go
+++ b/pkg/etcdutil/etcdutil_suite_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/gardener/etcd-backup-restore/test/utils"
 	. "github.com/onsi/ginkgo/v2"
@@ -23,10 +24,11 @@ const (
 )
 
 var (
-	logger  = logrus.New().WithField("suite", "etcdutil")
-	err     error
-	testCtx = context.Background()
-	etcd    *embed.Etcd
+	logger      = logrus.New().WithField("suite", "etcdutil")
+	err         error
+	testCtx     = context.Background()
+	etcd        *embed.Etcd
+	mockTimeout = time.Second * 5
 )
 
 func TestEtcdUtil(t *testing.T) {

--- a/pkg/etcdutil/etcdutil_test.go
+++ b/pkg/etcdutil/etcdutil_test.go
@@ -151,7 +151,7 @@ var _ = Describe("EtcdUtil Tests", func() {
 		})
 	})
 
-	Describe("With Etcd cluster", func() {
+	Describe("To defragment the Etcd cluster", func() {
 		var (
 			dummyID              = uint64(1111)
 			dummyClientEndpoints = []string{"http://127.0.0.1:2379", "http://127.0.0.1:9090"}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area backup
/area testing
/kind test

**What this PR does / why we need it**:
We noticed that some of the unit tests present in `pkg/defragmentor_test` should be present in `pkg/etcdutil_test`, hence we decided to move the some of the unit tests from `pkg/defragmentor_test` -> `pkg/etcdutiil_test`.
More info: https://github.com/gardener/etcd-backup-restore/issues/800#issuecomment-2626785569

**Which issue(s) this PR fixes**:
Fixes #800 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
