### PR TITLE
To re-add additional handling for `safe_guard` files with wider permissions.

### DIFF
--- a/pkg/initializer/validator/datavalidator.go
+++ b/pkg/initializer/validator/datavalidator.go
@@ -99,6 +99,12 @@ func (d *DataValidator) sanityCheck(failBelowRevision int64) (DataDirStatus, err
 			}
 		}
 
+		// Change file permissions of legacy `safe_guard` files.
+		// TODO: To be removed in etcd-backup-restore:v0.41.0.
+		if err := os.Chmod(path, 0600); err != nil {
+			d.Logger.Fatalf("can't change the permission of the `safe_guard` file because : %v", err)
+		}
+
 		// read the content of the file safe_guard and match it with the environment variable
 		content, err := os.ReadFile(path) // #nosec G304 -- this is a trusted safe_guard file written to by etcdbr.
 		if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
/area compliance

**What this PR does / why we need it**:
This PR adds the additional handling to address cases where the `safe_guard` file has broad permissions more than required.

**Which issue(s) this PR fixes**:
Fixes #932 

**Special notes for your reviewer**:
/cc @shreyas-s-rao 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adds the additional handling to reduce file permissions of `safe_guard` file.
```
