### PR TITLE
Change GHA trigger to `pull_request`

### DIFF
--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -1,7 +1,7 @@
 name: Build
 on:
   push:
-  pull_request_target:
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area open-source testing
/kind bug

**What this PR does / why we need it**:

We can avoid the caveats that come with the `pull_request_target` trigger like requiring an additional checkout to the PR branch as part of the workflow, requiring an `reviewed/ok-to-test` label for the PR branch to be checked out by the `trusted-checkout` step, etc.

The `pull_request_target` trigger is required only for specific cases where the PRs from forked repositories need to run the workflow with write privileges. This is not the case for the `etcd-backup-restore` repository.

Ref: https://gardener.github.io/cc-utils/github_actions.html#pull-requests-from-forked-repositories

**Special notes for your reviewer**:

The MCM repo has a [similar configuration for non-release workflows](https://github.com/gardener/machine-controller-manager/blob/master/.github/workflows/non-release.yaml) and seems to work fine even for PRs contributed by external contributors: https://github.com/gardener/machine-controller-manager/pull/1062/checks

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
