### PR TITLE
Added a support of skipping/ignoring of any snapshot in an object lock enabled S3 bucket.

### DIFF
--- a/docs/usage/enabling_immutable_snapshots.md
+++ b/docs/usage/enabling_immutable_snapshots.md
@@ -425,7 +425,35 @@ After adding the annotation or tag, `etcd-backup-restore` will ignore these snap
 
 #### AWS S3
 
-- The approach of tagging snapshot objects to exclude them during restoration is not supported for `AWS S3` buckets.
+- Ignoring or skipping any snapshot object(s) present in AWS S3 bucket is a two-step process:
+  1. Put a delete marker on the top of object. Please refer [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html) for more information regarding deletion in versioning enabled S3 bucket.
+  2. Then add a tag to snapshot object which you wish to be skipped/ignored during restoration:
+  - **Key:** `x-etcd-snapshot-exclude`
+  - **Value:** `true`
+
+To add the tag:
+
+1. **Using the `aws` CLI**
+
+  ```bash
+  aws s3api put-object-tagging --bucket [BUCKET_NAME] --key [SNAPSHOT_PATH] --version-id [SNAPSHOT_VERSION_ID] --tagging '{"TagSet": [{ "Key": "x-etcd-snapshot-exclude", "Value": "true" }]}'
+  ```
+
+  **Example:**
+
+  ```bash
+  aws s3api put-object-tagging --bucket --key shoot1/etcd-main/v2/Incr-000000xx-000000yy-xxyyy.gz --version-id abcdefgh --tagging '{"TagSet": [{ "Key": "x-etcd-snapshot-exclude", "Value": "true" }]}'
+  ```
+
+2. **Using the AWS S3 Portal**
+
+   - Navigate to the bucket
+   - Locate the object which need to be skipped/ignored.
+   - Click on the object to view its details.
+   - Scroll down to **Tags** section, then add tag:
+      - **Key:** `x-etcd-snapshot-exclude`
+      - **Value:** `true`
+   - Save the changes.
 
 > Note: With S3 object lock, S3 versioning will automatically get enabled, it only prevent locked object versions from being permanently deleted.
 

--- a/docs/usage/enabling_immutable_snapshots.md
+++ b/docs/usage/enabling_immutable_snapshots.md
@@ -426,8 +426,8 @@ After adding the annotation or tag, `etcd-backup-restore` will ignore these snap
 #### AWS S3
 
 - Ignoring or skipping any snapshot object(s) present in AWS S3 bucket is a two-step process:
-  1. Put a delete marker on the top of object. Please refer [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html) for more information regarding deletion in versioning enabled S3 bucket.
-  2. Then add a tag to snapshot object which you wish to be skipped/ignored during restoration:
+  1. Put a delete marker on the top of snapshot object. Please refer [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html) for more information regarding deletion in versioning enabled S3 bucket.
+  2. Then tag the snapshot object which you wish to skip or ignore during restoration with following key and value:
   - **Key:** `x-etcd-snapshot-exclude`
   - **Value:** `true`
 

--- a/docs/usage/enabling_immutable_snapshots.md
+++ b/docs/usage/enabling_immutable_snapshots.md
@@ -263,6 +263,8 @@ To lock the immutability policy:
     1. **Governance mode**: Only users with special permissions can overwrite, delete or alter object lock settings.
     2. **Compliance mode**: No users(including root user) can overwrite, delete or alter object lock settings.
 
+> Note: With S3 object lock, S3 versioning will automatically get enabled, it only prevent locked object versions from being permanently deleted.
+
 #### Create S3 Buckets with object lock enabled
 
 > Note: With S3 object lock, S3 versioning will automatically get enabled.
@@ -454,8 +456,6 @@ To add the tag:
       - **Key:** `x-etcd-snapshot-exclude`
       - **Value:** `true`
    - Save the changes.
-
-> Note: With S3 object lock, S3 versioning will automatically get enabled, it only prevent locked object versions from being permanently deleted.
 
 ---
 

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -792,9 +792,10 @@ func GetBucketImmutabilityTime(s *S3SnapStore) (bool, *int64, error) {
 	return false, nil, fmt.Errorf("got nil object lock configuration")
 }
 
+// isSnapshotMarkToBeIgnored checks whether snapshot object key with given versionID is marked to be ignored or not.
 func isSnapshotMarkToBeIgnored(client s3iface.S3API, bucketName, key, versionID string) bool {
 	out, err := client.GetObjectTagging(&s3.GetObjectTaggingInput{
-		Bucket:    &bucketName,
+		Bucket:    aws.String(bucketName),
 		Key:       aws.String(key),
 		VersionId: aws.String(versionID),
 	})
@@ -803,7 +804,7 @@ func isSnapshotMarkToBeIgnored(client s3iface.S3API, bucketName, key, versionID 
 	}
 
 	for _, tagOnSnap := range out.TagSet {
-		if *tagOnSnap.Key == brtypes.ExcludeSnapshotMetadataKey && *tagOnSnap.Value == "true" {
+		if tagOnSnap.Key != nil && *tagOnSnap.Key == brtypes.ExcludeSnapshotMetadataKey && tagOnSnap.Value != nil && *tagOnSnap.Value == "true" {
 			return true
 		}
 	}

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -574,7 +574,7 @@ func (s *S3SnapStore) List(includeAll bool) (brtypes.SnapList, error) {
 			versionID    string
 		}
 
-		// allSnapKeysMapToCreationTime contains oldest snapshots keys mapped to their versionID and creation timestamp.
+		// allSnapKeyMapToSnapshotInfo contains oldest snapshots keys mapped to their versionID and creation timestamp.
 		allSnapKeyMapToSnapshotInfo := make(map[string]*snapshotMetaInfo)
 
 		// allDeleteMarkersInfo contains key of all delete markers present(if any) in the S3 bucket.
@@ -620,7 +620,7 @@ func (s *S3SnapStore) List(includeAll bool) (brtypes.SnapList, error) {
 			// If a snapshot key has a delete marker present in the bucket,
 			// check whether that snapshot object is marked to be ignored.
 			if _, isDeleteMarkerPresent := allDeleteMarkersInfo[key]; isDeleteMarkerPresent && !includeAll {
-				if IsSnapshotMarkToBeIgnored(s.client, s.bucket, key, val.versionID) {
+				if IsSnapshotMarkedToBeIgnored(s.client, s.bucket, key, val.versionID) {
 					logrus.Infof("Snapshot: %s with versionID: %s is marked to be ignored", key, val.versionID)
 					continue
 				}
@@ -787,8 +787,8 @@ func GetBucketImmutabilityTime(s *S3SnapStore) (bool, *int64, error) {
 	return false, nil, fmt.Errorf("got nil object lock configuration")
 }
 
-// IsSnapshotMarkToBeIgnored checks whether snapshot object key with given versionID is tagged to be ignored or not.
-func IsSnapshotMarkToBeIgnored(client s3iface.S3API, bucketName, key, versionID string) bool {
+// IsSnapshotMarkedToBeIgnored checks whether snapshot object key with given versionID is tagged to be ignored or not.
+func IsSnapshotMarkedToBeIgnored(client s3iface.S3API, bucketName, key, versionID string) bool {
 	out, err := client.GetObjectTagging(&s3.GetObjectTaggingInput{
 		Bucket:    aws.String(bucketName),
 		Key:       aws.String(key),

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -625,7 +625,7 @@ func (s *S3SnapStore) List(includeAll bool) (brtypes.SnapList, error) {
 			// If a snapshot key has a delete marker present in the bucket,
 			// check whether that snapshot object is marked to be ignored.
 			if _, isDeleteMarkerPresent := allDeleteMarkersInfo[key]; isDeleteMarkerPresent && !includeAll {
-				if isSnapshotMarkToBeIgnored(s.client, s.bucket, key, val.versionID) {
+				if IsSnapshotMarkToBeIgnored(s.client, s.bucket, key, val.versionID) {
 					logrus.Infof("Snapshot: %s with versionID: %s is marked to be ignored", key, val.versionID)
 					continue
 				}
@@ -792,8 +792,8 @@ func GetBucketImmutabilityTime(s *S3SnapStore) (bool, *int64, error) {
 	return false, nil, fmt.Errorf("got nil object lock configuration")
 }
 
-// isSnapshotMarkToBeIgnored checks whether snapshot object key with given versionID is marked to be ignored or not.
-func isSnapshotMarkToBeIgnored(client s3iface.S3API, bucketName, key, versionID string) bool {
+// IsSnapshotMarkToBeIgnored checks whether snapshot object key with given versionID is tagged to be ignored or not.
+func IsSnapshotMarkToBeIgnored(client s3iface.S3API, bucketName, key, versionID string) bool {
 	out, err := client.GetObjectTagging(&s3.GetObjectTaggingInput{
 		Bucket:    aws.String(bucketName),
 		Key:       aws.String(key),

--- a/pkg/snapstore/s3_snapstore_test.go
+++ b/pkg/snapstore/s3_snapstore_test.go
@@ -295,6 +295,35 @@ func (m *mockS3Client) GetObjectLockConfiguration(in *s3.GetObjectLockConfigurat
 	return nil, fmt.Errorf("unable to check object lock configuration for given bucket")
 }
 
+// GetObjectTagging returns the tag for S3's mock bucket object.
+func (m *mockS3Client) GetObjectTagging(input *s3.GetObjectTaggingInput) (*s3.GetObjectTaggingOutput, error) {
+	if *input.Bucket == "mock-s3Bucket" {
+		return nil, fmt.Errorf("unable to check tag for given object input")
+	}
+
+	objectTag := []*s3.Tag{}
+
+	if *input.Key == "mock/v2/Full-000000xx-000000yy-yyxxzz.gz" && *input.VersionId == "mockVersion1" {
+		return &s3.GetObjectTaggingOutput{
+			TagSet: append(objectTag, &s3.Tag{
+				Key:   aws.String("x-etcd-snapshot-exclude"),
+				Value: aws.String("true"),
+			}),
+		}, nil
+	} else if *input.Key == "mock/v2/Full-000000xx-000000yy-yyxxzz.gz" && *input.VersionId == "mockVersion2" {
+		return &s3.GetObjectTaggingOutput{
+			TagSet: append(objectTag, &s3.Tag{
+				Key:   aws.String("x-etcd-snapshot-exclude"),
+				Value: aws.String("false"),
+			}),
+		}, nil
+	}
+
+	return &s3.GetObjectTaggingOutput{
+		TagSet: objectTag,
+	}, nil
+}
+
 // DeleteObject deletes the object from map for mock test
 func (m *mockS3Client) DeleteObject(in *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
 	delete(m.objects, *in.Key)

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -713,6 +713,44 @@ var _ = Describe("Get Immutability time for S3 bucket", func() {
 	})
 })
 
+var _ = Describe("S3 snapshot object mark to be ignored/skipped", func() {
+	awsS3Client := &mockS3Client{
+		objects: objectMap,
+		prefix:  prefixV2,
+	}
+
+	mockS3BucketName := "mock-s3ObjectLockedBucket"
+	mockSnapshotKey := "mock/v2/Full-000000xx-000000yy-yyxxzz.gz"
+
+	Context("Snapshot object is correctly tagged to be ignored", func() {
+		It("Should return true", func() {
+			isMarkedToIgnore := IsSnapshotMarkToBeIgnored(awsS3Client, mockS3BucketName, mockSnapshotKey, "mockVersion1")
+			Expect(isMarkedToIgnore).Should(BeTrue())
+		})
+	})
+
+	Context("Snapshot object is incorrectly tagged to be ignored", func() {
+		It("Should return false", func() {
+			isMarkedToIgnore := IsSnapshotMarkToBeIgnored(awsS3Client, mockS3BucketName, mockSnapshotKey, "mockVersion2")
+			Expect(isMarkedToIgnore).Should(BeFalse())
+		})
+	})
+
+	Context("No tag is present for given snapshot", func() {
+		It("Should return false", func() {
+			isMarkedToIgnore := IsSnapshotMarkToBeIgnored(awsS3Client, mockS3BucketName, mockSnapshotKey, "mockVersion3")
+			Expect(isMarkedToIgnore).Should(BeFalse())
+		})
+	})
+
+	Context("S3's GetObjectTagging API call fails", func() {
+		It("Should return false", func() {
+			isMarkedToIgnore := IsSnapshotMarkToBeIgnored(awsS3Client, "mock-s3Bucket", mockSnapshotKey, "mockVersion1")
+			Expect(isMarkedToIgnore).Should(BeFalse())
+		})
+	})
+})
+
 // createCredentialFilesInDirectory creates access credential files in the
 // specified directory and returns the timestamp of the last modified file.
 func createCredentialFilesInDirectory(directory string, filenames []string) (time.Time, error) {

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -713,7 +713,7 @@ var _ = Describe("Get Immutability time for S3 bucket", func() {
 	})
 })
 
-var _ = Describe("S3 snapshot object mark to be ignored/skipped", func() {
+var _ = Describe("S3 snapshot object is marked to be ignored/skipped", func() {
 	awsS3Client := &mockS3Client{
 		objects: objectMap,
 		prefix:  prefixV2,
@@ -724,28 +724,28 @@ var _ = Describe("S3 snapshot object mark to be ignored/skipped", func() {
 
 	Context("Snapshot object is correctly tagged to be ignored", func() {
 		It("Should return true", func() {
-			isMarkedToIgnore := IsSnapshotMarkToBeIgnored(awsS3Client, mockS3BucketName, mockSnapshotKey, "mockVersion1")
+			isMarkedToIgnore := IsSnapshotMarkedToBeIgnored(awsS3Client, mockS3BucketName, mockSnapshotKey, "mockVersion1")
 			Expect(isMarkedToIgnore).Should(BeTrue())
 		})
 	})
 
 	Context("Snapshot object is incorrectly tagged to be ignored", func() {
 		It("Should return false", func() {
-			isMarkedToIgnore := IsSnapshotMarkToBeIgnored(awsS3Client, mockS3BucketName, mockSnapshotKey, "mockVersion2")
+			isMarkedToIgnore := IsSnapshotMarkedToBeIgnored(awsS3Client, mockS3BucketName, mockSnapshotKey, "mockVersion2")
 			Expect(isMarkedToIgnore).Should(BeFalse())
 		})
 	})
 
 	Context("No tag is present for given snapshot", func() {
 		It("Should return false", func() {
-			isMarkedToIgnore := IsSnapshotMarkToBeIgnored(awsS3Client, mockS3BucketName, mockSnapshotKey, "mockVersion3")
+			isMarkedToIgnore := IsSnapshotMarkedToBeIgnored(awsS3Client, mockS3BucketName, mockSnapshotKey, "mockVersion3")
 			Expect(isMarkedToIgnore).Should(BeFalse())
 		})
 	})
 
 	Context("S3's GetObjectTagging API call fails", func() {
 		It("Should return false", func() {
-			isMarkedToIgnore := IsSnapshotMarkToBeIgnored(awsS3Client, "mock-s3Bucket", mockSnapshotKey, "mockVersion1")
+			isMarkedToIgnore := IsSnapshotMarkedToBeIgnored(awsS3Client, "mock-s3Bucket", mockSnapshotKey, "mockVersion1")
 			Expect(isMarkedToIgnore).Should(BeFalse())
 		})
 	})

--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -58,7 +58,7 @@ const (
 	MinChunkSize int64 = 5 * (1 << 20) //5 MiB
 
 	// ExcludeSnapshotMetadataKey is the tag that is to be added on snapshots in the object store if they are not to be included in SnapStore's List output.
-	// Note: only applicable for storage provider: ABS and GCS.
+	// Note: applicable for storage provider: ABS, GCS and S3.
 	ExcludeSnapshotMetadataKey = "x-etcd-snapshot-exclude"
 )
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area security
/kind technical-debt

**What this PR does / why we need it**:
This PR adds a support of skipping/ignoring of any snapshot in an object lock enabled S3 bucket using tag method.
It is achieved in a two-step:
  1. Put a delete marker on the top of object. Please refer [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html) for more information regarding deletion in versioning enabled S3 bucket.
  2. Then add a tag to snapshot object which you wish to be skipped/ignored during restoration:
    - **Key:** `x-etcd-snapshot-exclude`
    - **Value:** `true`


**Which issue(s) this PR fixes**:
Fixes #843 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Added a support for skipping or ignoring any snapshot in an object lock-enabled S3 bucket. For more information please refer to this doc: https://github.com/gardener/etcd-backup-restore/blob/master/docs/usage/enabling_immutable_snapshots.md#aws-s3
```
