### PR TITLE
Support non-HA autonomous clusters (#764)

### DIFF
--- a/hack/config/gcp_config.sh
+++ b/hack/config/gcp_config.sh
@@ -24,5 +24,12 @@ if [[ "${USE_FAKEGCS}" == "true" ]]; then
   mkdir -p /tmp/.gcp
   echo -n "${FAKEGCS_LOCAL_URL}"         > /tmp/.gcp/storageAPIEndpoint
   echo -n "true"                         > /tmp/.gcp/emulatorEnabled
+  # Create a dummy service account JSON file
+  cat <<EOF > /tmp/.gcp/service-account.json
+  {
+    "project_id": "dummy-project-id",
+    "type": "service_account"
+  }
+EOF
   export GOOGLE_APPLICATION_CREDENTIALS="/tmp/.gcp/service-account.json"
 fi

--- a/hack/e2e-test/run-e2e-test.sh
+++ b/hack/e2e-test/run-e2e-test.sh
@@ -108,17 +108,18 @@ function cleanup_azure_container() {
 
 # setup_awscli installs the awscli
 function setup_awscli() {
-    if ! $(which aws > /dev/null); then
-      echo "Installing awscli..."
-      if pip3 install --break-system-packages awscli; then
-        echo "Successfully installed awscli."
-      else
-        echo "Failed to install awscli."
-        return 1
-      fi
-    else
-      echo "awscli is already installed."
+    if $(which aws > /dev/null); then
+      return
     fi
+    echo "Installing awscli..."
+    apt update
+    apt install -y curl
+    apt install -y unzip
+    cd $HOME
+    curl -Lo "awscliv2.zip" "https://awscli.amazonaws.com/awscli-exe-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m).zip"
+    unzip awscliv2.zip > /dev/null
+    ./aws/install -i /usr/local/aws-cli -b /usr/local/bin
+    echo "Successfully installed awscli."
 }
 
 # create_aws_container creates the container for the AWS provider
@@ -186,25 +187,20 @@ function setup_aws_e2e() {
     setup_awscli
 }
 
-# setup_gsutil installs the gsutil
-function setup_gsutil() {
-  if ! $(which gsutil > /dev/null); then
-    echo "Installing gsutil..."
-    pip3 install gsutil
-    echo "Successfully installed gsutil."
-  else
-    echo "gsutil is already installed."
-  fi
-}
-
 # create_gcp_container creates the container for the GCP provider
 function create_gcp_container() {
   echo "Setting up GCS infrastructure..."
   echo "Creating test bucket..."
   if [[ -z ${GOOGLE_EMULATOR_HOST:-""} ]]; then
-    gsutil mb "gs://${TEST_ID}"
+    if ! gsutil mb "gs://${TEST_ID}"; then
+      echo "Failed to create GCS bucket ${TEST_ID}."
+      return 1
+    fi
   else 
-    gsutil -o "Credentials:gs_json_host=127.0.0.1" -o "Credentials:gs_json_port=4443" -o "Boto:https_validate_certificates=False" mb "gs://${TEST_ID}"
+    if ! gsutil -o "Credentials:gs_json_host=127.0.0.1" -o "Credentials:gs_json_port=4443" -o "Boto:https_validate_certificates=False" mb "gs://${TEST_ID}"; then
+      echo "Failed to create GCS bucket ${TEST_ID}."
+      return 1
+    fi
   fi
   echo "Successfully created test bucket."
   echo "Setting up GCS infrastructure completed."
@@ -228,11 +224,33 @@ EOM
   return 1
 }
 
+# setup_gcloud installs the gcloud sdk
+function setup_gcloud() {
+  if $(which gcloud > /dev/null); then
+    return
+  fi
+  echo "Installing gcloud..."
+  cd $HOME
+  apt update
+  apt install -y curl
+  apt install -y python3
+  curl -Lo "google-cloud-sdk.tar.gz" https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-503.0.0-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/aarch64/arm/').tar.gz
+  tar -xzf google-cloud-sdk.tar.gz
+  ./google-cloud-sdk/install.sh -q
+  export PATH=$PATH:${HOME}/google-cloud-sdk/bin
+  cd "${SOURCE_PATH}"
+  echo "Successfully installed gcloud."
+}
+
 # authorize_gcloud authorizes access to Gcloud
 function authorize_gcloud() {
   if ! $(which gcloud > /dev/null); then
     echo "gcloud is not installed. Please install gcloud and try again."
     return 1
+  fi
+  if [[ -n ${GOOGLE_EMULATOR_HOST:-""} ]]; then
+    gcloud config set project "dummy-project"
+    return 0
   fi
   echo "Authorizing access to Gcloud..."
   if gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" --project="${GCP_PROJECT_ID}"; then
@@ -243,8 +261,10 @@ function authorize_gcloud() {
   fi
 }
 
-# setup_gcp_e2e sets up the GCP infrastructure for the e2e tests including deploying fake-gcs and/or installing the gsutil
+# setup_gcp_e2e sets up the GCP infrastructure for the e2e tests including deploying installing the gcloud sdk and/or fake-gcs
 function setup_gcp_e2e() {
+  setup_gcloud
+  authorize_gcloud
   if [[ -n ${GOOGLE_EMULATOR_HOST:-""} ]]; then
     make deploy-fakegcs $KUBECONFIG
   else
@@ -252,9 +272,7 @@ function setup_gcp_e2e() {
     if [[ -z ${GCP_PROJECT_ID:-""} ]] || [[ -z ${GOOGLE_APPLICATION_CREDENTIALS} ]]; then
         usage_gcp
     fi
-    authorize_gcloud
   fi
-  setup_gsutil
 }
 
 # create_azure_container creates the container for the Azure provider
@@ -262,9 +280,15 @@ function create_azure_container() {
   echo "Setting up Azure infrastructure..."
   echo "Creating test bucket..."
   if [[ -n ${AZURITE_DOMAIN:-""} ]]; then
-    az storage container create --connection-string "${AZURE_STORAGE_CONNECTION_STRING}" --name "${TEST_ID}"
+    if ! az storage container create --connection-string "${AZURE_STORAGE_CONNECTION_STRING}" --name "${TEST_ID}"; then
+      echo "Failed to create Azure test bucket."
+      return 1
+    fi
   else
-    az storage container create --account-name "${STORAGE_ACCOUNT}" --account-key "${STORAGE_KEY}" --name "${TEST_ID}"
+    if ! az storage container create --account-name "${STORAGE_ACCOUNT}" --account-key "${STORAGE_KEY}" --name "${TEST_ID}"; then
+      echo "Failed to create Azure test bucket."
+      return 1
+    fi
   fi
   echo "Successfully created test bucket."
   echo "Setting up Azure infrastructure completed."

--- a/test/e2e/backup_test.go
+++ b/test/e2e/backup_test.go
@@ -300,7 +300,7 @@ var _ = Describe("Backup", func() {
 		Context("when data is corrupt", func() {
 			It("should restore data from latest snapshot", func() {
 				testDataCorruptionRestoration := func() {
-					cmd := "export ETCD_PID=$(pgrep etcd-wrapper) && rm -r proc/${ETCD_PID}/root/var/etcd/data/new.etcd/member"
+					cmd := "export ETCD_PID=$(ps -A | grep 'etcd-wrapper' | awk '{print $1}') && rm -r proc/${ETCD_PID}/root/var/etcd/data/new.etcd/member"
 					stdout, stderr, err := executeContainerCommand(kubeconfigPath, releaseNamespace, podName, debugContainerName, cmd)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(stderr).Should(BeEmpty())

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -117,7 +117,10 @@ func getProvider(providerName string) (testProvider, error) {
 		} else {
 			secretData["emulatorEnabled"] = "true"
 			secretData["storageAPIEndpoint"] = fmt.Sprintf("http://%s/storage/v1/", fakeGCSHost)
-			secretData["serviceAccountJson"] = "dummy-service-account-json"
+			secretData["serviceAccountJson"] = `{
+				"project_id": "dummy-project-id",
+				"type": "service_account"
+			}`
 		}
 		provider = testProvider{
 			name: "gcp",


### PR DESCRIPTION


**What this PR does / why we need it**:
CherryPick of PR: https://github.com/gardener/etcd-backup-restore/pull/764

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator
Support non-HA autonomous clusters by skipping creation of Kubernetes clientset.
⚠️ To completely prevent the creation of the Kubernetes `clientSet` in the non-HA etcd-backup-restore, please also set the following CLI flags to `false`: `--enable-member-lease-renewal` and `--enable-snapshot-lease-renewal`.
```
