### PR TITLE
Added one small check in GetNLatestFullSnapshots.

### DIFF
--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -78,6 +78,9 @@ func GetNLatestFullSnapshots(store brtypes.SnapStore, n int) (brtypes.SnapList, 
 
 	var fullSnapshotList brtypes.SnapList
 	for index := len(snapList); index > 0 && len(fullSnapshotList) < n; index-- {
+		if snapList[index-1].IsChunk {
+			continue
+		}
 		if snapList[index-1].Kind == brtypes.SnapshotKindFull {
 			fullSnapshotList = append(fullSnapshotList, snapList[index-1])
 		}


### PR DESCRIPTION

**What this PR does / why we need it**:
Added one small check in function `GetNLatestFullSnapshots`, I forgot to add this as review comment in this PR: https://github.com/gardener/etcd-backup-restore/pull/1001

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
