### PR TITLE
export testresults as inlined ocm-resource

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,8 +70,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-
-          .ci/unit_test
+          mkdir -p /tmp/blobs.d
+          .ci/unit_test |& tee /tmp/blobs.d/test-results.txt
+          tar czf /tmp/blobs.d/test-results.tar.gz -C /tmp/blobs.d test-results.txt
+      - name: add-test-results-to-component-descriptor
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
+        with:
+          blobs-directory: /tmp/blobs.d
+          ocm-resources: |
+            name: test-results
+            relation: local
+            access:
+              type: localBlob
+              localReference: test-results.tar.gz
+            labels:
+              - name: gardener.cloud/purposes
+                value:
+                  - test
 
   # integration-test:
   # TODO: integration-tests will need substantial re-work (not a default testmachinery-test, but
@@ -83,5 +98,26 @@ jobs:
       contents: read
     with:
       linter: gosec
-      run: .ci/check
+      run: |
+        set -euo pipefail
+        mkdir -p /tmp/blobs.d
+        .ci/check
+        tar czf /tmp/blobs.d/gosec-report.tar.gz gosec-report.sarif
       go-version: '1.25'
+    steps:
+      - name: add-gosec-report-to-component-descriptor
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
+        with:
+          blobs-directory: /tmp/blobs.d
+          ocm-resources: |
+            name: gosec-report
+            relation: local
+            access:
+              type: localBlob
+              localReference: gosec-report.tar.gz
+            labels:
+              - name: gardener.cloud/purposes
+                value:
+                  - lint
+                  - sast
+                  - gosec


### PR DESCRIPTION
export testresults as inlined ocm-resource

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area compliance
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
export testresults as inlined ocm-resource
```
