### PR TITLE
Adapt `etcd-backup-restore` to support `member-name-prefix` for etcd cluster members

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-configmap.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-configmap.yaml
@@ -18,10 +18,17 @@ data:
     {{- end }}
     # store the root context for later use
     {{- $root := . }}
+    # store the optional member name prefix
+    {{- $memberNamePrefix := .Values.memberNamePrefix | default "" }}
     # store the cluster entries in a list to be used for the initial-cluster configuration
     {{- $clusterEntries := list }}
     {{- range $i := until $replicas }}
-    {{- $entry := printf "%s-etcd-%d=%s://%s-etcd-%d.%s-etcd-peer.%s.svc:%d" $root.Release.Name $i $peerScheme $root.Release.Name $i $root.Release.Name $root.Release.Namespace (int $root.Values.servicePorts.etcd.peer) }}
+    {{- $podName := printf "%s-etcd-%d" $root.Release.Name $i }}
+    {{- $memberName := $podName }}
+    {{- if $memberNamePrefix }}
+    {{- $memberName = printf "%s-%s" $memberNamePrefix $podName }}
+    {{- end }}
+    {{- $entry := printf "%s=%s://%s-etcd-%d.%s-etcd-peer.%s.svc:%d" $memberName $peerScheme $root.Release.Name $i $root.Release.Name $root.Release.Namespace (int $root.Values.servicePorts.etcd.peer) }}
     {{- $clusterEntries = append $clusterEntries $entry }}
     {{- end }}
 
@@ -53,7 +60,12 @@ data:
     # Each member should include it's client URLs under the member name.
     advertise-client-urls:
       {{- range $i := until $replicas }}
-      {{ $root.Release.Name }}-etcd-{{ $i }}:
+      {{- $podName := printf "%s-etcd-%d" $root.Release.Name $i }}
+      {{- $memberName := $podName }}
+      {{- if $memberNamePrefix }}
+      {{- $memberName = printf "%s-%s" $memberNamePrefix $podName }}
+      {{- end }}
+      {{ $memberName }}:
       - {{ if $root.Values.tls.etcd }}https{{ else }}http{{ end }}://{{ $root.Release.Name }}-etcd-{{ $i }}.{{ $root.Release.Name }}-etcd-peer.{{ $root.Release.Namespace }}.svc:{{ $root.Values.servicePorts.etcd.client }}
       {{- end }}
 
@@ -61,7 +73,12 @@ data:
     # Each member should include it's peer URLs under the member name.
     initial-advertise-peer-urls:
       {{- range $i := until $replicas }}
-      {{ $root.Release.Name }}-etcd-{{ $i }}:
+      {{- $podName := printf "%s-etcd-%d" $root.Release.Name $i }}
+      {{- $memberName := $podName }}
+      {{- if $memberNamePrefix }}
+      {{- $memberName = printf "%s-%s" $memberNamePrefix $podName }}
+      {{- end }}
+      {{ $memberName }}:
       - {{ $peerScheme }}://{{ $root.Release.Name }}-etcd-{{ $i }}.{{ $root.Release.Name }}-etcd-peer.{{ $root.Release.Namespace }}.svc:{{ $root.Values.servicePorts.etcd.peer }}
       {{- end }}
 
@@ -84,6 +101,11 @@ data:
     {{- if .Values.autoCompaction.retentionLength }}
     auto-compaction-retention: {{ .Values.autoCompaction.retentionLength }}
     {{- end }}
+    {{- end }}
+
+    {{- if $memberNamePrefix }}
+    # Optional prefix prepended to the pod name to form the etcd member name.
+    member-name-prefix: {{ $memberNamePrefix }}
     {{- end }}
 
 {{- if .Values.tls.etcd }}

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -51,6 +51,10 @@ autoCompaction:
 
 replicas: 1
 
+# memberNamePrefix is an optional prefix prepended to the pod name to form the etcd member name.
+# When set, the member name becomes "<memberNamePrefix>-<pod-name>".
+memberNamePrefix: ""
+
 backup:
   # schedule is cron standard schedule to take full snapshots.
   schedule: "0 */1 * * *"

--- a/example/01-etcd-config.yaml
+++ b/example/01-etcd-config.yaml
@@ -19,3 +19,6 @@ initial-cluster-token: new
 initial-cluster-state: new
 auto-compaction-mode: periodic
 auto-compaction-retention: 30m
+# Optional: prefix to prepend to the pod name to form the etcd member name.
+# When set, the member name becomes "<member-name-prefix>-<pod-name>".
+# member-name-prefix: ""

--- a/pkg/health/heartbeat/heartbeat.go
+++ b/pkg/health/heartbeat/heartbeat.go
@@ -37,7 +37,7 @@ type Heartbeat struct {
 	heartbeatTimer *time.Timer
 	etcdConfig     *brtypes.EtcdConnectionConfig
 	metadata       map[string]string // metadata is currently added as annotations to the k8s lease object
-	podName        string
+	memberName     string
 	podNamespace   string
 }
 
@@ -61,11 +61,19 @@ func NewHeartbeat(logger *logrus.Entry, etcdConfig *brtypes.EtcdConnectionConfig
 	if err != nil {
 		logger.Fatalf("POD_NAMESPACE env var not present: %v", err)
 	}
+
+	configFile := miscellaneous.GetConfigFilePath()
+	prefix, err := miscellaneous.GetMemberNamePrefix(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read member name prefix: %w", err)
+	}
+	memberName = miscellaneous.ComputeMemberName(prefix, memberName)
+
 	return &Heartbeat{
 		logger:       logger.WithField("actor", "heartbeat"),
 		etcdConfig:   etcdConfig,
 		k8sClient:    clientSet,
-		podName:      memberName,
+		memberName:   memberName,
 		podNamespace: namespace,
 		metadata:     metadata,
 	}, nil
@@ -86,7 +94,7 @@ func (hb *Heartbeat) RenewMemberLease(ctx context.Context) error {
 	memberLease := &v1.Lease{}
 	err := hb.k8sClient.Get(ctx, client.ObjectKey{
 		Namespace: hb.podNamespace,
-		Name:      hb.podName,
+		Name:      hb.memberName,
 	}, memberLease)
 	if err != nil {
 		return &errors.EtcdError{

--- a/pkg/health/heartbeat/heartbeat_test.go
+++ b/pkg/health/heartbeat/heartbeat_test.go
@@ -29,13 +29,29 @@ var _ = Describe("Heartbeat", func() {
 	var (
 		etcdConnectionConfig *brtypes.EtcdConnectionConfig
 		metadata             map[string]string
+		memberNamePrefix     string
 	)
 
 	BeforeEach(func() {
+		memberNamePrefix = ""
 		etcdConnectionConfig = brtypes.NewEtcdConnectionConfig()
 		etcdConnectionConfig.Endpoints = []string{etcd.Clients[0].Addr().String()}
 		etcdConnectionConfig.ConnectionTimeout.Duration = 5 * time.Second
 		metadata = map[string]string{}
+	})
+
+	JustBeforeEach(func() {
+		prefixLine := ""
+		if memberNamePrefix != "" {
+			prefixLine = "\nmember-name-prefix: " + memberNamePrefix
+		}
+		outfile := "/tmp/etcd-heartbeat.conf.yaml"
+		Expect(os.WriteFile(outfile, []byte("name: etcd-test"+prefixLine), 0600)).To(Succeed())
+		Expect(os.Setenv("ETCD_CONF", outfile)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		_ = os.Unsetenv("ETCD_CONF")
 	})
 
 	Describe("creating Heartbeat", func() {
@@ -358,6 +374,34 @@ var _ = Describe("Heartbeat", func() {
 
 				err = heartbeat.RenewMemberLease(context.TODO())
 				Expect(err).Should(HaveOccurred())
+			})
+		})
+		Context("With member-name-prefix set in config", func() {
+			BeforeEach(func() {
+				memberNamePrefix = "myprefix"
+				Expect(os.Setenv("POD_NAME", "test_pod")).To(Succeed())
+				Expect(os.Setenv("POD_NAMESPACE", "test_namespace")).To(Succeed())
+				metadata = map[string]string{heartbeat.PeerURLTLSEnabledKey: "true"}
+			})
+			AfterEach(func() {
+				Expect(os.Unsetenv("POD_NAME")).To(Succeed())
+				Expect(os.Unsetenv("POD_NAMESPACE")).To(Succeed())
+			})
+			It("should use the prefixed member name to renew the member lease", func() {
+				clientSet := miscellaneous.GetFakeKubernetesClientSet()
+				hb, err := heartbeat.NewHeartbeat(logger, etcdConnectionConfig, clientSet, metadata)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				prefixedLease := &v1.Lease{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myprefix-test_pod",
+						Namespace: "test_namespace",
+					},
+				}
+				Expect(clientSet.Create(context.TODO(), prefixedLease)).To(Succeed())
+
+				err = hb.RenewMemberLease(context.TODO())
+				Expect(err).ShouldNot(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -80,6 +80,7 @@ type memberControl struct {
 	clientFactory etcdClient.Factory
 	logger        logrus.Entry
 	podName       string
+	memberName    string
 	configFile    string
 	podNamespace  string
 }
@@ -105,10 +106,16 @@ func NewMemberControl(etcdConnConfig *brtypes.EtcdConnectionConfig) Control {
 	//TODO: Refactor needed
 	configFile = miscellaneous.GetConfigFilePath()
 
+	memberNamePrefix, err := miscellaneous.GetMemberNamePrefix(configFile)
+	if err != nil {
+		logger.Fatalf("failed to read member name prefix: %v", err)
+	}
+	memberName := miscellaneous.ComputeMemberName(memberNamePrefix, podName)
+
 	return &memberControl{
 		clientFactory: clientFactory,
 		logger:        *logger,
-		podName:       podName,
+		memberName:    memberName,
 		configFile:    configFile,
 		podNamespace:  podNamespace,
 	}
@@ -134,10 +141,10 @@ func (m *memberControl) AddMemberAsLearner(ctx context.Context) error {
 	response, err := cli.MemberAddAsLearner(memAddCtx, memberPeerURLs)
 	if err != nil {
 		if errors.Is(err, rpctypes.Error(rpctypes.ErrGRPCPeerURLExist)) || errors.Is(err, rpctypes.Error(rpctypes.ErrGRPCMemberExist)) {
-			m.logger.Infof("Member %s with peer urls %v already part of etcd cluster", m.podName, memberPeerURLs)
+			m.logger.Infof("Member %s with peer urls %v already part of etcd cluster", m.memberName, memberPeerURLs)
 			return nil
 		} else if errors.Is(err, rpctypes.Error(rpctypes.ErrGRPCTooManyLearners)) {
-			m.logger.Infof("Unable to add member %s as a learner because the cluster already has a learner", m.podName)
+			m.logger.Infof("Unable to add member %s as a learner because the cluster already has a learner", m.memberName)
 			return rpctypes.Error(rpctypes.ErrGRPCTooManyLearners)
 		}
 		metrics.IsLearnerCountTotal.With(prometheus.Labels{metrics.LabelSucceeded: metrics.ValueSucceededFalse}).Inc()
@@ -154,7 +161,7 @@ func (m *memberControl) AddMemberAsLearner(ctx context.Context) error {
 
 // IsMemberInCluster checks is the current members peer URL is already part of the etcd cluster
 func (m *memberControl) IsMemberInCluster(_ context.Context) (_ bool, err error) {
-	m.logger.Infof("Checking if member %s is part of a running cluster", m.podName)
+	m.logger.Infof("Checking if member %s is part of a running cluster", m.memberName)
 	// Check if an etcd is already available
 
 	backoff := miscellaneous.CreateBackoff(RetryPeriod, RetrySteps)
@@ -191,21 +198,21 @@ func (m *memberControl) IsMemberInCluster(_ context.Context) (_ bool, err error)
 	}
 
 	for _, member := range etcdMemberList.Members {
-		if member.GetName() == m.podName {
-			m.logger.Infof("Member %s part of running cluster", m.podName)
+		if member.GetName() == m.memberName {
+			m.logger.Infof("Member %s part of running cluster", m.memberName)
 			return true, nil
 		}
 	}
 
-	m.logger.Infof("Member %v not part of any running cluster", m.podName)
-	m.logger.Infof("Could not find member %v in the list", m.podName)
+	m.logger.Infof("Member %v not part of any running cluster", m.memberName)
+	m.logger.Infof("Could not find member %v in the list", m.memberName)
 	return false, nil
 }
 
 // doUpdateMemberPeerAddress updated the peer address of a specified etcd member
 func (m *memberControl) doUpdateMemberPeerAddress(ctx context.Context, cli etcdClient.ClusterCloser, id uint64) error {
 	// Already existing clusters or cluster after restoration have `http://localhost:2380` as the peer address. This needs to explicitly updated to the correct peer address.
-	m.logger.Infof("Updating member peer URL for %s", m.podName)
+	m.logger.Infof("Updating member peer URL for %s", m.memberName)
 	memberPeerURLs, err := miscellaneous.GetMemberPeerURLs(m.configFile)
 	if err != nil {
 		return fmt.Errorf("could not fetch member URL : %v", err)
@@ -223,7 +230,7 @@ func (m *memberControl) doUpdateMemberPeerAddress(ctx context.Context, cli etcdC
 
 // PromoteMember promotes an etcd member from a learner to a voting member of the cluster. This will succeed only if its logs are caught up with the leader
 func (m *memberControl) PromoteMember(ctx context.Context) error {
-	m.logger.Infof("Attempting to promote member %s", m.podName)
+	m.logger.Infof("Attempting to promote member %s", m.memberName)
 	cli, err := m.clientFactory.NewCluster()
 	if err != nil {
 		return fmt.Errorf("failed to build etcd cluster client : %v", err)
@@ -241,7 +248,7 @@ func (m *memberControl) PromoteMember(ctx context.Context) error {
 		return fmt.Errorf("error listing members: %v", err)
 	}
 
-	foundMember := findMember(etcdList.Members, m.podName)
+	foundMember := findMember(etcdList.Members, m.memberName)
 	if foundMember == nil {
 		return ErrMissingMember
 	}
@@ -260,7 +267,7 @@ func findMember(existingMembers []*etcdserverpb.Member, memberName string) *etcd
 
 // UpdateMemberPeerURL updates the peer address of a specified etcd cluster member.
 func (m *memberControl) UpdateMemberPeerURL(ctx context.Context, cli etcdClient.ClusterCloser) error {
-	m.logger.Infof("Attempting to update the member Info: %v", m.podName)
+	m.logger.Infof("Attempting to update the member Info: %v", m.memberName)
 	ctx, cancel := context.WithTimeout(ctx, brtypes.DefaultEtcdConnectionTimeout)
 	defer cancel()
 
@@ -274,7 +281,7 @@ func (m *memberControl) UpdateMemberPeerURL(ctx context.Context, cli etcdClient.
 
 // RemoveMember removes the member from the etcd cluster.
 func (m *memberControl) RemoveMember(ctx context.Context) error {
-	m.logger.Infof("Removing the %s member from cluster", m.podName)
+	m.logger.Infof("Removing the %s member from cluster", m.memberName)
 
 	cli, err := m.clientFactory.NewCluster()
 	if err != nil {
@@ -290,7 +297,7 @@ func (m *memberControl) RemoveMember(ctx context.Context) error {
 		return fmt.Errorf("error listing members: %v", err)
 	}
 
-	foundMember := findMember(memberInfo.Members, m.podName)
+	foundMember := findMember(memberInfo.Members, m.memberName)
 	if foundMember == nil {
 		return nil
 	}
@@ -352,7 +359,7 @@ func (m *memberControl) GetPeerURLs(ctx context.Context, closer etcdClient.Clust
 		return nil, fmt.Errorf("could not list any etcd members %w", err)
 	}
 	for _, member := range etcdMemberList.Members {
-		if member.GetName() == m.podName {
+		if member.GetName() == m.memberName {
 			return member.GetPeerURLs(), nil
 		}
 	}
@@ -371,7 +378,7 @@ func (m *memberControl) WasMemberInCluster(ctx context.Context, clientSet client
 	memberLease := &v1.Lease{}
 	if err := clientSet.Get(ctx, client.ObjectKey{
 		Namespace: m.podNamespace,
-		Name:      m.podName,
+		Name:      m.memberName,
 	}, memberLease); err != nil {
 		m.logger.Errorf("couldn't fetch member lease while checking if the member was part of the cluster: %v", err)
 		return false

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -108,7 +108,7 @@ func NewMemberControl(etcdConnConfig *brtypes.EtcdConnectionConfig) Control {
 
 	memberNamePrefix, err := miscellaneous.GetMemberNamePrefix(configFile)
 	if err != nil {
-		logger.Fatalf("failed to read member name prefix: %v", err)
+		logger.Fatalf("failed to read member-name-prefix: %v", err)
 	}
 	memberName := miscellaneous.ComputeMemberName(memberNamePrefix, podName)
 

--- a/pkg/member/member_control_test.go
+++ b/pkg/member/member_control_test.go
@@ -28,9 +28,11 @@ var _ = Describe("Membercontrol", func() {
 		ctrl                 *gomock.Controller
 		factory              *mockfactory.MockFactory
 		cl                   *mockfactory.MockClusterCloser
+		memberNamePrefix     string
 	)
 
 	BeforeEach(func() {
+		memberNamePrefix = ""
 		etcdConnectionConfig = brtypes.NewEtcdConnectionConfig()
 		etcdConnectionConfig.Endpoints = []string{etcd.Clients[0].Addr().String()}
 		etcdConnectionConfig.ConnectionTimeout.Duration = 30 * time.Second
@@ -43,6 +45,15 @@ var _ = Describe("Membercontrol", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		factory = mockfactory.NewMockFactory(ctrl)
 		cl = mockfactory.NewMockClusterCloser(ctrl)
+	})
+
+	JustBeforeEach(func() {
+		urlKey := podName
+		prefixLine := ""
+		if memberNamePrefix != "" {
+			urlKey = memberNamePrefix + "-" + podName
+			prefixLine = "\nmember-name-prefix: " + memberNamePrefix
+		}
 
 		outfile := "/tmp/etcd.conf.yaml"
 		etcdConfigYaml := `# Human-readable name for this member.
@@ -53,21 +64,20 @@ snapshot-count: 75000
 quota-backend-bytes: 1073741824
 listen-client-urls: http://0.0.0.0:2379
 advertise-client-urls:
-  ` + podName + `:
+  ` + urlKey + `:
     - http://` + etcd.Clients[0].Addr().String() + `
 initial-advertise-peer-urls:
-  ` + podName + `:
+  ` + urlKey + `:
     - http://` + etcd.Peers[0].Addr().String() + `
 initial-cluster: etcd1=http://0.0.0.0:2380
 initial-cluster-token: new
 initial-cluster-state: new
 auto-compaction-mode: periodic
-auto-compaction-retention: 30m`
+auto-compaction-retention: 30m` + prefixLine
 
 		err := os.WriteFile(outfile, []byte(etcdConfigYaml), 0755)
 		Expect(err).ShouldNot(HaveOccurred())
 		os.Setenv("ETCD_CONF", outfile)
-
 	})
 
 	AfterEach(func() {
@@ -109,15 +119,24 @@ auto-compaction-retention: 30m`
 		})
 		Context("If member is not part of a cluster", func() {
 			It("Should return false", func() {
-				podName := "default-0"
-				os.Setenv("POD_NAME", podName)
+				os.Setenv("POD_NAME", "default-0")
 
 				mem := member.NewMemberControl(etcdConnectionConfig)
 				present, err := mem.IsMemberInCluster(context.TODO())
 
 				Expect(present).To(BeFalse())
 				Expect(err).To(BeNil())
-				_ = os.Unsetenv("POD_NAME")
+			})
+		})
+		Context("If member-name-prefix is set in config", func() {
+			BeforeEach(func() {
+				memberNamePrefix = "myprefix"
+			})
+			It("should apply the prefix to POD_NAME and use it for the member lookup", func() {
+				mem := member.NewMemberControl(etcdConnectionConfig)
+				present, err := mem.IsMemberInCluster(context.TODO())
+				Expect(present).To(BeFalse())
+				Expect(err).To(BeNil())
 			})
 		})
 	})
@@ -129,6 +148,8 @@ auto-compaction-retention: 30m`
 		)
 		BeforeEach(func() {
 			factory.EXPECT().NewCluster().Return(cl, nil)
+		})
+		JustBeforeEach(func() {
 			m = member.NewMemberControl(etcdConnectionConfig)
 		})
 
@@ -195,19 +216,17 @@ auto-compaction-retention: 30m`
 		var (
 			m member.Control
 		)
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			m = member.NewMemberControl(etcdConnectionConfig)
 		})
 		Context("When cluster is up and member is not part of the list", func() {
 			It("should return true", func() {
-				podName := "default-0"
-				os.Setenv("POD_NAME", podName)
+				os.Setenv("POD_NAME", "default-0")
 				m = member.NewMemberControl(etcdConnectionConfig)
 
 				isScaleUp, err := m.IsClusterScaledUp(testCtx)
 				Expect(isScaleUp).Should(BeTrue())
 				Expect(err).ShouldNot(HaveOccurred())
-				_ = os.Unsetenv("POD_NAME")
 			})
 		})
 

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -64,6 +64,43 @@ type advertiseURLsConfig struct {
 	InitialAdvertisePeerURLs map[string][]string `json:"initial-advertise-peer-urls"`
 }
 
+// GetMemberNamePrefix reads the member-name-prefix from the etcd config file.
+func GetMemberNamePrefix(configFile string) (string, error) {
+	config, err := ReadConfigFileAsMap(configFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to read etcd config file %q: %w", configFile, err)
+	}
+	if prefix, ok := config["member-name-prefix"]; ok {
+		if p, ok := prefix.(string); ok {
+			return p, nil
+		}
+	}
+	return "", nil
+}
+
+// ComputeMemberName constructs the member name from an optional prefix and pod name.
+// If prefix is non-empty, the member name is "<prefix>-<podName>", otherwise it is just <podName>.
+func ComputeMemberName(memberNamePrefix, podName string) string {
+	if memberNamePrefix != "" {
+		return memberNamePrefix + "-" + podName
+	}
+	return podName
+}
+
+// GetMemberName reads the member-name-prefix from the config file and computes
+// the member name using the POD_NAME environment variable.
+func GetMemberName(configFile string) (string, error) {
+	podName, err := GetEnvVarOrError("POD_NAME")
+	if err != nil {
+		return "", fmt.Errorf("POD_NAME env var not set: %w", err)
+	}
+	prefix, err := GetMemberNamePrefix(configFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to get member name prefix: %w", err)
+	}
+	return ComputeMemberName(prefix, podName), nil
+}
+
 // GetNLatestFullSnapshots returns the latest N full snapshots from the store.
 // N must be greater than 0.
 func GetNLatestFullSnapshots(store brtypes.SnapStore, n int) (brtypes.SnapList, error) {
@@ -602,11 +639,12 @@ func parseAdvertiseURLsConfig(configFile string) (*advertiseURLsConfig, error) {
 	return &advURLsConfig, nil
 }
 
-// GetMemberPeerURLs retrieves the initial advertise peer URLs for the etcd member using the POD_NAME environment variable.
+// GetMemberPeerURLs retrieves the initial advertise peer URLs for the etcd member.
+// The member name is derived from the POD_NAME environment variable and the optional member-name-prefix in the config.
 func GetMemberPeerURLs(configFile string) ([]string, error) {
-	memberName, err := GetEnvVarOrError("POD_NAME")
+	memberName, err := GetMemberName(configFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get member name: %w", err)
 	}
 
 	advURLsConfig, err := parseAdvertiseURLsConfig(configFile)
@@ -627,11 +665,12 @@ func GetMemberPeerURLs(configFile string) ([]string, error) {
 	return peerURLs, nil
 }
 
-// GetMemberClientURLs retrieves the advertise client URLs for the etcd member using the POD_NAME environment variable.
+// GetMemberClientURLs retrieves the advertise client URLs for the etcd member.
+// The member name is derived from the POD_NAME environment variable and the optional member-name-prefix in the config.
 func GetMemberClientURLs(configFile string) ([]string, error) {
-	memberName, err := GetEnvVarOrError("POD_NAME")
+	memberName, err := GetMemberName(configFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get member name: %w", err)
 	}
 
 	advURLsConfig, err := parseAdvertiseURLsConfig(configFile)

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -78,11 +78,11 @@ func GetMemberNamePrefix(configFile string) (string, error) {
 	return "", nil
 }
 
-// ComputeMemberName constructs the member name from an optional prefix and pod name.
-// If prefix is non-empty, the member name is "<prefix>-<podName>", otherwise it is just <podName>.
+// ComputeMemberName constructs the member name from a pod name and from an optional member-name-prefix (if any).
+// If member-name-prefix is non-empty, then member name would be "<memberPrefix>-<podName>", otherwise it would be just <podName>.
 func ComputeMemberName(memberNamePrefix, podName string) string {
 	if memberNamePrefix != "" {
-		return memberNamePrefix + "-" + podName
+		return fmt.Sprintf("%s-%s", memberNamePrefix, podName)
 	}
 	return podName
 }
@@ -94,11 +94,11 @@ func GetMemberName(configFile string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("POD_NAME env var not set: %w", err)
 	}
-	prefix, err := GetMemberNamePrefix(configFile)
+	memberNamePrefix, err := GetMemberNamePrefix(configFile)
 	if err != nil {
-		return "", fmt.Errorf("failed to get member name prefix: %w", err)
+		return "", fmt.Errorf("failed to get member-name-prefix: %w", err)
 	}
-	return ComputeMemberName(prefix, podName), nil
+	return ComputeMemberName(memberNamePrefix, podName), nil
 }
 
 // GetNLatestFullSnapshots returns the latest N full snapshots from the store.

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -992,6 +992,85 @@ initial-cluster: etcd1=http://0.0.0.0:2380`
 			})
 		})
 	})
+
+	Describe("Member Name Computation", func() {
+		Describe("#ComputeMemberName", func() {
+			It("should return podName when prefix is empty", func() {
+				Expect(ComputeMemberName("", "etcd-main-0")).To(Equal("etcd-main-0"))
+			})
+			It("should return prefix-podName when prefix is non-empty", func() {
+				Expect(ComputeMemberName("myprefix", "etcd-main-0")).To(Equal("myprefix-etcd-main-0"))
+			})
+		})
+
+		Describe("#GetMemberNamePrefix", func() {
+			const configFile = "/tmp/etcd-member-prefix-config.yaml"
+			AfterEach(func() {
+				_ = os.Remove(configFile)
+			})
+			It("should return an error when config file cannot be read", func() {
+				_, err := GetMemberNamePrefix("/nonexistent/config.yaml")
+				Expect(err).To(HaveOccurred())
+			})
+			It("should return empty string when member-name-prefix is not set", func() {
+				writeConfigToFile(configFile, map[string]interface{}{"name": "etcd-test"})
+				prefix, err := GetMemberNamePrefix(configFile)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(prefix).To(Equal(""))
+			})
+			It("should return the prefix when member-name-prefix is set", func() {
+				writeConfigToFile(configFile, map[string]interface{}{
+					"name":               "etcd-test",
+					"member-name-prefix": "myprefix",
+				})
+				prefix, err := GetMemberNamePrefix(configFile)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(prefix).To(Equal("myprefix"))
+			})
+		})
+
+		Describe("#GetMemberName", func() {
+			const (
+				configFile = "/tmp/etcd-member-name-config.yaml"
+				podName    = "etcd-main-0"
+			)
+			BeforeEach(func() {
+				Expect(os.Setenv("POD_NAME", podName)).To(Succeed())
+			})
+			AfterEach(func() {
+				Expect(os.Unsetenv("POD_NAME")).To(Succeed())
+				_ = os.Remove(configFile)
+			})
+			It("should return podName when member-name-prefix is not set", func() {
+				writeConfigToFile(configFile, map[string]interface{}{"name": "etcd-test"})
+				name, err := GetMemberName(configFile)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(name).To(Equal(podName))
+			})
+			It("should return prefix-podName when member-name-prefix is set", func() {
+				writeConfigToFile(configFile, map[string]interface{}{
+					"name":               "etcd-test",
+					"member-name-prefix": "myprefix",
+				})
+				name, err := GetMemberName(configFile)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(name).To(Equal("myprefix-" + podName))
+			})
+			It("should return an error when config file cannot be read", func() {
+				_, err := GetMemberName("/nonexistent/config.yaml")
+				Expect(err).To(HaveOccurred())
+			})
+			Context("When POD_NAME environment variable is not set", func() {
+				BeforeEach(func() {
+					Expect(os.Unsetenv("POD_NAME")).To(Succeed())
+				})
+				It("should return an error", func() {
+					_, err := GetMemberName(configFile)
+					Expect(err).To(HaveOccurred())
+				})
+			})
+		})
+	})
 })
 
 func emptyStatefulSet(name, namespace string) *appsv1.StatefulSet {

--- a/pkg/server/httpAPI.go
+++ b/pkg/server/httpAPI.go
@@ -421,7 +421,15 @@ func (h *HTTPHandler) serveConfig(rw http.ResponseWriter, req *http.Request) {
 	podNS := os.Getenv("POD_NAMESPACE")
 	podName := os.Getenv("POD_NAME")
 
-	config["name"] = podName
+	memberNamePrefix, err := miscellaneous.GetMemberNamePrefix(inputFileName)
+	if err != nil {
+		h.Logger.Warnf("Unable to read member name prefix from etcd config file: %v", err)
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	memberName := miscellaneous.ComputeMemberName(memberNamePrefix, podName)
+
+	config["name"] = memberName
 
 	// fetch initial-advertise-peer-urls from etcd config file
 	initAdPeerURLs, err := miscellaneous.GetMemberPeerURLs(inputFileName)
@@ -441,7 +449,7 @@ func (h *HTTPHandler) serveConfig(rw http.ResponseWriter, req *http.Request) {
 	}
 	config["advertise-client-urls"] = strings.Join(advClientURLs, ",")
 
-	config["initial-cluster"] = getInitialCluster(req.Context(), fmt.Sprint(config["initial-cluster"]), *h.EtcdConnectionConfig, *h.Logger, podName)
+	config["initial-cluster"] = getInitialCluster(req.Context(), fmt.Sprint(config["initial-cluster"]), *h.EtcdConnectionConfig, *h.Logger, memberName)
 
 	clusterSize, err := miscellaneous.GetClusterSize(fmt.Sprint(config["initial-cluster"]))
 	if err != nil {
@@ -510,7 +518,7 @@ func (h *HTTPHandler) getClusterState(ctx context.Context, clusterSize int, podN
 	return *state, nil
 }
 
-func getInitialCluster(ctx context.Context, initialCluster string, etcdConn brtypes.EtcdConnectionConfig, logger logrus.Entry, podName string) string {
+func getInitialCluster(ctx context.Context, initialCluster string, etcdConn brtypes.EtcdConnectionConfig, logger logrus.Entry, memberName string) string {
 	// INITIAL_CLUSTER served via the etcd config must be tailored to the number of members in the cluster at that point. Else etcd complains with error "member count is unequal"
 	// One reason why we might want to have a strict ordering when members are joining the cluster
 	// addmember subcommand achieves this by making sure the pod with the previous index is running before attempting to add itself as a learner
@@ -560,7 +568,7 @@ func getInitialCluster(ctx context.Context, initialCluster string, etcdConn brty
 		for _, y := range initialcluster {
 			// Add member to `initial-cluster` only if already a cluster member
 			z := strings.Split(y, "=")
-			if membrs[z[0]] || z[0] == podName {
+			if membrs[z[0]] || z[0] == memberName {
 				cluster = cluster + y + ","
 			}
 		}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane-migration delivery open-source
/kind api-change enhancement epic

**What this PR does / why we need it**:
Adapts etcd-backup-restore to the `member-name-prefix feature` from [etcd-druid#1309](https://github.com/gardener/etcd-druid/pull/1309). When set in the etcd config file, each member name becomes `<prefix>-<pod-name>` instead of just the pod name. Backward compatible `-` prefix is optional.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/etcd-backup-restore/issues/896 https://github.com/gardener/etcd-druid/issues/1237 https://github.com/gardener/gardener/issues/10686

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
etcd member names now support an optional `member-name-prefix` field in the etcd config file. When set, member names take the form `<prefix>-<pod-name>` instead of just the pod name.

```
