### PR TITLE
Add environment variable support for storage-provider and store-prefix

### DIFF
--- a/pkg/types/snapstore.go
+++ b/pkg/types/snapstore.go
@@ -7,6 +7,7 @@ package types
 import (
 	"fmt"
 	"io"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -241,6 +242,23 @@ func (c *SnapstoreConfig) Validate() error {
 
 // Complete completes the config.
 func (c *SnapstoreConfig) Complete() {
+	// Build environment variable names based on prefix
+	envPrefix := c.EnvPrefix
+	providerEnvVar := envPrefix + "STORAGE_PROVIDER"
+	prefixEnvVar := envPrefix + "STORE_PREFIX"
+
+	// Apply environment variables if flags are not set
+	if c.Provider == "" {
+		if envProvider := os.Getenv(providerEnvVar); envProvider != "" {
+			c.Provider = envProvider
+		}
+	}
+	if c.Prefix == "" {
+		if envStorePrefix := os.Getenv(prefixEnvVar); envStorePrefix != "" {
+			c.Prefix = envStorePrefix
+		}
+	}
+
 	c.Prefix = path.Join(c.Prefix, backupFormatVersion)
 
 	if c.TempDir == "" {


### PR DESCRIPTION
Support configuring storage provider and store prefix via environment variables as an alternative to command-line flags. This allows for more flexible configuration management in containerized environments.

Environment variables:
- STORAGE_PROVIDER: equivalent to --storage-provider flag
- STORE_PREFIX: equivalent to --store-prefix flag
- SECONDARY_STORAGE_PROVIDER: for secondary snapstore (--secondary-storage-provider)
- SECONDARY_STORE_PREFIX: for secondary snapstore (--secondary-store-prefix)

The environment variables are only used when the corresponding flags are not provided, ensuring backwards compatibility and allowing flags to override environment variables.

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
NONE
```other operator

```
