### PR TITLE
Fix linter errors.

### DIFF
--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -246,8 +246,8 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 						b.logger.Fatalf("failed to create snapshot backup copier: %v", err)
 					}
 
-					cp := copier.NewCopier(b.logger, ss, secondary, -1, -1, 10, false, 0)
-					if err := cp.SyncBackups(ctx, b.config.SecondarySnapstoreConfig.SyncPeriod.Duration); err != nil {
+					cp = copier.NewCopier(b.logger, ss, secondary, -1, -1, 10, false, 0)
+					if err := cp.SyncBackups(leCtx, b.config.SecondarySnapstoreConfig.SyncPeriod.Duration); err != nil {
 						b.logger.Fatalf("failed to sync backups: %v", err)
 					}
 					go backupssr.RunGarbageCollector(backupGcStop)
@@ -274,10 +274,6 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 		OnStoppedLeading: func() {
 			if runServerWithSnapshotter {
 				b.logger.Info("backup-restore stops leading...")
-				if cp != nil {
-					b.logger.Infof("Stopping backup copier.")
-					cp.Stop()
-				}
 				close(backupGcStop)
 				handler.SetSnapshotterToNil()
 

--- a/pkg/snapstore/init.go
+++ b/pkg/snapstore/init.go
@@ -18,6 +18,7 @@ func NewSnapstoreConfig() *brtypes.SnapstoreConfig {
 	}
 }
 
+// NewSecondarySnapstoreConfig returns the secondary-snapstore config.
 func NewSecondarySnapstoreConfig() *brtypes.SecondarySnapstoreConfig {
 	return &brtypes.SecondarySnapstoreConfig{
 		StoreConfig:       NewSnapstoreConfig(),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes linting errors:
```
> Format
2025/12/18 23:35:55 Paths: [./cmd/]
2025/12/18 23:35:55 Processing ./cmd/
2025/12/18 23:36:00 Paths: [./pkg/]
2025/12/18 23:36:00 Processing ./pkg/
2025/12/18 23:36:51 Paths: [./test/]
2025/12/18 23:36:51 Processing ./test/
> Check
Executing golangci-lint
Executing gofmt/goimports
Checking Helm charts linting
==> Linting ./chart/etcd-backup-restore
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
Checking Go version
All checks successful
```

- Also pass the correct context to `SyncBackups` func , so that it will get close if leadership changes.

**Which issue(s) this PR fixes**:
Fixes #955 

**Special notes for your reviewer**:

**Release note**:

```other operator
None
```
