### PR TITLE
Check for snapshot names with the `.final` suffix trimmed in the destination store before upload.

### DIFF
--- a/pkg/snapshot/copier/copier.go
+++ b/pkg/snapshot/copier/copier.go
@@ -7,6 +7,7 @@ package copier
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -135,7 +136,8 @@ func (c *Copier) copyBackups() error {
 	// find snapshots missing in destination
 	var snapshotsToCopy brtypes.SnapList
 	for _, snapshot := range sourceSnapshot {
-		if _, ok := destSnapshotsMap[snapshot.SnapName]; !ok {
+		snapNameWithoutSuffix := strings.TrimSuffix(snapshot.SnapName, brtypes.FinalSuffix)
+		if _, ok := destSnapshotsMap[snapNameWithoutSuffix]; !ok {
 			snapshotsToCopy = append(snapshotsToCopy, snapshot)
 		} else {
 			c.logger.Infof("Skipping %s snapshot %s as it already exists", snapshot.Kind, snapshot.SnapName)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane-migration
/area backup
/kind bug

**What this PR does / why we need it**:

This PR trims the `.final` suffix from the name of snapshots when their presence is being checked in the destination, as snapshots are not uploaded with this suffix to the destination.

**Which issue(s) this PR fixes**:
Fixes #906

**Special notes for your reviewer**:

cc @ishan16696 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `copy` command does not attempt to upload snapshots with the `.final` suffix in the source to the destination store if they are already in the destination.
```
