### PR TITLE
fix(metrics): correct 'occured' -> 'occurred' in LabelError comment

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -26,7 +26,7 @@ const (
 	ValueRestoreSingleNode = "single_node"
 	// LabelKind is a metrics label indicates kind of snapshot associated with metric.
 	LabelKind = "kind"
-	// LabelError is a metric error to indicate error occured.
+	// LabelError is a metric error to indicate error occurred.
 	LabelError = "error"
 	// LabelRestorationKind metric label indicates kind of restoration associated with metric.
 	LabelRestorationKind = "restore"


### PR DESCRIPTION
The doc comment on `LabelError` in `pkg/metrics/metrics.go:29` used `error to indicate error occured`. Doc-only Go change inside a `//` comment.