### PR TITLE
Disable fsync in the embedded etcd

### DIFF
--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -235,6 +235,7 @@ func StartEmbeddedEtcd(logger *logrus.Entry, ro *brtypes.RestoreOptions) (*Embed
 	cfg.MaxTxnOps = ro.Config.MaxTxnOps
 	cfg.AutoCompactionMode = ro.Config.AutoCompactionMode
 	cfg.AutoCompactionRetention = ro.Config.AutoCompactionRetention
+	cfg.UnsafeNoFsync = true
 	cfg.Logger = "zap"
 	e, err := embed.StartEtcd(cfg)
 	if err != nil {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -73,6 +73,7 @@ func StartEmbeddedEtcd(ctx context.Context, etcdDir string, logger *logrus.Entry
 	cfg.AdvertisePeerUrls = []url.URL{*apurl}
 	cfg.AdvertiseClientUrls = []url.URL{*acurl}
 	cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name)
+	cfg.UnsafeNoFsync = true
 	cfg.Logger = "zap"
 	cfg.AutoCompactionMode = "periodic"
 	cfg.AutoCompactionRetention = "0"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area performance
/kind enhancement

**What this PR does / why we need it**:

This PR ~~adds the `--unsafe-no-fsync` flag to~~ disables fsync in the embedded etcd which is used for applying delta snapshots.

The goal is to drastically reduce the time needed to restore a backup with heavy delta snapshots. Despite the `unsafe` prefix in the flag, there should be no data loss when the `etcdbrctl` command ends without error. 

Here are my measures:

Backup files:

|Name|Size|
|---|---|
|Full-00000000-8391520845-1763683200|344M|
|Incr-8391520846-8391652657-1763684913|232M|

Time to restore:
|`--unsafe-no-fsync`|Duration|
|---|---|
|false|2m24.394s|
|true|0m22.227s|

Logs (some lines were stripped for better readability):

```console
$ time etcdbrctl restore --storage-provider=Local --store-container=path/to/backup
INFO[0000] Finding latest set of snapshot to recover from... 
INFO[0000] Creating temporary directory default.restoration.tmp for persisting full and delta snapshots locally.  actor=restorer
INFO[0000] Restoring from base snapshot: Full-00000000-8391520845-1763683200  actor=restorer
INFO[0000] Fetched the snapshot from the object store in 0.361176521 seconds  actor=restorer
INFO[0000] Successfully fetched and saved data of the base snapshot in 0.361176521 seconds  actor=restorer
INFO[0000] Successfully restored from base snapshot: Full-00000000-8391520845-1763683200  actor=restorer
INFO[0000] Attempting to apply 1 delta snapshots for restoration.  actor=restorer
INFO[0000] Starting an embedded etcd server...           actor=restorer
INFO[0001] Embedded server is ready to listen client at: 127.0.0.1:39021  actor=restorer
INFO[0001] Applying delta snapshots...                   actor=restorer
INFO[0001] Applying first delta snapshot Incr-8391520846-8391652657-1763684913  actor=restorer
INFO[0002] successfully read the data of delta snapshot in 0.451580816 seconds  actor=restorer
INFO[0003] Applying first delta snapshot Incr-8391520846-8391652657-1763684913  actor=restorer
INFO[0144] Successfully restored the etcd data directory. 

real	2m24.394s
user	0m40.313s
sys	0m29.337s
```

```console
$ time etcdbrctl restore --storage-provider=Local --store-container=path/to/backup --unsafe-no-fsync
INFO[0000] Finding latest set of snapshot to recover from... 
INFO[0000] Creating temporary directory default.restoration.tmp for persisting full and delta snapshots locally.  actor=restorer
INFO[0000] Restoring from base snapshot: Full-00000000-8391520845-1763683200  actor=restorer
INFO[0000] Fetched the snapshot from the object store in 0.08836313 seconds  actor=restorer
INFO[0000] Successfully fetched and saved data of the base snapshot in 0.08836313 seconds  actor=restorer
INFO[0000] Successfully restored from base snapshot: Full-00000000-8391520845-1763683200  actor=restorer
INFO[0000] Attempting to apply 1 delta snapshots for restoration.  actor=restorer
INFO[0000] Starting an embedded etcd server...           actor=restorer
INFO[0001] Embedded server is ready to listen client at: 127.0.0.1:33309  actor=restorer
INFO[0001] Applying delta snapshots...                   actor=restorer
INFO[0001] Applying first delta snapshot Incr-8391520846-8391652657-1763684913  actor=restorer
INFO[0002] successfully read the data of delta snapshot in 0.261979689 seconds  actor=restorer
INFO[0003] Applying first delta snapshot Incr-8391520846-8391652657-1763684913  actor=restorer
INFO[0022] Successfully restored the etcd data directory. 

real	0m22.227s
user	0m26.358s
sys	0m13.448s
```

**Special notes for your reviewer**:

~~It's currently disabled by default, should we consider enabling this by default in the future?~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Disable fsync in the embedded etcd during restoration to reduce restoration time.
```
