### PR TITLE
Clean up snapshot temp directory during initialization

### DIFF
--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -124,6 +124,19 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 			}
 		}
 	}
+
+	// clean up snapshot temp directory and recreate it, since this can be considered part of initializing
+	// the data directory for future snapshotting, if snapshot TempDir is specified.
+	// This also allows cleaning up a previously created temp directory files with wider file permissions.
+	if e.Config.SnapstoreConfig.TempDir != "" && e.Config.SnapstoreConfig.TempDir != "/tmp" {
+		if err = e.removeDir(e.Config.SnapstoreConfig.TempDir); err != nil {
+			return fmt.Errorf("failed to remove directory %s with err: %v", e.Config.SnapstoreConfig.TempDir, err)
+		}
+		if err = os.MkdirAll(e.Config.SnapstoreConfig.TempDir, 0700); err != nil {
+			return fmt.Errorf("failed to create temporary directory %s: %v", e.Config.SnapstoreConfig.TempDir, err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -300,7 +300,7 @@ func (m *memberControl) RemoveMember(ctx context.Context) error {
 
 // IsLearnerPresent checks for the learner(non-voting) member in a cluster.
 func (m *memberControl) IsLearnerPresent(ctx context.Context) (bool, error) {
-	m.logger.Infof("checking the presence of a learner in a cluster...")
+	m.logger.Infof("checking the presence of a learner in the cluster...")
 
 	cli, err := m.clientFactory.NewCluster()
 	if err != nil {
@@ -366,7 +366,7 @@ func (m *memberControl) GetPeerURLs(ctx context.Context, closer etcdClient.Clust
 	return []string{}, nil
 }
 
-// WasMemberInCluster checks the whether etcd member was part of etcd cluster.
+// WasMemberInCluster checks whether etcd member was part of etcd cluster.
 func (m *memberControl) WasMemberInCluster(ctx context.Context, clientSet client.Client) bool {
 	etcdMemberPresent, err := m.IsMemberInCluster(ctx)
 	if err == nil {

--- a/pkg/server/httpAPI.go
+++ b/pkg/server/httpAPI.go
@@ -464,7 +464,7 @@ func (h *HTTPHandler) serveConfig(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	state, err := h.GetClusterState(req.Context(), clusterSize, podName, podNS)
+	state, err := h.getClusterState(req.Context(), clusterSize, podName, podNS)
 	if err != nil {
 		h.Logger.Warnf("failed to get cluster state %v", err)
 		rw.WriteHeader(http.StatusInternalServerError)
@@ -490,8 +490,8 @@ func (h *HTTPHandler) serveConfig(rw http.ResponseWriter, req *http.Request) {
 	h.Logger.Info("Served config for ETCD instance.")
 }
 
-// GetClusterState returns the Cluster state either `new` or `existing`.
-func (h *HTTPHandler) GetClusterState(ctx context.Context, clusterSize int, podName string, podNS string) (string, error) {
+// getClusterState returns the Cluster state either `new` or `existing`.
+func (h *HTTPHandler) getClusterState(ctx context.Context, clusterSize int, podName string, podNS string) (string, error) {
 	if clusterSize == 1 {
 		return miscellaneous.ClusterStateNew, nil
 	}

--- a/pkg/snapstore/utils.go
+++ b/pkg/snapstore/utils.go
@@ -46,24 +46,6 @@ func GetSnapstore(config *brtypes.SnapstoreConfig) (brtypes.SnapStore, error) {
 		return nil, fmt.Errorf("storage container name not specified")
 	}
 
-	if len(config.TempDir) == 0 {
-		config.TempDir = path.Join("/tmp")
-	}
-	if _, err := os.Stat(config.TempDir); err != nil {
-		if !os.IsNotExist(err) {
-			return nil, fmt.Errorf("failed to get file info of temporary directory %s: %v", config.TempDir, err)
-		}
-
-		logrus.Infof("Temporary directory %s does not exist. Creating it...", config.TempDir)
-		if err := os.MkdirAll(config.TempDir, 0700); err != nil {
-			return nil, fmt.Errorf("failed to create temporary directory %s: %v", config.TempDir, err)
-		}
-	}
-
-	if config.MaxParallelChunkUploads <= 0 {
-		config.MaxParallelChunkUploads = 5
-	}
-
 	switch config.Provider {
 	case brtypes.SnapstoreProviderLocal, "":
 		if config.Container == "" {

--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -234,6 +234,10 @@ func (c *SnapstoreConfig) Validate() error {
 // Complete completes the config.
 func (c *SnapstoreConfig) Complete() {
 	c.Prefix = path.Join(c.Prefix, backupFormatVersion)
+
+	if c.TempDir == "" {
+		c.TempDir = "/tmp"
+	}
 }
 
 // MergeWith completes the config based on other config


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area security compliance
/kind task cleanup

**What this PR does / why we need it**:
Clean up snapshot temp directory during initialization, to ensure any previously created temp files for snapshot upload will be cleaned up, which helps in two ways (a) to remove unnecessary files which may not have been properly cleaned up in a previous run of etcdbr and (b) these older files might have old file permissions before umask of 0077 was set, which might violate [DISA STIG](https://www.stigviewer.com/stig/kubernetes/) standards, hence cleaning up these files is beneficial from a security perspective as well.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Clean up snapshot temp directory during initialization.
```
