### PR TITLE
Add support for `WORM immutable objects` for ALI cloud's  OSS.

### DIFF
--- a/docs/usage/enabling_immutable_snapshots.md
+++ b/docs/usage/enabling_immutable_snapshots.md
@@ -5,6 +5,7 @@ This guide walks you through the process of enabling immutable snapshots in `etc
 1. Google Cloud Storage (GCS)
 2. Azure Blob Storage (ABS)
 3. Amazon Simple Storage Service (AWS S3)
+4. ALI Cloud Object Storage Service (OSS)
 
 > [!Note]
 > Currently, Openstack object storage (swift) doesn't support immutability for objects: https://blueprints.launchpad.net/swift/+spec/immutability-middleware.
@@ -37,6 +38,7 @@ Please move to respective storage providers for configurations:
 - [Google Cloud Storage](#google-cloud-storage-gcs)
 - [Azure Blob Storage](#azure-blob-storage-abs)
 - [AWS Simple Storage Service](#aws-simple-storage-service-aws-s3)
+- [ALI Cloud OSS](#ali-cloud-oss)
 
 ## Google Cloud Storage (GCS)
 
@@ -348,6 +350,97 @@ The following diagram illustrates the working of snapshots with S3 for existing/
 
   ![Working with S3](../images/S3_immutability_working.png)
 
+### ALI Cloud OSS
+
+### ALI Cloud OSS Terminology
+
+- **Bucket**: A storage resource in cloud storage services where objects (such as snapshots) are stored. Ali cloud OSS uses the term **bucket**.
+
+- **WORM**: The property of an object being unmodifiable after creation i.e write-once-ready-many, until the retention period expires.
+
+- **Retention Policy**: A configuration that specifies a retention period during which objects in a bucket are protected from deletion or modification.
+
+- **Retention Period**: The duration defined in the retention policy during which objects remain immutable/worm.
+
+#### Configure an retention policy on a OSS bucket
+
+1. **Set the Retention Policy**
+
+   Use the `aliyun` command-line tool to set the immutability/retention period:
+
+   ```bash
+   aliyun oss worm init oss://[BUCKET_NAME] [RETENTION_PERIOD]
+   ```
+
+   - Replace `[RETENTION_PERIOD]` with the desired immutability period (e.g., `4d` for four days).
+   - Replace `[BUCKET_NAME]` with the name of your bucket.
+
+   **Example:**
+
+   ```bash
+   aliyun oss worm init oss://my-bucket 4
+   ```
+
+  > [!Note]
+  > If a retention policy is not locked within 24 hours after it is created, the retention policy becomes invalid.
+
+#### Modify the retention policy
+
+You can remove an unlocked retention policy to adjust the retention period or you can extend retention period of the bucket(provided retention policy is locked).
+
+1. **Remove the Retention Policy**
+
+  ```bash
+  aliyun oss worm abort oss://[BUCKET_NAME]
+  ```
+
+  **Example:**
+
+  ```bash
+  aliyun oss worm abort oss://my-bucket
+  ```
+
+2. **Extend Retention Period**
+
+   - To extend the retention period:
+      1. [Retention policy must be locked](#lock-the-retention-policy-for-oss).
+      2. Get the wormId of bucket as it's need to be pass in the request.
+  
+```bash
+## Get the wormId of bucket
+aliyun oss worm get oss://[BUCKET_NAME]
+
+# extend then retention period of retention policy for bucket
+aliyun oss worm extend oss://[BUCKET_NAME] [RETENTION_PERIOD] [WormId]
+```
+
+  **Example:**
+
+  ```bash
+  aliyun oss worm get oss://my-bucket
+
+  aliyun oss worm extend oss://my-bucket 5 <worm-id>
+  ```
+
+#### Lock the retention policy for OSS
+
+Locking the retention policy makes it irreversible and ensures that the policy cannot be reduced or removed. This provides compliance with regulatory requirements.
+
+1. **Lock the Policy**
+
+  ```bash
+  aliyun oss worm complete oss://[BUCKET_NAME] [WormId]
+  ```
+
+  **Example:**
+
+  ```bash
+  aliyun oss worm complete oss://my-bucket <wormID>
+  ```
+
+  > [!CAUTION]
+  > Once retention policy is locked, then retention policy cannot be removed and retention period can't be decreased.
+
 ## Ignoring Snapshots During Restoration
 
 In certain scenarios, you might want `etcd-backup-restore` to ignore specific snapshots present in the object store during the restoration of etcd's data directory. When snapshots were mutable, operators could simply delete any snapshots present in the object store, and subsequent restorations would not include them. However, once immutability is enabled, it is no longer possible to delete these snapshots.
@@ -511,3 +604,7 @@ By following best practices and regularly reviewing your backup and immutability
   - [Object Lock Documentation](https://aws.amazon.com/s3/features/object-lock/)
   - [Object Lock modes and best practices](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html)
   - [Deletion of object](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html)
+
+- **ALI Cloud OSS**
+  - [Enable Worm on bucket](https://www.alibabacloud.com/help/en/oss/developer-reference/worm)
+  - [OSS Retention Policy](https://www.alibabacloud.com/help/en/oss/user-guide/oss-retention-policies)

--- a/docs/usage/enabling_immutable_snapshots.md
+++ b/docs/usage/enabling_immutable_snapshots.md
@@ -404,7 +404,7 @@ You can remove an unlocked retention policy to adjust the retention period or yo
 
    - To extend the retention period:
       1. [Retention policy must be locked](#lock-the-retention-policy-for-oss).
-      2. Get the wormId of bucket as it's need to be pass in the request.
+      2. Get the wormId of bucket as it's required to be passed in the request.
   
 ```bash
 ## Get the wormId of bucket

--- a/pkg/snapstore/internal/ossApi/interface.go
+++ b/pkg/snapstore/internal/ossApi/interface.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ossApi
+
+import (
+	"io"
+
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+)
+
+// OSSBucket is an interface for oss.Bucket used in snapstore
+type OSSBucket interface {
+	// GetObject downloads the object.
+	GetObject(objectKey string, options ...oss.Option) (io.ReadCloser, error)
+	// ListObjects lists the objects under the current bucket.
+	ListObjects(options ...oss.Option) (oss.ListObjectsResult, error)
+	// DeleteObject deletes the object.
+	DeleteObject(objectKey string, options ...oss.Option) error
+	// InitiateMultipartUpload initializes multipart upload
+	InitiateMultipartUpload(objectKey string, options ...oss.Option) (oss.InitiateMultipartUploadResult, error)
+	// CompleteMultipartUpload completes the multipart upload.
+	CompleteMultipartUpload(imur oss.InitiateMultipartUploadResult, parts []oss.UploadPart, options ...oss.Option) (oss.CompleteMultipartUploadResult, error)
+	// UploadPart uploads parts
+	UploadPart(imur oss.InitiateMultipartUploadResult, reader io.Reader, partSize int64, partNumber int, options ...oss.Option) (oss.UploadPart, error)
+	// AbortMultipartUpload aborts the multipart upload.
+	AbortMultipartUpload(imur oss.InitiateMultipartUploadResult, options ...oss.Option) error
+}
+
+// Client is an interface for oss.Client used in snapstore
+type Client interface {
+	// GetBucketWorm get bucket WORM(Write-Once-Read-Many) configuration.
+	GetBucketWorm(bucketName string, options ...oss.Option) (oss.WormConfiguration, error)
+}

--- a/pkg/snapstore/oss/interface.go
+++ b/pkg/snapstore/oss/interface.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package ossApi
+package oss
 
 import (
 	"io"

--- a/pkg/snapstore/oss_snapstore.go
+++ b/pkg/snapstore/oss_snapstore.go
@@ -18,7 +18,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gardener/etcd-backup-restore/pkg/snapstore/internal/ossApi"
+	stiface "github.com/gardener/etcd-backup-restore/pkg/snapstore/oss"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
@@ -42,8 +42,8 @@ type authOptions struct {
 
 // OSSSnapStore is snapstore with Alicloud OSS object store as backend
 type OSSSnapStore struct {
-	bucket                  ossApi.OSSBucket
-	client                  ossApi.Client
+	bucket                  stiface.OSSBucket
+	client                  stiface.Client
 	bucketName              string
 	prefix                  string
 	tempDir                 string
@@ -75,7 +75,7 @@ func newOSSFromAuthOpt(bucket, prefix, tempDir string, maxParallelChunkUploads u
 }
 
 // NewOSSFromBucket will create the new OSS snapstore object from OSS bucket
-func NewOSSFromBucket(prefix, tempDir, bucketName string, maxParallelChunkUploads uint, minChunkSize int64, client ossApi.Client, bucket ossApi.OSSBucket) *OSSSnapStore {
+func NewOSSFromBucket(prefix, tempDir, bucketName string, maxParallelChunkUploads uint, minChunkSize int64, client stiface.Client, bucket stiface.OSSBucket) *OSSSnapStore {
 	return &OSSSnapStore{
 		prefix:                  prefix,
 		bucket:                  bucket,

--- a/pkg/snapstore/oss_snapstore.go
+++ b/pkg/snapstore/oss_snapstore.go
@@ -18,11 +18,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/smithy-go/ptr"
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore/internal/ossApi"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/aws/smithy-go/ptr"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/snapstore/oss_snapstore_test.go
+++ b/pkg/snapstore/oss_snapstore_test.go
@@ -173,7 +173,7 @@ func (m *mockOSSBucket) DeleteObject(objectKey string, _ ...oss.Option) error {
 	return nil
 }
 
-// // GetBucketWorm get bucket worm configuration for given bucket name.
+// GetBucketWorm get bucket worm configuration for given bucket name.
 func (m *mockOSSClient) GetBucketWorm(_ string, _ ...oss.Option) (oss.WormConfiguration, error) {
 	return oss.WormConfiguration{
 		State:                 "InProgress",

--- a/pkg/snapstore/oss_snapstore_test.go
+++ b/pkg/snapstore/oss_snapstore_test.go
@@ -12,8 +12,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore/internal/ossApi"
+
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 )
 
 // ensure mockOSSBucket implements the OSSBucket interface
@@ -173,7 +174,7 @@ func (m *mockOSSBucket) DeleteObject(objectKey string, _ ...oss.Option) error {
 }
 
 // // GetBucketWorm get bucket worm configuration for given bucket name.
-func (m *mockOSSClient) GetBucketWorm(bucketName string, opts ...oss.Option) (oss.WormConfiguration, error) {
+func (m *mockOSSClient) GetBucketWorm(_ string, _ ...oss.Option) (oss.WormConfiguration, error) {
 	return oss.WormConfiguration{
 		State:                 "InProgress",
 		RetentionPeriodInDays: 1,

--- a/pkg/snapstore/oss_snapstore_test.go
+++ b/pkg/snapstore/oss_snapstore_test.go
@@ -12,16 +12,16 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gardener/etcd-backup-restore/pkg/snapstore/internal/ossApi"
+	stiface "github.com/gardener/etcd-backup-restore/pkg/snapstore/oss"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 )
 
 // ensure mockOSSBucket implements the OSSBucket interface
-var _ ossApi.OSSBucket = (*mockOSSBucket)(nil)
+var _ stiface.OSSBucket = (*mockOSSBucket)(nil)
 
 // ensure mockOSSClient implements the Client interface
-var _ ossApi.Client = (*mockOSSClient)(nil)
+var _ stiface.Client = (*mockOSSClient)(nil)
 
 type uploadParts []oss.UploadPart
 


### PR DESCRIPTION
**How to categorize this PR?**
/area compliance
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR introduces support for `WORM immutable objects` in Alibaba Cloud's Object Storage Service (OSS) by modifying the garbage collection functionality to manage immutable snapshots. Additionally, it updates the documentation in `docs/usage/immutable_snapshots.md`.

**Which issue(s) this PR fixes**:
Fixes #879 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
etcd-backup-restore now supports worm immutable objects for storage provider: ALI Cloud OSS, provided by the [WORM Lock](https://www.alibabacloud.com/help/en/oss/developer-reference/worm) feature.
```

```noteworthy operator
Snapshots garbage collection performed by etcd-backup-restore (if enabled) for ALI Cloud OSS is performed only when the snapshots's retention period get expires.
```

```noteworthy operator
Support for WORM lock (ALI Cloud's OSS) in etcd-backup-restore is backward compatible. For more info please refer to this doc: https://github.com/gardener/etcd-backup-restore/blob/master/docs/usage/enabling_immutable_snapshots.md
```
