### PR TITLE
Upgrade to go 1.25.x

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.25.3 AS builder
+FROM golang:1.25.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/backup-restore
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/etcd-backup-restore
 
-go 1.24.0
+go 1.25.0
 
 require (
 	cloud.google.com/go/iam v1.5.0


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR : 
- Upgrade to Go 1.25.5 in Dockerfile.
- Upgrade Go module to 1.25.0 .

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Fixes the vulnerability.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Upgrade to go 1.25.0
```
