### PR TITLE
Nit: reorder args in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ format: $(GOIMPORTS_REVISER)
 # Check packages
 .PHONY: check
 check: $(GOLANGCI_LINT) $(GOIMPORTS) $(HELM) format
-	@./hack/check.sh --golangci-lint-config=./.golangci.yaml ./pkg/... ./cmd/... ./test/...
+	@./hack/check.sh --golangci-lint-config=./.golangci.yaml ./cmd/... ./pkg/... ./test/...
 
 .PHONY: sast
 sast: $(GOSEC)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind task

**What this PR does / why we need it**:
Fixes the release notes in `rel-v0.35`.

**Which issue(s) this PR fixes**:
Fixes the release notes in `rel-v0.35`.

**Special notes for your reviewer**:

This PR adds release notes of commits that were directly added to `rel-v0.35`, and not added as PRs.

The branch was created by editing the bump commit instead of cherry-picking all commits from master to `rel-v0.35` through PRs. This should be avoided in the future.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Added a support for skipping or ignoring any snapshot in an object lock-enabled S3 bucket. For more information please refer to this doc: https://github.com/gardener/etcd-backup-restore/blob/master/docs/usage/enabling_immutable_snapshots.md#aws-s3
```
```noteworthy developer
Introduce `golangci-lint`, `goimports-reviser`, `goimports`, upgrade tool versions, etc.
```
```other developer
Upgrade Go to 1.24, and dependencies.
```
