### PR TITLE
Fix regression for snapshot temp dir cleanup when no snapstore configured

### DIFF
--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -128,13 +128,20 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode, failBelowRevision int6
 	// clean up snapshot temp directory and recreate it, since this can be considered part of initializing
 	// the data directory for future snapshotting, if snapshot TempDir is specified.
 	// This also allows cleaning up a previously created temp directory files with wider file permissions.
+
+	if e.Config.SnapstoreConfig == nil {
+		logger.Infof("Will not clean up temporary snapshot directory since no snapstore configured. Continuing.")
+		return nil
+	}
+
 	if e.Config.SnapstoreConfig.TempDir != "" && e.Config.SnapstoreConfig.TempDir != "/tmp" {
 		if err = e.removeDir(e.Config.SnapstoreConfig.TempDir); err != nil {
 			return fmt.Errorf("failed to remove directory %s with err: %v", e.Config.SnapstoreConfig.TempDir, err)
 		}
-		if err = os.MkdirAll(e.Config.SnapstoreConfig.TempDir, 0700); err != nil {
-			return fmt.Errorf("failed to create temporary directory %s: %v", e.Config.SnapstoreConfig.TempDir, err)
-		}
+	}
+	logger.Infof("Creating temporary directory %s if it does not exist.", e.Config.SnapstoreConfig.TempDir)
+	if err = os.MkdirAll(e.Config.SnapstoreConfig.TempDir, 0700); err != nil {
+		return fmt.Errorf("failed to create temporary directory %s: %w", e.Config.SnapstoreConfig.TempDir, err)
 	}
 
 	return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area backup
/kind regression bug

**What this PR does / why we need it**:
Fix regression for snapshot temp dir cleanup when no snapstore configured, by checking for whether snapstoreConfig is configured before attempting to clean up the temporary directory.

**Which issue(s) this PR fixes**:
Fixes #880 

**Special notes for your reviewer**:
/invite @anveshreddy18 @seshachalam-yv 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix regression for snapshot temp dir cleanup when no snapstore configured.
```
