### PR TITLE
[hotfix-v0.41] Migrate LocalStack e2e tests to licensed image

### DIFF
--- a/docs/development/tests.md
+++ b/docs/development/tests.md
@@ -48,6 +48,12 @@ Currently, the tests can be run using the following cloud providers:
 
 #### Running the e2e tests with the emulators
 
+> **_NOTE:_** Running the AWS e2e tests requires a `LOCALSTACK_AUTH_TOKEN` environment variable to be set.
+> The project has a [LocalStack for Open Source](https://localstack.cloud/open-source) license. Ask a
+> maintainer for the token, or apply for your own. Alternatively, the frozen community archive image
+> `localstack/localstack:s3-community-archive` can be used without a token, but it will not receive
+> updates or security patches.
+
 ##### On a Kind Cluster
 
 To run the e2e tests with the emulators, run the following command:

--- a/hack/deploy-localstack.sh
+++ b/hack/deploy-localstack.sh
@@ -7,8 +7,31 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ -z "${LOCALSTACK_AUTH_TOKEN:-}" ]]; then
+  printf '%s\n' "Error: LOCALSTACK_AUTH_TOKEN is not set. Get a token from https://app.localstack.cloud." >&2
+  exit 1
+fi
+
+kubectl --kubeconfig=${KUBECONFIG} create secret generic localstack-auth \
+  --from-literal=auth-token="${LOCALSTACK_AUTH_TOKEN}" \
+  --dry-run=client -o yaml | kubectl --kubeconfig=${KUBECONFIG} apply -f -
+
 KUBECONFIG=$1
 
 kubectl --kubeconfig=${KUBECONFIG} apply -f ./hack/e2e-test/infrastructure/localstack/localstack.yaml
 kubectl --kubeconfig=${KUBECONFIG} rollout status deploy/localstack
 kubectl --kubeconfig=${KUBECONFIG} wait --for=condition=ready pod -l app=localstack --timeout=240s
+
+# Wait for LocalStack to be reachable from the host via the kind node port mapping.
+# The pod may be ready before the hostPort is actually forwarded.
+printf '%s' "Waiting for LocalStack to be reachable on localhost:4566"
+for i in $(seq 1 60); do
+  if curl -sf http://localhost:4566/_localstack/health > /dev/null 2>&1; then
+    printf '\n%s\n' "LocalStack is ready."
+    exit 0
+  fi
+  printf '%s' "."
+  sleep 2
+done
+printf '\n%s\n' "Error: LocalStack did not become reachable on localhost:4566 within 120s." >&2
+exit 1

--- a/hack/e2e-test/infrastructure/localstack/localstack.yaml
+++ b/hack/e2e-test/infrastructure/localstack/localstack.yaml
@@ -24,7 +24,12 @@ spec:
               value: "1"
             - name: SERVICES
               value: s3
-          image: localstack/localstack:s3-latest
+            - name: LOCALSTACK_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: localstack-auth
+                  key: auth-token
+          image: localstack/localstack:stable
           imagePullPolicy: IfNotPresent
           name: localstack-service
           ports:


### PR DESCRIPTION
**What this PR does / why we need it**:
Back-porting this PR: https://github.com/gardener/etcd-backup-restore/pull/1014 as automated cherry-pick failed

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
Migrate e2e tests from archived LocalStack community image to licensed `localstack/localstack:stable`. Running AWS e2e tests now requires a `LOCALSTACK_AUTH_TOKEN` environment variable.
```
