### PR TITLE
Changes in e2e tests setup required for running them in prow job environment

### DIFF
--- a/hack/config/gcp_config.sh
+++ b/hack/config/gcp_config.sh
@@ -24,5 +24,12 @@ if [[ "${USE_FAKEGCS}" == "true" ]]; then
   mkdir -p /tmp/.gcp
   echo -n "${FAKEGCS_LOCAL_URL}"         > /tmp/.gcp/storageAPIEndpoint
   echo -n "true"                         > /tmp/.gcp/emulatorEnabled
+  # Create a dummy service account JSON file
+  cat <<EOF > /tmp/.gcp/service-account.json
+  {
+    "project_id": "dummy-project-id",
+    "type": "service_account"
+  }
+EOF
   export GOOGLE_APPLICATION_CREDENTIALS="/tmp/.gcp/service-account.json"
 fi

--- a/hack/e2e-test/run-e2e-test.sh
+++ b/hack/e2e-test/run-e2e-test.sh
@@ -108,17 +108,18 @@ function cleanup_azure_container() {
 
 # setup_awscli installs the awscli
 function setup_awscli() {
-    if ! $(which aws > /dev/null); then
-      echo "Installing awscli..."
-      if pip3 install --break-system-packages awscli; then
-        echo "Successfully installed awscli."
-      else
-        echo "Failed to install awscli."
-        return 1
-      fi
-    else
-      echo "awscli is already installed."
+    if $(which aws > /dev/null); then
+      return
     fi
+    echo "Installing awscli..."
+    apt update
+    apt install -y curl
+    apt install -y unzip
+    cd $HOME
+    curl -Lo "awscliv2.zip" "https://awscli.amazonaws.com/awscli-exe-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m).zip"
+    unzip awscliv2.zip > /dev/null
+    ./aws/install -i /usr/local/aws-cli -b /usr/local/bin
+    echo "Successfully installed awscli."
 }
 
 # create_aws_container creates the container for the AWS provider

--- a/test/e2e/backup_test.go
+++ b/test/e2e/backup_test.go
@@ -300,7 +300,7 @@ var _ = Describe("Backup", func() {
 		Context("when data is corrupt", func() {
 			It("should restore data from latest snapshot", func() {
 				testDataCorruptionRestoration := func() {
-					cmd := "export ETCD_PID=$(pgrep etcd-wrapper) && rm -r proc/${ETCD_PID}/root/var/etcd/data/new.etcd/member"
+					cmd := "export ETCD_PID=$(ps -A | grep 'etcd-wrapper' | awk '{print $1}') && rm -r proc/${ETCD_PID}/root/var/etcd/data/new.etcd/member"
 					stdout, stderr, err := executeContainerCommand(kubeconfigPath, releaseNamespace, podName, debugContainerName, cmd)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(stderr).Should(BeEmpty())

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -117,7 +117,10 @@ func getProvider(providerName string) (testProvider, error) {
 		} else {
 			secretData["emulatorEnabled"] = "true"
 			secretData["storageAPIEndpoint"] = fmt.Sprintf("http://%s/storage/v1/", fakeGCSHost)
-			secretData["serviceAccountJson"] = "dummy-service-account-json"
+			secretData["serviceAccountJson"] = `{
+				"project_id": "dummy-project-id",
+				"type": "service_account"
+			}`
 		}
 		provider = testProvider{
 			name: "gcp",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind test

**What this PR does / why we need it**:

The PR #743 restored the e2e tests and made them run with cloud providers(real infra & their emulators), to make that happen it installs the provider CLIs such as `awscli`, `az` and `gcloud` to interact with both real providers and emulators. The current code uses `pip3` to install these CLI tools but we plan to run these tests in prow environment where they run inside a Debian linux container where pip3 is not present by default. So the PR makes changes to install these tools using `apt` pkg manager which is native to Debian environments. 

This PR also fixes a failing e2e test case where the `pgrep` command to get the PID of the `etcd-wrapper` process is not working as intended, changed it to use combination of `ps`, `grep` and `awk` through piping.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Updated e2e test setup to install provider CLIs using `apt` package manager and fixed a failing test case involving `etcd-wrapper` process PID retrieval.
```
