### PR TITLE
Add fallback when service-endpoints is not specified

### DIFF
--- a/pkg/etcdutil/etcdutil.go
+++ b/pkg/etcdutil/etcdutil.go
@@ -114,7 +114,7 @@ func GetTLSClientForEtcd(tlsConfig *brtypes.EtcdConnectionConfig, options *clien
 				return nil, fmt.Errorf("failed to get etcd endpoints from config file %s: %v", configFilePath, err)
 			}
 			if len(endpoints) == 0 {
-				endpoints = tlsConfig.Endpoints
+				return nil, fmt.Errorf("no etcd endpoints present in config file %s", configFilePath)
 			}
 		}
 	}

--- a/pkg/etcdutil/etcdutil_test.go
+++ b/pkg/etcdutil/etcdutil_test.go
@@ -324,8 +324,8 @@ var _ = Describe("EtcdUtil Tests", func() {
 
 		AfterEach(func() {
 			if tempConfigFile != "" {
-				os.Remove(tempConfigFile)
-				os.Unsetenv("ETCD_CONF")
+				Expect(os.Remove(tempConfigFile)).To(Succeed())
+				Expect(os.Unsetenv("ETCD_CONF")).To(Succeed())
 				tempConfigFile = ""
 			}
 		})

--- a/pkg/etcdutil/etcdutil_test.go
+++ b/pkg/etcdutil/etcdutil_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gardener/etcd-backup-restore/pkg/compressor"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
+	"github.com/gardener/etcd-backup-restore/pkg/etcdutil/client"
 	mockfactory "github.com/gardener/etcd-backup-restore/pkg/mock/etcdutil/client"
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
@@ -302,6 +303,107 @@ var _ = Describe("EtcdUtil Tests", func() {
 
 				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, dummyClientEndpoints, mockTimeout, logger)
 				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("UseServiceEndpoints option", func() {
+		var (
+			cfg            brtypes.EtcdConnectionConfig
+			tempConfigFile string
+		)
+
+		BeforeEach(func() {
+			cfg = brtypes.EtcdConnectionConfig{
+				Endpoints:          []string{"http://default:2379"},
+				ServiceEndpoints:   []string{},
+				InsecureTransport:  true,
+				InsecureSkipVerify: false,
+			}
+		})
+
+		AfterEach(func() {
+			if tempConfigFile != "" {
+				os.Remove(tempConfigFile)
+				os.Unsetenv("ETCD_CONF")
+				tempConfigFile = ""
+			}
+		})
+
+		Context("when UseServiceEndpoints is false", func() {
+			It("should use Endpoints from config", func() {
+				etcdClient, err := etcdutil.GetTLSClientForEtcd(&cfg, &client.Options{UseServiceEndpoints: false})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(etcdClient).ShouldNot(BeNil())
+				Expect(etcdClient.Endpoints()).Should(Equal([]string{"http://default:2379"}))
+				etcdClient.Close()
+			})
+		})
+
+		Context("when UseServiceEndpoints is true", func() {
+			Context("and ServiceEndpoints are provided", func() {
+				It("should use ServiceEndpoints", func() {
+					cfg.ServiceEndpoints = []string{"http://service:2379"}
+					etcdClient, err := etcdutil.GetTLSClientForEtcd(&cfg, &client.Options{UseServiceEndpoints: true})
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(etcdClient).ShouldNot(BeNil())
+					Expect(etcdClient.Endpoints()).Should(Equal([]string{"http://service:2379"}))
+					etcdClient.Close()
+				})
+			})
+
+			Context("and ServiceEndpoints are empty", func() {
+				Context("and config file exists with member client URLs", func() {
+					It("should use endpoints from config file", func() {
+						// Create a temporary config file with proper format
+						configContent := []byte(`name: member-1
+initial-cluster: member-1=http://member-1:2380,member-2=http://member-2:2380,member-3=http://member-3:2380
+initial-advertise-peer-urls:
+  member-1:
+    - http://member-1:2380
+  member-2:
+    - http://member-2:2380
+  member-3:
+    - http://member-3:2380
+advertise-client-urls:
+  member-1:
+    - http://member-1:2379
+  member-2:
+    - http://member-2:2379
+  member-3:
+    - http://member-3:2379
+`)
+						tempFile, err := os.CreateTemp("", "etcd-config-*.yaml")
+						Expect(err).ShouldNot(HaveOccurred())
+						tempConfigFile = tempFile.Name()
+						_, err = tempFile.Write(configContent)
+						Expect(err).ShouldNot(HaveOccurred())
+						tempFile.Close()
+
+						// Set environment variable to point to temp config file
+						os.Setenv("ETCD_CONF", tempConfigFile)
+
+						cfg.ServiceEndpoints = []string{}
+						etcdClient, err := etcdutil.GetTLSClientForEtcd(&cfg, &client.Options{UseServiceEndpoints: true})
+						Expect(err).ShouldNot(HaveOccurred())
+						Expect(etcdClient).ShouldNot(BeNil())
+						Expect(etcdClient.Endpoints()).Should(ConsistOf("http://member-1:2379", "http://member-2:2379", "http://member-3:2379"))
+						etcdClient.Close()
+					})
+				})
+
+				Context("and config file is missing", func() {
+					It("should fallback to Endpoints", func() {
+						// Set invalid config file path
+						os.Setenv("ETCD_CONF", "/nonexistent/path/config.yaml")
+
+						cfg.ServiceEndpoints = []string{}
+						_, err := etcdutil.GetTLSClientForEtcd(&cfg, &client.Options{UseServiceEndpoints: true})
+						// Should fail because config file doesn't exist
+						Expect(err).Should(HaveOccurred())
+						Expect(err.Error()).Should(ContainSubstring("failed to get etcd endpoints from config file"))
+					})
+				})
 			})
 		})
 	})

--- a/pkg/etcdutil/etcdutil_test.go
+++ b/pkg/etcdutil/etcdutil_test.go
@@ -333,10 +333,10 @@ var _ = Describe("EtcdUtil Tests", func() {
 		Context("when UseServiceEndpoints is false", func() {
 			It("should use Endpoints from config", func() {
 				etcdClient, err := etcdutil.GetTLSClientForEtcd(&cfg, &client.Options{UseServiceEndpoints: false})
+				defer etcdClient.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(etcdClient).ShouldNot(BeNil())
 				Expect(etcdClient.Endpoints()).Should(Equal([]string{"http://default:2379"}))
-				etcdClient.Close()
 			})
 		})
 
@@ -345,10 +345,10 @@ var _ = Describe("EtcdUtil Tests", func() {
 				It("should use ServiceEndpoints", func() {
 					cfg.ServiceEndpoints = []string{"http://service:2379"}
 					etcdClient, err := etcdutil.GetTLSClientForEtcd(&cfg, &client.Options{UseServiceEndpoints: true})
+					defer etcdClient.Close()
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(etcdClient).ShouldNot(BeNil())
 					Expect(etcdClient.Endpoints()).Should(Equal([]string{"http://service:2379"}))
-					etcdClient.Close()
 				})
 			})
 
@@ -374,21 +374,21 @@ advertise-client-urls:
     - http://member-3:2379
 `)
 						tempFile, err := os.CreateTemp("", "etcd-config-*.yaml")
+						defer tempFile.Close()
 						Expect(err).ShouldNot(HaveOccurred())
 						tempConfigFile = tempFile.Name()
 						_, err = tempFile.Write(configContent)
 						Expect(err).ShouldNot(HaveOccurred())
-						tempFile.Close()
 
 						// Set environment variable to point to temp config file
 						os.Setenv("ETCD_CONF", tempConfigFile)
 
 						cfg.ServiceEndpoints = []string{}
 						etcdClient, err := etcdutil.GetTLSClientForEtcd(&cfg, &client.Options{UseServiceEndpoints: true})
+						defer etcdClient.Close()
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(etcdClient).ShouldNot(BeNil())
 						Expect(etcdClient.Endpoints()).Should(ConsistOf("http://member-1:2379", "http://member-2:2379", "http://member-3:2379"))
-						etcdClient.Close()
 					})
 				})
 

--- a/pkg/etcdutil/etcdutil_test.go
+++ b/pkg/etcdutil/etcdutil_test.go
@@ -333,8 +333,8 @@ var _ = Describe("EtcdUtil Tests", func() {
 		Context("when UseServiceEndpoints is false", func() {
 			It("should use Endpoints from config", func() {
 				etcdClient, err := etcdutil.GetTLSClientForEtcd(&cfg, &client.Options{UseServiceEndpoints: false})
-				defer etcdClient.Close()
 				Expect(err).ShouldNot(HaveOccurred())
+				defer etcdClient.Close()
 				Expect(etcdClient).ShouldNot(BeNil())
 				Expect(etcdClient.Endpoints()).Should(Equal([]string{"http://default:2379"}))
 			})
@@ -345,8 +345,8 @@ var _ = Describe("EtcdUtil Tests", func() {
 				It("should use ServiceEndpoints", func() {
 					cfg.ServiceEndpoints = []string{"http://service:2379"}
 					etcdClient, err := etcdutil.GetTLSClientForEtcd(&cfg, &client.Options{UseServiceEndpoints: true})
-					defer etcdClient.Close()
 					Expect(err).ShouldNot(HaveOccurred())
+					defer etcdClient.Close()
 					Expect(etcdClient).ShouldNot(BeNil())
 					Expect(etcdClient.Endpoints()).Should(Equal([]string{"http://service:2379"}))
 				})
@@ -374,8 +374,8 @@ advertise-client-urls:
     - http://member-3:2379
 `)
 						tempFile, err := os.CreateTemp("", "etcd-config-*.yaml")
-						defer tempFile.Close()
 						Expect(err).ShouldNot(HaveOccurred())
+						defer tempFile.Close()
 						tempConfigFile = tempFile.Name()
 						_, err = tempFile.Write(configContent)
 						Expect(err).ShouldNot(HaveOccurred())
@@ -385,8 +385,8 @@ advertise-client-urls:
 
 						cfg.ServiceEndpoints = []string{}
 						etcdClient, err := etcdutil.GetTLSClientForEtcd(&cfg, &client.Options{UseServiceEndpoints: true})
-						defer etcdClient.Close()
 						Expect(err).ShouldNot(HaveOccurred())
+						defer etcdClient.Close()
 						Expect(etcdClient).ShouldNot(BeNil())
 						Expect(etcdClient.Endpoints()).Should(ConsistOf("http://member-1:2379", "http://member-2:2379", "http://member-3:2379"))
 					})

--- a/pkg/member/member_control_test.go
+++ b/pkg/member/member_control_test.go
@@ -54,10 +54,10 @@ quota-backend-bytes: 1073741824
 listen-client-urls: http://0.0.0.0:2379
 advertise-client-urls:
   ` + podName + `:
-    - http://0.0.0.0:2379
+    - http://` + etcd.Clients[0].Addr().String() + `
 initial-advertise-peer-urls:
   ` + podName + `:
-    - http://etcd-main-peer.default:2380
+    - http://` + etcd.Peers[0].Addr().String() + `
 initial-cluster: etcd1=http://0.0.0.0:2380
 initial-cluster-token: new
 initial-cluster-state: new

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -652,6 +652,26 @@ func GetMemberClientURLs(configFile string) ([]string, error) {
 	return clientURLs, nil
 }
 
+// GetAllMemberClientURLs retrieves the client URLs of all members.
+func GetAllMemberClientURLs(configFile string) ([]string, error) {
+	advURLsConfig, err := parseAdvertiseURLsConfig(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse advertise URLs config: %w", err)
+	}
+
+	clientURLs := []string{}
+	for _, urls := range advURLsConfig.AdvertiseClientURLs {
+		clientURLs = append(clientURLs, urls...)
+	}
+
+	for _, clientURL := range clientURLs {
+		if _, err := url.Parse(clientURL); err != nil {
+			return nil, fmt.Errorf("invalid client URL %s: %w", clientURL, err)
+		}
+	}
+	return clientURLs, nil
+}
+
 // IsPeerURLTLSEnabled checks whether all peer URLs are TLS-enabled (i.e., use the "https" scheme).
 func IsPeerURLTLSEnabled() (bool, error) {
 	memberPeerURLs, err := GetMemberPeerURLs(GetConfigFilePath())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/area high-availability
/kind enhancement
/kind api-change

**What this PR does / why we need it**:
If the "service-endpoints" field is not supplied, the endpoints used for creating the etcd client will be derived from the member IPs obtained from the config file as fallback. This is useful for cases where a single service endpoint is not available for the etcd cluster but the sidecar has to contact the etcd cluster anyways.

**Which issue(s) this PR fixes**:
Part of gardener/etcd-druid#1071

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
A fallback mechanism is introduced for contacting the etcd cluster when the `--service-endpoints` flag is not specified.
```
