### PR TITLE
Introduce `.dockerignore`.

### DIFF
--- a/build/.dockerignore
+++ b/build/.dockerignore
@@ -1,0 +1,19 @@
+# Ignore everything
+**
+
+# Exclude folders relevant for build
+!.git
+!.dockerignore
+!chart/
+!pkg/
+!cmd/
+!main.go
+!test/
+!vendor/
+!.golangci.yaml
+!go.mod
+!go.sum
+!LICENSE
+!Makefile
+!VERSION
+!hack/tools.mk


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Introduce `.dockerignore`, which specifies what files must be copied into the docker layers during local docker image builds.

For example, the `.dockerignore` will avoid copying the `hack` directory which contains a lot of development tools that need not be copied into the docker layers at build.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Introduce `build/.dockerignore` to reduce the time take in the `COPY` phase during a local docker build on a developer's machine.
```
