### PR TITLE
Fix regression in cleaning up snapshot temp directory during initialization

### DIFF
--- a/hack/test-unit.sh
+++ b/hack/test-unit.sh
@@ -27,7 +27,7 @@ test_with_coverage() {
 
 ################################################################################
 
-# To run a specific package, run TEST_PACKAGES=<PATH_TO_PACKAGE> make test
+# To run a specific package, run TEST_PACKAGES=<PATH_TO_PACKAGE> make test-unit
 # If the TEST_PACKAGES is not set, then define a list of packages to run.
 TEST_PACKAGES="${TEST_PACKAGES:-"
 ./pkg/backoff \

--- a/pkg/snapstore/utils.go
+++ b/pkg/snapstore/utils.go
@@ -46,6 +46,20 @@ func GetSnapstore(config *brtypes.SnapstoreConfig) (brtypes.SnapStore, error) {
 		return nil, fmt.Errorf("storage container name not specified")
 	}
 
+	if len(config.TempDir) == 0 {
+		config.TempDir = path.Join("/tmp")
+	}
+	if _, err := os.Stat(config.TempDir); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to get file info of temporary directory %s: %v", config.TempDir, err)
+		}
+
+		logrus.Infof("Temporary directory %s does not exist. Creating it...", config.TempDir)
+		if err := os.MkdirAll(config.TempDir, 0700); err != nil {
+			return nil, fmt.Errorf("failed to create temporary directory %s: %v", config.TempDir, err)
+		}
+	}
+
 	switch config.Provider {
 	case brtypes.SnapstoreProviderLocal, "":
 		if config.Container == "" {

--- a/pkg/snapstore/utils_test.go
+++ b/pkg/snapstore/utils_test.go
@@ -1,0 +1,124 @@
+package snapstore_test
+
+import (
+	"os"
+
+	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+
+	. "github.com/gardener/etcd-backup-restore/pkg/snapstore"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetSnapstore", func() {
+	var (
+		config *brtypes.SnapstoreConfig
+	)
+
+	BeforeEach(func() {
+		config = &brtypes.SnapstoreConfig{
+			Provider:  brtypes.SnapstoreProviderLocal,
+			Prefix:    "test",
+			Container: "test-container",
+			TempDir:   "/tmp",
+		}
+	})
+
+	Context("when prefix is not set", func() {
+		BeforeEach(func() {
+			config.Prefix = ""
+		})
+		It("should set default prefix", func() {
+			_, err := GetSnapstore(config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Prefix).To(Equal("v2"))
+		})
+	})
+
+	Context("when container is not set", func() {
+		BeforeEach(func() {
+			config.Container = ""
+		})
+		Context("if snapstore is to be created for source bucket", func() {
+			BeforeEach(func() {
+				config.IsSource = true
+				Expect(os.Setenv("SOURCE_STORAGE_CONTAINER", "container")).ToNot(HaveOccurred())
+			})
+			AfterEach(func() {
+				Expect(os.Unsetenv("SOURCE_STORAGE_CONTAINER")).ToNot(HaveOccurred())
+			})
+			It("should use SOURCE_STORAGE_CONTAINER env variable", func() {
+				_, err := GetSnapstore(config)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Container).To(Equal("container"))
+			})
+		})
+		Context("if snapstore is to be created for a non-source bucket", func() {
+			BeforeEach(func() {
+				config.IsSource = false
+				Expect(os.Setenv("STORAGE_CONTAINER", "dest-container")).ToNot(HaveOccurred())
+			})
+			AfterEach(func() {
+				Expect(os.Unsetenv("STORAGE_CONTAINER")).ToNot(HaveOccurred())
+			})
+			It("should use STORAGE_CONTAINER env variable", func() {
+				_, err := GetSnapstore(config)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Container).To(Equal("dest-container"))
+			})
+		})
+	})
+
+	Context("when snapshot temp dir not provided", func() {
+		BeforeEach(func() {
+			config.TempDir = ""
+		})
+		It("should use default temp dir and create it if necessary", func() {
+			snapstore, err := GetSnapstore(config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(snapstore).ToNot(BeNil())
+			Expect(config.TempDir).To(Equal("/tmp"))
+			_, err = os.Stat(config.TempDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("when provided snapshot temp dir does not exist", func() {
+		BeforeEach(func() {
+			config.TempDir = "/tmp/nonexistent/dir"
+		})
+		It("should create the temp dir", func() {
+			snapstore, err := GetSnapstore(config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(snapstore).ToNot(BeNil())
+			_, err = os.Stat(config.TempDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("when snapstore provider is local", func() {
+		BeforeEach(func() {
+			config.Provider = brtypes.SnapstoreProviderLocal
+			config.Container = "test-container"
+		})
+		It("should return a local snapstore", func() {
+			snapstore, err := GetSnapstore(config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(snapstore).ToNot(BeNil())
+			_, ok := snapstore.(*LocalSnapStore)
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Context("when snapstore provider is unknown", func() {
+		BeforeEach(func() {
+			config.Provider = "unknown"
+		})
+		It("should return an error", func() {
+			snapstore, err := GetSnapstore(config)
+			Expect(err).To(HaveOccurred())
+			Expect(snapstore).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("unsupported storage provider"))
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area backup
/kind regression bug

**What this PR does / why we need it**:
Fix regression caused by #869, due to which snapshot temp directory was not getting created, specifically for compaction command that doesn't use `initializer` package to initialize the directories. The code which was erroneously removed was [this](https://github.com/gardener/etcd-backup-restore/pull/869/files#diff-29fda098b6a688bb2dc41eb985a767e795ffcbe1c3cd788b12148cab0ea4f21fL49-L61), in an attempt to clean up redundant code. This PR adds that code back.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @seshachalam-yv @anveshreddy18 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix regression in cleanup of snapshot temporary directory.
```
