### PR TITLE
Fix `make verify` so that it calls the `test-unit` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ update-dependencies:
 	@make revendor
 
 .PHONY: verify
-verify: check test
+verify: check test-unit
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind regression

**What this PR does / why we need it**:
This PR fixes the `make verify` target so that it calls `test-unit` instead of `test` which no-longer exists.
I did not see this target being used in any scripts, however it is mentioned in the documentation:
https://github.com/gardener/etcd-backup-restore/blob/6dd3c2d45bb0f63085e5bc1ea48c08537ed97fc1/docs/development/testing_and_dependencies.md?plain=1#L24-L32
and
https://github.com/gardener/etcd-backup-restore/blob/36243e6fca29ac92342cd5ce92f67462b6e57c06/docs/development/new_cp_support.md?plain=1#L20
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @renormalize 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The `make verify` target was fixed so that it properly executes unit tests.
```
