### PR TITLE
Removed extra handling of safe_guard file created with wider permissions

### DIFF
--- a/pkg/initializer/validator/datavalidator.go
+++ b/pkg/initializer/validator/datavalidator.go
@@ -99,12 +99,6 @@ func (d *DataValidator) sanityCheck(failBelowRevision int64) (DataDirStatus, err
 			}
 		}
 
-		// change file permission to handle previously created files with too wide permissions.
-		// TODO (shreyas-s-rao): remove this code to change file mode, in etcd-backup-restore:v0.36.0.
-		if err := os.Chmod(path, 0600); err != nil {
-			d.Logger.Fatalf("can't change the permission of the `safe_guard` file because : %v", err)
-		}
-
 		// read the content of the file safe_guard and match it with the environment variable
 		content, err := os.ReadFile(path) // #nosec G304 -- this is a trusted safe_guard file written to by etcdbr.
 		if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
/area compliance
/kind cleanup

**What this PR does / why we need it**:
This PR: https://github.com/gardener/etcd-backup-restore/pull/821 introduces the extra handling of `safe_guard` file created with wider permissions to reduce them, now this extra handling is no longer required.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @shreyas-s-rao 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
