### PR TITLE
Setting the default snapshot compression to true.

### DIFF
--- a/pkg/compressor/types.go
+++ b/pkg/compressor/types.go
@@ -14,7 +14,7 @@ const (
 	ZlibCompressionPolicy = "zlib"
 
 	// DefaultCompression is constant used for whether to compress the snapshots or not.
-	DefaultCompression = false
+	DefaultCompression = true
 	// DefaultCompressionPolicy is constant for default compression algorithm(only if compression is enabled).
 	DefaultCompressionPolicy = "gzip"
 


### PR DESCRIPTION
**How to categorize this PR?**
/area backup
/kind technical-debt

**What this PR does / why we need it**:
Snapshot compression feature was introduced long back by this PR https://github.com/gardener/etcd-backup-restore/pull/293 but we decided not to enable it by default. Now I think the feature has been matured enough and it can be enabled by default, so that community user who are not very well aware of each feature(s) can also consume it using default values.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Snapshot compression is now enabled by default.
If you wish to disable the snapshot compression then please set this flag: `--compress-snapshots` to false.
```
