### PR TITLE
Switch Slack references to Gardener workspace

### DIFF
--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -9,5 +9,5 @@ STOP -- PLEASE READ!
 
 GitHub is not the right place for support requests.
 
-If you're looking for help, please post your question on the [Kubernetes Slack](http://slack.k8s.io/) ([#gardener](https://kubernetes.slack.com/messages/gardener) channel) or join our [bi-weekly meetings](https://gardener.cloud/docs/contribute/#bi-weekly-meetings).
+If you're looking for help, please post your question on the [Gardener Slack](https://gardener-cloud.slack.com/) (join the workspace [here](https://gardener.cloud/community/community-bio/)) or join our [bi-weekly meetings](https://gardener.cloud/community/).
 -->


### PR DESCRIPTION
/kind enhancement
/area open-source

**What this PR does / why we need it**:

This PR switches all Slack references to the dedicated Gardener Project workspace.

**Which issue(s) this PR fixes**:

Part of https://github.com/gardener/documentation/issues/606

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
