### PR TITLE
Remove deprecated support for passing endpoint via credential secrets

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
@@ -21,30 +21,15 @@ data:
   {{- if .Values.backup.s3.s3ForcePathStyle }}
   s3ForcePathStyle: {{ .Values.backup.s3.s3ForcePathStyle | b64enc}}
   {{- end }}
-  {{- if .Values.backup.s3.endpoint }}
-  endpoint: {{ .Values.backup.s3.endpoint | b64enc }}
-  {{- end }}
 {{- else if eq .Values.backup.storageProvider "ABS" }}
   storageAccount: {{ .Values.backup.abs.storageAccount | b64enc }}
   storageKey : {{ .Values.backup.abs.storageKey | b64enc }}
-  {{- if .Values.backup.abs.emulatorEnabled }}
-  emulatorEnabled: {{ .Values.backup.abs.emulatorEnabled | b64enc}}
-  {{- end }}
-  {{- if .Values.backup.abs.domain }}
-  domain: {{ .Values.backup.abs.domain | b64enc}}
-  {{- end }}
 {{- else if eq .Values.backup.storageProvider "GCS" }}
   {{- if .Values.backup.tokenAuth.enabled }}
   credentialsConfig: {{ include "gcs.credentialsConfig" . | fromYaml | toJson | b64enc }}
   projectID: {{ .Values.backup.gcs.projectID }}
   {{- else }}
   serviceaccount.json : {{ .Values.backup.gcs.serviceAccountJson | b64enc }}
-  {{- end }}
-  {{- if .Values.backup.gcs.storageAPIEndpoint }}
-  storageAPIEndpoint: {{ .Values.backup.gcs.storageAPIEndpoint | b64enc}}
-  {{- end }}
-  {{- if .Values.backup.gcs.emulatorEnabled }}
-  emulatorEnabled: {{ .Values.backup.gcs.emulatorEnabled | b64enc}}
   {{- end }}
 {{- else if eq .Values.backup.storageProvider "Swift" }}
   authURL: {{ .Values.backup.swift.authURL | b64enc }}

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -211,14 +211,6 @@ spec:
   {{- if eq .Values.backup.storageProvider "S3" }}
         - name: "AWS_APPLICATION_CREDENTIALS"
           value: "/var/etcd-backup"
-    {{- if .Values.backup.s3.endpoint }}
-        - name: "AWS_ENDPOINT_URL_S3"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-etcd-backup
-              key: "endpoint"
-              optional: true
-    {{- end }}
   {{- else if eq .Values.backup.storageProvider "ABS" }}
         - name: "AZURE_APPLICATION_CREDENTIALS"
           value: "/var/etcd-backup"

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -107,7 +107,6 @@ backup:
   #   region: region-where-bucket-exists
   #   secretAccessKey: secret-access-key-with-object-storage-privileges
   #   accessKeyID: access-key-id-with-route53-privileges
-  #   endpoint: endpoint-override-for-s3 # optional
   #   s3ForcePathStyle: "true" # optional
   #   sseCustomerKey: aes-256-sse-customer-key # optional
   #   sseCustomerAlgorithm: aes-256-sse-customer-algorithm # optional
@@ -122,13 +121,9 @@ backup:
   #     token_url: "https://sts.googleapis.com/v1/token"
   #     service_account_impersonation_url: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/<service_account_email>:generateAccessToken" # optional
   #   projectID: project
-  #   storageAPIEndpoint: endpoint-override-for-storage-api # optional
-  #   emulatorEnabled: boolean-flag-to-configure-etcdbr-to-use-gcs-emulator # optional
   # abs:
   #   storageAccount: storage-account-with-object-storage-privileges
   #   storageKey: storage-key-with-object-storage-privileges
-  #   domain: non-default-domain-for-object-storage-service # optional
-  #   emulatorEnabled: boolean-float-to-enable-e2e-tests-to-use-azure-emulator # optional
   # swift:
   #   authURL: identity-server-url
   #   domainName: domain-name

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -50,7 +50,7 @@ const (
 type awsCredentials struct {
 	SSECustomerAlgorithm       *string `json:"sseCustomerAlgorithm,omitempty"`
 	SSECustomerKey             *string `json:"sseCustomerKey,omitempty"`
-	Endpoint                   *string `json:"endpoint,omitempty"`
+
 	S3ForcePathStyle           *bool   `json:"s3ForcePathStyle,omitempty"`
 	InsecureSkipVerify         *bool   `json:"insecureSkipVerify,omitempty"`
 	TrustedCaCert              *string `json:"trustedCaCert,omitempty"`
@@ -210,12 +210,6 @@ func awsCredentialsFromConfig(awsConfig *awsCredentials) ([]func(*awsconfig.Load
 	}
 	cfgOpts = append(cfgOpts, awsconfig.WithCredentialsProvider(aws.NewCredentialsCache(credentialsProvider)))
 
-	// TODO: @renormalize support for passing Endpoint through the credential file must be removed in v0.42.0.
-	if awsConfig.Endpoint != nil {
-		logrus.Warnf("Passing endpoint override through the credential file is now deprecated. Please use the `--store-endpoint-override` flag instead.")
-		cfgOpts = append(cfgOpts, awsconfig.WithBaseEndpoint(*awsConfig.Endpoint))
-	}
-
 	if awsConfig.S3ForcePathStyle != nil {
 		cliOpts = append(cliOpts, func(o *s3.Options) {
 			o.UsePathStyle = *awsConfig.S3ForcePathStyle
@@ -298,12 +292,6 @@ func readAWSCredentialFromDir(dirname string) (*awsCredentials, error) {
 				return nil, err
 			}
 			awsConfig.SecretAccessKey = string(data)
-		case "endpoint":
-			data, err := os.ReadFile(filepath.Join(dirname, "endpoint")) // #nosec G304 -- this is a trusted file, obtained via user input.
-			if err != nil {
-				return nil, err
-			}
-			awsConfig.Endpoint = ptr.To(string(data))
 		case "s3ForcePathStyle":
 			data, err := os.ReadFile(filepath.Join(dirname, "s3ForcePathStyle")) // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area storage
/kind cleanup

**What this PR does / why we need it**:

Prior to this change, storage endpoint configuration could be passed through credential secrets (endpoint for S3, domain for Azure, storageAPIEndpoint for GCS). This was deprecated in PR #952  which introduced the `--store-endpoint-override` CLI flag as the recommended approach.

This PR removes the backward compatibility code that was kept for migration purposes:

- S3: Remove `Endpoint` field from `awsCredentials` struct and related handling in `awsCredentialsFromConfig()` and `readAWSCredentialFromDir()`
- Azure: Remove `Domain` field from `absCredentials` struct and related handling in `NewABSSnapStore()` and `readABSCredentialFiles()`
- GCS: Remove `fileNameStorageAPIEndpoint` constant and `getGCSStorageAPIEndpointFromFile()` function
- Chart: Remove deprecated fields from secret template and values.yaml (endpoint, domain, storageAPIEndpoint, emulatorEnabled)

Users must now use the `--store-endpoint-override` flag for custom endpoints (emulators, regional endpoints, S3-compatible providers).

**Which issue(s) this PR fixes**:
Fixes #970 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
BREAKING: Removed deprecated support for passing storage endpoint via credential secrets for AWS, GCP & Azure. Users must now use the [--store-endpoint-override](https://github.com/gardener/etcd-backup-restore/blob/36243e6fca29ac92342cd5ce92f67462b6e57c06/docs/deployment/getting_started.md?plain=1#L21) flag for custom endpoints (emulators, S3-compatible providers, regional endpoints). The following credential secret fields are no longer supported: `endpoint` (S3), `domain`/`emulatorEnabled` (Azure), `storageAPIEndpoint`/`emulatorEnabled` (GCS).
```
