### PR TITLE
Enhance schedule/cron defrag

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -208,22 +208,22 @@ func (c *validatorOptions) validate() error {
 
 type snapshotterOptions struct {
 	etcdConnectionConfig     *brtypes.EtcdConnectionConfig
+	defragConfig             *brtypes.DefragConfig
 	compressionConfig        *compressor.CompressionConfig
 	snapstoreConfig          *brtypes.SnapstoreConfig
 	snapshotterConfig        *brtypes.SnapshotterConfig
 	exponentialBackoffConfig *brtypes.ExponentialBackoffConfig
-	defragmentationSchedule  string
 }
 
 // newSnapshotterOptions returns the snapshotter options.
 func newSnapshotterOptions() *snapshotterOptions {
 	return &snapshotterOptions{
 		etcdConnectionConfig:     brtypes.NewEtcdConnectionConfig(),
+		defragConfig:             brtypes.NewDefragConfig(),
 		snapstoreConfig:          snapstore.NewSnapstoreConfig(),
 		snapshotterConfig:        snapshotter.NewSnapshotterConfig(),
 		compressionConfig:        compressor.NewCompressorConfig(),
 		exponentialBackoffConfig: brtypes.NewExponentialBackOffConfig(),
-		defragmentationSchedule:  "0 0 */3 * *",
 	}
 }
 
@@ -234,9 +234,7 @@ func (c *snapshotterOptions) addFlags(fs *flag.FlagSet) {
 	c.snapshotterConfig.AddFlags(fs)
 	c.compressionConfig.AddFlags(fs)
 	c.exponentialBackoffConfig.AddFlags(fs)
-
-	// Miscellaneous
-	fs.StringVar(&c.defragmentationSchedule, "defragmentation-schedule", c.defragmentationSchedule, "schedule to defragment etcd data directory")
+	c.defragConfig.AddFlags(fs)
 }
 
 // Validate validates the config.
@@ -254,6 +252,10 @@ func (c *snapshotterOptions) validate() error {
 	}
 
 	if err := c.exponentialBackoffConfig.Validate(); err != nil {
+		return err
+	}
+
+	if err := c.defragConfig.Validate(); err != nil {
 		return err
 	}
 	return c.etcdConnectionConfig.Validate()

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -48,13 +48,13 @@ storing snapshots on various cloud storage providers as well as local disk locat
 				logger.Fatalf("Failed to create snapshotter: %v", err)
 			}
 
-			defragSchedule, err := cron.ParseStandard(opts.defragmentationSchedule)
+			defragSchedule, err := cron.ParseStandard(opts.defragConfig.DefragmentationSchedule)
 			if err != nil {
 				logger.Fatalf("failed to parse defragmentation schedule: %v", err)
 				return
 			}
 
-			go defragmentor.DefragDataPeriodically(ctx, opts.etcdConnectionConfig, defragSchedule, ssr.TriggerFullSnapshot, logger)
+			go defragmentor.DefragDataPeriodically(ctx, opts.etcdConnectionConfig, opts.defragConfig, defragSchedule, ssr.TriggerFullSnapshot, logger)
 
 			go ssr.RunGarbageCollector(ctx.Done())
 			if err := ssr.Run(ctx.Done(), true); err != nil {

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -13,7 +13,6 @@ import (
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 
 	"github.com/go-logr/logr"
-	cron "github.com/robfig/cron/v3"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -48,13 +47,7 @@ storing snapshots on various cloud storage providers as well as local disk locat
 				logger.Fatalf("Failed to create snapshotter: %v", err)
 			}
 
-			defragSchedule, err := cron.ParseStandard(opts.defragConfig.DefragmentationSchedule)
-			if err != nil {
-				logger.Fatalf("failed to parse defragmentation schedule: %v", err)
-				return
-			}
-
-			go defragmentor.DefragDataPeriodically(ctx, opts.etcdConnectionConfig, opts.defragConfig, defragSchedule, ssr.TriggerFullSnapshot, logger)
+			go defragmentor.DefragDataPeriodically(ctx, opts.etcdConnectionConfig, opts.defragConfig, ssr.TriggerFullSnapshot, logger)
 
 			go ssr.RunGarbageCollector(ctx.Done())
 			if err := ssr.Run(ctx.Done(), true); err != nil {

--- a/example/00-backup-restore-server-config.yaml
+++ b/example/00-backup-restore-server-config.yaml
@@ -5,7 +5,6 @@ etcdConnectionConfig:
   # password: admin
   connectionTimeout: 10s
   snapshotTimeout: 8m
-  defragTimeout: 8m
   # insecureTransport: true
   # insecureSkipVerify: true
   # certFile: "ssl/etcd/tls.crt"
@@ -58,8 +57,12 @@ restorationConfig:
   autoCompactionMode: "periodic"
   autoCompactionRetention: "30m"
 
-defragmentationSchedule: "0 0 */3 * *"
 useEtcdWrapper: false
+
+defragConfig:
+  defragmentationSchedule: "0 0 */3 * *"
+  defragTimeout: 8m
+  freespaceThreshold: 524288000
 
 compressionConfig:
    enabled: true

--- a/pkg/defragmentor/defrag.go
+++ b/pkg/defragmentor/defrag.go
@@ -37,6 +37,9 @@ func NewDefragmentorJob(ctx context.Context, etcdConnectionConfig *brtypes.EtcdC
 	}
 }
 
+// Run executes one defragmentation cycle.
+//   - First checks whether defragmentation can be skipped based on DB-size and free-space thresholds.
+//   - If not, then waits until all etcd cluster members are healthy before defragmenting.
 func (d *defragmentorJob) Run() {
 	clientFactory := etcdutil.NewFactory(*d.etcdConnectionConfig)
 
@@ -45,6 +48,14 @@ func (d *defragmentorJob) Run() {
 		d.logger.Warnf("failed to create etcd maintenance client")
 	}
 	defer clientMaintenance.Close()
+
+	canSkip, err := miscellaneous.CanDefragSkip(d.ctx, clientMaintenance, d.etcdConnectionConfig)
+	if err != nil {
+		d.logger.Warnf("failed to check etcd defrag skip conditions, proceeding with etcd defragmentation: %v", err)
+	} else if canSkip {
+		d.logger.Infof("skipping the schedule defrag for etcd cluster as Total DBSize is below %dGB threshold and available free-space is below %dGB threshold", miscellaneous.DefragThreshold/1024/1024/1024, miscellaneous.FreeSpaceThreshold/1024/1024/1024)
+		return
+	}
 
 	client, err := clientFactory.NewCluster()
 	if err != nil {
@@ -75,7 +86,7 @@ waitLoop:
 			}
 
 			if isClusterHealthy {
-				d.logger.Infof("Starting the defragmentation as all members of etcd cluster are in healthy state")
+				d.logger.Infof("Starting the schedule defragmentation as all members of etcd cluster are in healthy state")
 				err = etcdutil.DefragmentData(d.ctx, clientMaintenance, client, etcdEndpoints, d.etcdConnectionConfig.DefragTimeout.Duration, d.logger)
 				if err != nil {
 					d.logger.Warnf("failed to defrag data with error: %v", err)

--- a/pkg/defragmentor/defrag.go
+++ b/pkg/defragmentor/defrag.go
@@ -23,15 +23,17 @@ type CallbackFunc func(ctx context.Context, isFinal bool) (*brtypes.Snapshot, er
 type defragmentorJob struct {
 	ctx                  context.Context
 	etcdConnectionConfig *brtypes.EtcdConnectionConfig
+	defragConfig         *brtypes.DefragConfig
 	logger               *logrus.Entry
 	callback             CallbackFunc
 }
 
 // NewDefragmentorJob returns the new defragmentor job.
-func NewDefragmentorJob(ctx context.Context, etcdConnectionConfig *brtypes.EtcdConnectionConfig, logger *logrus.Entry, callback CallbackFunc) cron.Job {
+func NewDefragmentorJob(ctx context.Context, etcdConnectionConfig *brtypes.EtcdConnectionConfig, defragConfig *brtypes.DefragConfig, logger *logrus.Entry, callback CallbackFunc) cron.Job {
 	return &defragmentorJob{
 		ctx:                  ctx,
 		etcdConnectionConfig: etcdConnectionConfig,
+		defragConfig:         defragConfig,
 		logger:               logger.WithField("job", "defragmentor"),
 		callback:             callback,
 	}
@@ -49,11 +51,11 @@ func (d *defragmentorJob) Run() {
 	}
 	defer clientMaintenance.Close()
 
-	canSkip, err := miscellaneous.CanDefragSkip(d.ctx, clientMaintenance, d.etcdConnectionConfig)
+	canSkip, err := miscellaneous.CanDefragSkip(d.ctx, clientMaintenance, d.etcdConnectionConfig, d.defragConfig)
 	if err != nil {
 		d.logger.Warnf("failed to check etcd defrag skip conditions, proceeding with etcd defragmentation: %v", err)
 	} else if canSkip {
-		d.logger.Infof("skipping the schedule defrag for etcd cluster as Total DBSize is below %dGB threshold and available free-space is below %dGB threshold", miscellaneous.DefragThreshold/1024/1024/1024, miscellaneous.FreeSpaceThreshold/1024/1024/1024)
+		d.logger.Infof("skipping the schedule defrag for etcd cluster as Total DBSize is below %dGB threshold and available free-space is below %dGB threshold", miscellaneous.DefragThreshold/1024/1024/1024, d.defragConfig.FreespaceThreshold/1024/1024/1024)
 		return
 	}
 
@@ -87,7 +89,7 @@ waitLoop:
 
 			if isClusterHealthy {
 				d.logger.Infof("Starting the schedule defragmentation as all members of etcd cluster are in healthy state")
-				err = etcdutil.DefragmentData(d.ctx, clientMaintenance, client, etcdEndpoints, d.etcdConnectionConfig.DefragTimeout.Duration, d.logger)
+				err = etcdutil.DefragmentData(d.ctx, clientMaintenance, client, etcdEndpoints, d.defragConfig.DefragTimeout.Duration, d.logger)
 				if err != nil {
 					d.logger.Warnf("failed to defrag data with error: %v", err)
 					continue
@@ -104,8 +106,8 @@ waitLoop:
 }
 
 // DefragDataPeriodically defragments the data directory of each etcd member.
-func DefragDataPeriodically(ctx context.Context, etcdConnectionConfig *brtypes.EtcdConnectionConfig, defragmentationSchedule cron.Schedule, callback CallbackFunc, logger *logrus.Entry) {
-	defragmentorJob := NewDefragmentorJob(ctx, etcdConnectionConfig, logger, callback)
+func DefragDataPeriodically(ctx context.Context, etcdConnectionConfig *brtypes.EtcdConnectionConfig, defragConfig *brtypes.DefragConfig, defragmentationSchedule cron.Schedule, callback CallbackFunc, logger *logrus.Entry) {
+	defragmentorJob := NewDefragmentorJob(ctx, etcdConnectionConfig, defragConfig, logger, callback)
 	// TODO: Sync logrus logger to cron logger
 	jobRunner := cron.New(cron.WithChain(cron.SkipIfStillRunning(cron.DefaultLogger)))
 	jobRunner.Schedule(defragmentationSchedule, defragmentorJob)

--- a/pkg/defragmentor/defrag.go
+++ b/pkg/defragmentor/defrag.go
@@ -51,7 +51,7 @@ func (d *defragmentorJob) Run() {
 	}
 	defer clientMaintenance.Close()
 
-	canSkip, err := miscellaneous.CanDefragSkip(d.ctx, clientMaintenance, d.etcdConnectionConfig, d.defragConfig)
+	canSkip, err := miscellaneous.CanSkipDefrag(d.ctx, clientMaintenance, d.etcdConnectionConfig, d.defragConfig)
 	if err != nil {
 		d.logger.Warnf("failed to check etcd defrag skip conditions, proceeding with etcd defragmentation: %v", err)
 	} else if canSkip {
@@ -88,7 +88,7 @@ waitLoop:
 			}
 
 			if isClusterHealthy {
-				d.logger.Infof("Starting the schedule defragmentation as all members of etcd cluster are in healthy state")
+				d.logger.Infof("Starting the scheduled defragmentation since all members of the etcd cluster are in a healthy state")
 				err = etcdutil.DefragmentData(d.ctx, clientMaintenance, client, etcdEndpoints, d.defragConfig.DefragTimeout.Duration, d.logger)
 				if err != nil {
 					d.logger.Warnf("failed to defrag data with error: %v", err)
@@ -106,7 +106,13 @@ waitLoop:
 }
 
 // DefragDataPeriodically defragments the data directory of each etcd member.
-func DefragDataPeriodically(ctx context.Context, etcdConnectionConfig *brtypes.EtcdConnectionConfig, defragConfig *brtypes.DefragConfig, defragmentationSchedule cron.Schedule, callback CallbackFunc, logger *logrus.Entry) {
+func DefragDataPeriodically(ctx context.Context, etcdConnectionConfig *brtypes.EtcdConnectionConfig, defragConfig *brtypes.DefragConfig, callback CallbackFunc, logger *logrus.Entry) {
+	defragmentationSchedule, err := cron.ParseStandard(defragConfig.DefragmentationSchedule)
+	if err != nil {
+		logger.Fatalf("failed to parse defragmentation schedule: %v", err)
+		return
+	}
+
 	defragmentorJob := NewDefragmentorJob(ctx, etcdConnectionConfig, defragConfig, logger, callback)
 	// TODO: Sync logrus logger to cron logger
 	jobRunner := cron.New(cron.WithChain(cron.SkipIfStillRunning(cron.DefaultLogger)))

--- a/pkg/defragmentor/defrag.go
+++ b/pkg/defragmentor/defrag.go
@@ -55,7 +55,7 @@ func (d *defragmentorJob) Run() {
 	if err != nil {
 		d.logger.Warnf("failed to check etcd defrag skip conditions, proceeding with etcd defragmentation: %v", err)
 	} else if canSkip {
-		d.logger.Infof("skipping the schedule defrag for etcd cluster as Total DBSize is below %dGB threshold and available free-space is below %dGB threshold", etcdutil.DefragThreshold/1024/1024/1024, d.defragConfig.FreespaceThreshold/1024/1024/1024)
+		d.logger.Infof("skipping the schedule defrag for etcd cluster as Total DBSize is below %.2fGB threshold and available free-space is below %.2fGB threshold", float64(etcdutil.DefragThreshold)/1024/1024/1024, float64(d.defragConfig.FreespaceThreshold)/1024/1024/1024)
 		return
 	}
 

--- a/pkg/defragmentor/defrag.go
+++ b/pkg/defragmentor/defrag.go
@@ -51,11 +51,11 @@ func (d *defragmentorJob) Run() {
 	}
 	defer clientMaintenance.Close()
 
-	canSkip, err := miscellaneous.CanSkipDefrag(d.ctx, clientMaintenance, d.etcdConnectionConfig, d.defragConfig)
+	canSkip, err := etcdutil.CanSkipDefrag(d.ctx, clientMaintenance, d.etcdConnectionConfig, d.defragConfig)
 	if err != nil {
 		d.logger.Warnf("failed to check etcd defrag skip conditions, proceeding with etcd defragmentation: %v", err)
 	} else if canSkip {
-		d.logger.Infof("skipping the schedule defrag for etcd cluster as Total DBSize is below %dGB threshold and available free-space is below %dGB threshold", miscellaneous.DefragThreshold/1024/1024/1024, d.defragConfig.FreespaceThreshold/1024/1024/1024)
+		d.logger.Infof("skipping the schedule defrag for etcd cluster as Total DBSize is below %dGB threshold and available free-space is below %dGB threshold", etcdutil.DefragThreshold/1024/1024/1024, d.defragConfig.FreespaceThreshold/1024/1024/1024)
 		return
 	}
 

--- a/pkg/defragmentor/defrag_test.go
+++ b/pkg/defragmentor/defrag_test.go
@@ -25,17 +25,18 @@ import (
 var _ = Describe("Defrag", func() {
 	var (
 		etcdConnectionConfig *brtypes.EtcdConnectionConfig
+		defragConfig         *brtypes.DefragConfig
 		keyPrefix            = "/defrag/key-"
 		valuePrefix          = "val"
 	)
 
 	BeforeEach(func() {
 		etcdConnectionConfig = brtypes.NewEtcdConnectionConfig()
+		defragConfig = brtypes.NewDefragConfig()
 		etcdConnectionConfig.Endpoints = endpoints
 		etcdConnectionConfig.ConnectionTimeout.Duration = 30 * time.Second
 		etcdConnectionConfig.SnapshotTimeout.Duration = 30 * time.Second
-		etcdConnectionConfig.DefragTimeout.Duration = 30 * time.Second
-
+		defragConfig.DefragTimeout.Duration = 30 * time.Second
 	})
 
 	Context("Defragmentation", func() {
@@ -81,7 +82,7 @@ var _ = Describe("Defrag", func() {
 			// compact the ETCD DB to let the defragmentor have full effect
 			_, err = clientKV.Compact(testCtx, oldRevision, clientv3.WithCompactPhysical())
 			Expect(err).ShouldNot(HaveOccurred())
-			defragmentorJob := NewDefragmentorJob(testCtx, etcdConnectionConfig, logger, nil)
+			defragmentorJob := NewDefragmentorJob(testCtx, etcdConnectionConfig, defragConfig, logger, nil)
 			defragmentorJob.Run()
 
 			ctx, cancel = context.WithTimeout(testCtx, etcdDialTimeout)
@@ -94,7 +95,7 @@ var _ = Describe("Defrag", func() {
 		})
 
 		It("should keep size of DB same in case of timeout", func() {
-			etcdConnectionConfig.DefragTimeout.Duration = time.Microsecond
+			defragConfig.DefragTimeout.Duration = time.Microsecond
 			clientFactory := etcdutil.NewFactory(*etcdConnectionConfig)
 
 			clientMaintenance, err := clientFactory.NewMaintenance()
@@ -108,7 +109,7 @@ var _ = Describe("Defrag", func() {
 			oldDBSize := oldStatus.DbSize
 			oldRevision := oldStatus.Header.GetRevision()
 
-			defragmentorJob := NewDefragmentorJob(ctx, etcdConnectionConfig, logger, nil)
+			defragmentorJob := NewDefragmentorJob(ctx, etcdConnectionConfig, defragConfig, logger, nil)
 			defragmentorJob.Run()
 			cancel()
 
@@ -152,7 +153,7 @@ var _ = Describe("Defrag", func() {
 
 			defragThreadCtx, cancelDefragThread := context.WithTimeout(testCtx, time.Second*time.Duration(235))
 			defer cancelDefragThread()
-			DefragDataPeriodically(defragThreadCtx, etcdConnectionConfig, defragSchedule, func(_ context.Context, _ bool) (*brtypes.Snapshot, error) {
+			DefragDataPeriodically(defragThreadCtx, etcdConnectionConfig, defragConfig, defragSchedule, func(_ context.Context, _ bool) (*brtypes.Snapshot, error) {
 				defragCount++
 				return nil, nil
 			}, logger)

--- a/pkg/defragmentor/defrag_test.go
+++ b/pkg/defragmentor/defrag_test.go
@@ -62,6 +62,8 @@ var _ = Describe("Defrag", func() {
 		})
 
 		It("should defragment and reduce size of DB within time", func() {
+			// To make sure defrag should run set the FreespaceThreshold =1Byte
+			defragConfig.FreespaceThreshold = 1
 			clientFactory := etcdutil.NewFactory(*etcdConnectionConfig)
 
 			clientMaintenance, err := clientFactory.NewMaintenance()
@@ -79,7 +81,10 @@ var _ = Describe("Defrag", func() {
 			oldDBSize := oldStatus.DbSize
 			oldRevision := oldStatus.Header.GetRevision()
 
-			// compact the ETCD DB to let the defragmentor have full effect
+			// Delete all keys and compact the ETCD DB to let the defragmentor have full effect
+			_, err = clientKV.Delete(testCtx, "", clientv3.WithPrefix())
+			Expect(err).ShouldNot(HaveOccurred())
+
 			_, err = clientKV.Compact(testCtx, oldRevision, clientv3.WithCompactPhysical())
 			Expect(err).ShouldNot(HaveOccurred())
 			defragmentorJob := NewDefragmentorJob(testCtx, etcdConnectionConfig, defragConfig, logger, nil)
@@ -91,7 +96,7 @@ var _ = Describe("Defrag", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(newStatus.DbSize).Should(BeNumerically("<", oldDBSize))
-			Expect(newStatus.Header.GetRevision()).Should(BeNumerically("==", oldRevision))
+			Expect(newStatus.Header.GetRevision()).Should(BeNumerically("==", oldRevision+1))
 		})
 
 		It("should keep size of DB same in case of timeout", func() {
@@ -123,6 +128,8 @@ var _ = Describe("Defrag", func() {
 		})
 
 		It("should defrag periodically with callback", func() {
+			// To make sure defrag should run set the FreespaceThreshold to 1Byte
+			defragConfig.FreespaceThreshold = 1
 			defragCount := 0
 			minimumExpectedDefragCount := 2
 			defragSchedule, _ := cron.ParseStandard("*/1 * * * *")

--- a/pkg/defragmentor/defrag_test.go
+++ b/pkg/defragmentor/defrag_test.go
@@ -14,7 +14,6 @@ import (
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 	"github.com/gardener/etcd-backup-restore/test/utils"
 
-	cron "github.com/robfig/cron/v3"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	. "github.com/gardener/etcd-backup-restore/pkg/defragmentor"
@@ -130,9 +129,9 @@ var _ = Describe("Defrag", func() {
 		It("should defrag periodically with callback", func() {
 			// To make sure defrag should run set the FreespaceThreshold to 1Byte
 			defragConfig.FreespaceThreshold = 1
+			defragConfig.DefragmentationSchedule = "*/1 * * * *"
 			defragCount := 0
 			minimumExpectedDefragCount := 2
-			defragSchedule, _ := cron.ParseStandard("*/1 * * * *")
 
 			// Then populate the etcd with some more data to add the subsequent delta snapshots
 			populatorCtx, cancelPopulator := context.WithTimeout(testCtx, 5*time.Second)
@@ -160,7 +159,7 @@ var _ = Describe("Defrag", func() {
 
 			defragThreadCtx, cancelDefragThread := context.WithTimeout(testCtx, time.Second*time.Duration(235))
 			defer cancelDefragThread()
-			DefragDataPeriodically(defragThreadCtx, etcdConnectionConfig, defragConfig, defragSchedule, func(_ context.Context, _ bool) (*brtypes.Snapshot, error) {
+			DefragDataPeriodically(defragThreadCtx, etcdConnectionConfig, defragConfig, func(_ context.Context, _ bool) (*brtypes.Snapshot, error) {
 				defragCount++
 				return nil, nil
 			}, logger)

--- a/pkg/etcdutil/etcdutil.go
+++ b/pkg/etcdutil/etcdutil.go
@@ -31,6 +31,8 @@ import (
 
 const (
 	hashBufferSize = 4 * 1024 * 1024 // 4 MB
+	// DefragThreshold is the minimum total DB size above which schedule defragmentation is triggered.
+	DefragThreshold = 3 * 1024 * 1024 * 1024 // 3GB
 )
 
 // NewFactory returns a Factory that constructs new clients using the supplied ETCD client configuration.
@@ -425,4 +427,28 @@ func saveSnapshotToStore(store brtypes.SnapStore, rc io.ReadCloser, startTime ti
 	metrics.SnapshotDurationSeconds.With(prometheus.Labels{metrics.LabelKind: snapshot.Kind, metrics.LabelSucceeded: metrics.ValueSucceededTrue}).Observe(timeTaken.Seconds())
 	logger.Infof("Total time to save %s snapshot: %f seconds.", snapshot.Kind, timeTaken.Seconds())
 	return snapshot, nil
+}
+
+// CanSkipDefrag checks whether defragmentation can be skipped for a given etcd cluster.
+// It returns false (do not skip) when either TotalDBSize or available free space is greater than threshold.
+// It returns true (can skip) when the TotalDBSize and available free space are below threshold, meaning defragmentation would have
+// little benefit.
+func CanSkipDefrag(pCtx context.Context, client client.MaintenanceCloser, etcdConnectionConfig *brtypes.EtcdConnectionConfig, defragCfg *brtypes.DefragConfig) (bool, error) {
+	ctx, cancel := context.WithTimeout(pCtx, etcdConnectionConfig.ConnectionTimeout.Duration)
+	defer cancel()
+
+	if len(etcdConnectionConfig.Endpoints) == 0 {
+		return false, fmt.Errorf("etcd endpoints are not passed correctly")
+	}
+
+	etcdStatus, err := client.Status(ctx, etcdConnectionConfig.Endpoints[0])
+	if err != nil {
+		return false, err
+	}
+
+	if etcdStatus.DbSize > DefragThreshold || ((etcdStatus.DbSize - etcdStatus.DbSizeInUse) > defragCfg.FreespaceThreshold) {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/pkg/etcdutil/etcdutil_test.go
+++ b/pkg/etcdutil/etcdutil_test.go
@@ -30,14 +30,16 @@ import (
 
 var _ = Describe("EtcdUtil Tests", func() {
 	var (
-		factory           *mockfactory.MockFactory
-		ctrl              *gomock.Controller
-		cl                *mockfactory.MockClusterCloser
-		cm                *mockfactory.MockMaintenanceCloser
-		store             brtypes.SnapStore
-		etcdDBPath        string
-		snapstoreConfig   *brtypes.SnapstoreConfig
-		compressionConfig *compressor.CompressionConfig
+		factory              *mockfactory.MockFactory
+		ctrl                 *gomock.Controller
+		cl                   *mockfactory.MockClusterCloser
+		cm                   *mockfactory.MockMaintenanceCloser
+		store                brtypes.SnapStore
+		etcdDBPath           string
+		snapstoreConfig      *brtypes.SnapstoreConfig
+		compressionConfig    *compressor.CompressionConfig
+		etcdConnectionConfig *brtypes.EtcdConnectionConfig
+		defragConfig         *brtypes.DefragConfig
 	)
 
 	BeforeEach(func() {
@@ -405,6 +407,71 @@ advertise-client-urls:
 					})
 				})
 			})
+		})
+	})
+
+	Describe("Can Defragmentation be skipped", func() {
+		BeforeEach(func() {
+			factory.EXPECT().NewMaintenance().Return(cm, nil).AnyTimes()
+			etcdConnectionConfig = brtypes.NewEtcdConnectionConfig()
+			defragConfig = brtypes.NewDefragConfig()
+		})
+		It("should return false when TotalDBSize is greater than threshold", func() {
+			clientMaintenance, err := factory.NewMaintenance()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
+				response := new(clientv3.StatusResponse)
+				response.DbSize = 4 * 1024 * 1024 * 1024 // 4GB
+				return response, nil
+			}).Times(1)
+
+			canSkip, err := etcdutil.CanSkipDefrag(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
+			Expect(err).Should(BeNil())
+			Expect(canSkip).Should(BeFalse())
+		})
+
+		It("should return false when available free space is greater than threshold", func() {
+			clientMaintenance, err := factory.NewMaintenance()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
+				response := new(clientv3.StatusResponse)
+				response.DbSize = 2 * 1024 * 1024 * 1024 // 2GB
+				response.DbSizeInUse = 500 * 1024 * 1024 // 500MB
+				return response, nil
+			}).Times(1)
+
+			canSkip, err := etcdutil.CanSkipDefrag(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
+			Expect(err).Should(BeNil())
+			Expect(canSkip).Should(BeFalse())
+		})
+
+		It("should return true when TotalDBSize and available free space are below threshold", func() {
+			clientMaintenance, err := factory.NewMaintenance()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
+				response := new(clientv3.StatusResponse)
+				response.DbSize = 1 * 1024 * 1024 * 1024 // 1GB
+				response.DbSizeInUse = 500 * 1024 * 1024 // 500MB
+				return response, nil
+			}).Times(1)
+
+			canSkip, err := etcdutil.CanSkipDefrag(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
+			Expect(err).Should(BeNil())
+			Expect(canSkip).Should(BeTrue())
+		})
+
+		It("should return false with error", func() {
+			clientMaintenance, err := factory.NewMaintenance()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			cm.EXPECT().Status(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("failed to connect to the dummy etcd")).AnyTimes()
+
+			canSkip, err := etcdutil.CanSkipDefrag(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
+			Expect(err).ShouldNot(BeNil())
+			Expect(canSkip).Should(BeFalse())
 		})
 	})
 })

--- a/pkg/member/member_control_test.go
+++ b/pkg/member/member_control_test.go
@@ -37,7 +37,6 @@ var _ = Describe("Membercontrol", func() {
 		etcdConnectionConfig.Endpoints = []string{etcd.Clients[0].Addr().String()}
 		etcdConnectionConfig.ConnectionTimeout.Duration = 30 * time.Second
 		etcdConnectionConfig.SnapshotTimeout.Duration = 30 * time.Second
-		etcdConnectionConfig.DefragTimeout.Duration = 30 * time.Second
 
 		os.Setenv("POD_NAME", podName)
 		os.Setenv("POD_NAMESPACE", podNamespace)

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -57,6 +57,11 @@ const (
 
 	// etcdWrapperPort defines the port no. used by etcd-wrapper.
 	etcdWrapperPort = "9095"
+
+	// DefragThreshold is the minimum total DB size above which schedule defragmentation is triggered.
+	DefragThreshold = 3 * 1024 * 1024 * 1024 // 3GB
+	// FreeSpaceThreshold is the minimum free space above which schedule defragmentation is triggered.
+	FreeSpaceThreshold = 1 * 1024 * 1024 * 1024 // 1GB
 )
 
 type advertiseURLsConfig struct {
@@ -819,4 +824,28 @@ func getEtcdWrapperEndpoint(etcdEndpoints []string) (string, error) {
 	}
 
 	return fmt.Sprintf("%s://%s:%s", etcdURL.Scheme, etcdURL.Hostname(), etcdWrapperPort), nil
+}
+
+// CanDefragSkip checks whether defragmentation can be skipped for a given etcd cluster.
+// It returns false (do not skip) when either TotalDBSize or available free space is greater than threshold.
+// It returns true (can skip) when the TotalDBSize and available free space are below threshold, meaning defragmentation would have
+// little benefit.
+func CanDefragSkip(pCtx context.Context, client etcdClient.MaintenanceCloser, etcdConnectionConfig *brtypes.EtcdConnectionConfig) (bool, error) {
+	ctx, cancel := context.WithTimeout(pCtx, etcdConnectionConfig.ConnectionTimeout.Duration)
+	defer cancel()
+
+	if len(etcdConnectionConfig.Endpoints) == 0 {
+		return false, fmt.Errorf("etcd endpoints are not passed correctly")
+	}
+
+	etcdStatus, err := client.Status(ctx, etcdConnectionConfig.Endpoints[0])
+	if err != nil {
+		return false, err
+	}
+
+	if etcdStatus.DbSize > DefragThreshold || ((etcdStatus.DbSize - etcdStatus.DbSizeInUse) > FreeSpaceThreshold) {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -60,8 +60,6 @@ const (
 
 	// DefragThreshold is the minimum total DB size above which schedule defragmentation is triggered.
 	DefragThreshold = 3 * 1024 * 1024 * 1024 // 3GB
-	// FreeSpaceThreshold is the minimum free space above which schedule defragmentation is triggered.
-	FreeSpaceThreshold = 1 * 1024 * 1024 * 1024 // 1GB
 )
 
 type advertiseURLsConfig struct {
@@ -830,7 +828,7 @@ func getEtcdWrapperEndpoint(etcdEndpoints []string) (string, error) {
 // It returns false (do not skip) when either TotalDBSize or available free space is greater than threshold.
 // It returns true (can skip) when the TotalDBSize and available free space are below threshold, meaning defragmentation would have
 // little benefit.
-func CanDefragSkip(pCtx context.Context, client etcdClient.MaintenanceCloser, etcdConnectionConfig *brtypes.EtcdConnectionConfig) (bool, error) {
+func CanDefragSkip(pCtx context.Context, client etcdClient.MaintenanceCloser, etcdConnectionConfig *brtypes.EtcdConnectionConfig, defragCfg *brtypes.DefragConfig) (bool, error) {
 	ctx, cancel := context.WithTimeout(pCtx, etcdConnectionConfig.ConnectionTimeout.Duration)
 	defer cancel()
 
@@ -843,7 +841,7 @@ func CanDefragSkip(pCtx context.Context, client etcdClient.MaintenanceCloser, et
 		return false, err
 	}
 
-	if etcdStatus.DbSize > DefragThreshold || ((etcdStatus.DbSize - etcdStatus.DbSizeInUse) > FreeSpaceThreshold) {
+	if etcdStatus.DbSize > DefragThreshold || ((etcdStatus.DbSize - etcdStatus.DbSizeInUse) > defragCfg.FreespaceThreshold) {
 		return false, nil
 	}
 

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -57,9 +57,6 @@ const (
 
 	// etcdWrapperPort defines the port no. used by etcd-wrapper.
 	etcdWrapperPort = "9095"
-
-	// DefragThreshold is the minimum total DB size above which schedule defragmentation is triggered.
-	DefragThreshold = 3 * 1024 * 1024 * 1024 // 3GB
 )
 
 type advertiseURLsConfig struct {
@@ -822,28 +819,4 @@ func getEtcdWrapperEndpoint(etcdEndpoints []string) (string, error) {
 	}
 
 	return fmt.Sprintf("%s://%s:%s", etcdURL.Scheme, etcdURL.Hostname(), etcdWrapperPort), nil
-}
-
-// CanSkipDefrag checks whether defragmentation can be skipped for a given etcd cluster.
-// It returns false (do not skip) when either TotalDBSize or available free space is greater than threshold.
-// It returns true (can skip) when the TotalDBSize and available free space are below threshold, meaning defragmentation would have
-// little benefit.
-func CanSkipDefrag(pCtx context.Context, client etcdClient.MaintenanceCloser, etcdConnectionConfig *brtypes.EtcdConnectionConfig, defragCfg *brtypes.DefragConfig) (bool, error) {
-	ctx, cancel := context.WithTimeout(pCtx, etcdConnectionConfig.ConnectionTimeout.Duration)
-	defer cancel()
-
-	if len(etcdConnectionConfig.Endpoints) == 0 {
-		return false, fmt.Errorf("etcd endpoints are not passed correctly")
-	}
-
-	etcdStatus, err := client.Status(ctx, etcdConnectionConfig.Endpoints[0])
-	if err != nil {
-		return false, err
-	}
-
-	if etcdStatus.DbSize > DefragThreshold || ((etcdStatus.DbSize - etcdStatus.DbSizeInUse) > defragCfg.FreespaceThreshold) {
-		return false, nil
-	}
-
-	return true, nil
 }

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -824,11 +824,11 @@ func getEtcdWrapperEndpoint(etcdEndpoints []string) (string, error) {
 	return fmt.Sprintf("%s://%s:%s", etcdURL.Scheme, etcdURL.Hostname(), etcdWrapperPort), nil
 }
 
-// CanDefragSkip checks whether defragmentation can be skipped for a given etcd cluster.
+// CanSkipDefrag checks whether defragmentation can be skipped for a given etcd cluster.
 // It returns false (do not skip) when either TotalDBSize or available free space is greater than threshold.
 // It returns true (can skip) when the TotalDBSize and available free space are below threshold, meaning defragmentation would have
 // little benefit.
-func CanDefragSkip(pCtx context.Context, client etcdClient.MaintenanceCloser, etcdConnectionConfig *brtypes.EtcdConnectionConfig, defragCfg *brtypes.DefragConfig) (bool, error) {
+func CanSkipDefrag(pCtx context.Context, client etcdClient.MaintenanceCloser, etcdConnectionConfig *brtypes.EtcdConnectionConfig, defragCfg *brtypes.DefragConfig) (bool, error) {
 	ctx, cancel := context.WithTimeout(pCtx, etcdConnectionConfig.ConnectionTimeout.Duration)
 	defer cancel()
 

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -43,6 +43,7 @@ const (
 var _ = Describe("Miscellaneous Tests", func() {
 	var (
 		etcdConnectionConfig *brtypes.EtcdConnectionConfig
+		defragConfig         *brtypes.DefragConfig
 		ctrl                 *gomock.Controller
 		factory              *mockfactory.MockFactory
 		cm                   *mockfactory.MockMaintenanceCloser
@@ -51,10 +52,10 @@ var _ = Describe("Miscellaneous Tests", func() {
 
 	BeforeEach(func() {
 		etcdConnectionConfig = brtypes.NewEtcdConnectionConfig()
+		defragConfig = brtypes.NewDefragConfig()
 		etcdConnectionConfig.Endpoints = []string{"http://127.0.0.1:2379"}
 		etcdConnectionConfig.ConnectionTimeout.Duration = 30 * time.Second
 		etcdConnectionConfig.SnapshotTimeout.Duration = 30 * time.Second
-		etcdConnectionConfig.DefragTimeout.Duration = 30 * time.Second
 
 		ctrl = gomock.NewController(GinkgoT())
 		factory = mockfactory.NewMockFactory(ctrl)
@@ -1086,7 +1087,7 @@ initial-cluster: etcd1=http://0.0.0.0:2380`
 				return response, nil
 			}).Times(1)
 
-			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig)
+			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
 			Expect(err).Should(BeNil())
 			Expect(canSkip).Should(BeFalse())
 		})
@@ -1102,7 +1103,7 @@ initial-cluster: etcd1=http://0.0.0.0:2380`
 				return response, nil
 			}).Times(1)
 
-			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig)
+			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
 			Expect(err).Should(BeNil())
 			Expect(canSkip).Should(BeFalse())
 		})
@@ -1118,7 +1119,7 @@ initial-cluster: etcd1=http://0.0.0.0:2380`
 				return response, nil
 			}).Times(1)
 
-			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig)
+			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
 			Expect(err).Should(BeNil())
 			Expect(canSkip).Should(BeTrue())
 		})
@@ -1129,7 +1130,7 @@ initial-cluster: etcd1=http://0.0.0.0:2380`
 
 			cm.EXPECT().Status(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("failed to connect to the dummy etcd")).AnyTimes()
 
-			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig)
+			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
 			Expect(err).ShouldNot(BeNil())
 			Expect(canSkip).Should(BeFalse())
 		})

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -1071,6 +1071,69 @@ initial-cluster: etcd1=http://0.0.0.0:2380`
 			})
 		})
 	})
+
+	Describe("Can Defragmentation be skipped", func() {
+		BeforeEach(func() {
+			factory.EXPECT().NewMaintenance().Return(cm, nil).AnyTimes()
+		})
+		It("should return false when TotalDBSize is greater than threshold", func() {
+			clientMaintenance, err := factory.NewMaintenance()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
+				response := new(clientv3.StatusResponse)
+				response.DbSize = 4 * 1024 * 1024 * 1024 // 4GB
+				return response, nil
+			}).Times(1)
+
+			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig)
+			Expect(err).Should(BeNil())
+			Expect(canSkip).Should(BeFalse())
+		})
+
+		It("should return false when available free space is greater than threshold", func() {
+			clientMaintenance, err := factory.NewMaintenance()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
+				response := new(clientv3.StatusResponse)
+				response.DbSize = 2 * 1024 * 1024 * 1024 // 2GB
+				response.DbSizeInUse = 500 * 1024 * 1024 // 500MB
+				return response, nil
+			}).Times(1)
+
+			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig)
+			Expect(err).Should(BeNil())
+			Expect(canSkip).Should(BeFalse())
+		})
+
+		It("should return true when TotalDBSize and available free space are below threshold", func() {
+			clientMaintenance, err := factory.NewMaintenance()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
+				response := new(clientv3.StatusResponse)
+				response.DbSize = 1 * 1024 * 1024 * 1024 // 1GB
+				response.DbSizeInUse = 500 * 1024 * 1024 // 500MB
+				return response, nil
+			}).Times(1)
+
+			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig)
+			Expect(err).Should(BeNil())
+			Expect(canSkip).Should(BeTrue())
+		})
+
+		It("should return false with error", func() {
+			clientMaintenance, err := factory.NewMaintenance()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			cm.EXPECT().Status(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("failed to connect to the dummy etcd")).AnyTimes()
+
+			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig)
+			Expect(err).ShouldNot(BeNil())
+			Expect(canSkip).Should(BeFalse())
+		})
+	})
 })
 
 func emptyStatefulSet(name, namespace string) *appsv1.StatefulSet {

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -43,7 +43,6 @@ const (
 var _ = Describe("Miscellaneous Tests", func() {
 	var (
 		etcdConnectionConfig *brtypes.EtcdConnectionConfig
-		defragConfig         *brtypes.DefragConfig
 		ctrl                 *gomock.Controller
 		factory              *mockfactory.MockFactory
 		cm                   *mockfactory.MockMaintenanceCloser
@@ -52,7 +51,6 @@ var _ = Describe("Miscellaneous Tests", func() {
 
 	BeforeEach(func() {
 		etcdConnectionConfig = brtypes.NewEtcdConnectionConfig()
-		defragConfig = brtypes.NewDefragConfig()
 		etcdConnectionConfig.Endpoints = []string{"http://127.0.0.1:2379"}
 		etcdConnectionConfig.ConnectionTimeout.Duration = 30 * time.Second
 		etcdConnectionConfig.SnapshotTimeout.Duration = 30 * time.Second
@@ -1070,69 +1068,6 @@ initial-cluster: etcd1=http://0.0.0.0:2380`
 					Expect(err).To(HaveOccurred())
 				})
 			})
-		})
-	})
-
-	Describe("Can Defragmentation be skipped", func() {
-		BeforeEach(func() {
-			factory.EXPECT().NewMaintenance().Return(cm, nil).AnyTimes()
-		})
-		It("should return false when TotalDBSize is greater than threshold", func() {
-			clientMaintenance, err := factory.NewMaintenance()
-			Expect(err).ShouldNot(HaveOccurred())
-
-			cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
-				response := new(clientv3.StatusResponse)
-				response.DbSize = 4 * 1024 * 1024 * 1024 // 4GB
-				return response, nil
-			}).Times(1)
-
-			canSkip, err := CanSkipDefrag(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
-			Expect(err).Should(BeNil())
-			Expect(canSkip).Should(BeFalse())
-		})
-
-		It("should return false when available free space is greater than threshold", func() {
-			clientMaintenance, err := factory.NewMaintenance()
-			Expect(err).ShouldNot(HaveOccurred())
-
-			cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
-				response := new(clientv3.StatusResponse)
-				response.DbSize = 2 * 1024 * 1024 * 1024 // 2GB
-				response.DbSizeInUse = 500 * 1024 * 1024 // 500MB
-				return response, nil
-			}).Times(1)
-
-			canSkip, err := CanSkipDefrag(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
-			Expect(err).Should(BeNil())
-			Expect(canSkip).Should(BeFalse())
-		})
-
-		It("should return true when TotalDBSize and available free space are below threshold", func() {
-			clientMaintenance, err := factory.NewMaintenance()
-			Expect(err).ShouldNot(HaveOccurred())
-
-			cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
-				response := new(clientv3.StatusResponse)
-				response.DbSize = 1 * 1024 * 1024 * 1024 // 1GB
-				response.DbSizeInUse = 500 * 1024 * 1024 // 500MB
-				return response, nil
-			}).Times(1)
-
-			canSkip, err := CanSkipDefrag(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
-			Expect(err).Should(BeNil())
-			Expect(canSkip).Should(BeTrue())
-		})
-
-		It("should return false with error", func() {
-			clientMaintenance, err := factory.NewMaintenance()
-			Expect(err).ShouldNot(HaveOccurred())
-
-			cm.EXPECT().Status(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("failed to connect to the dummy etcd")).AnyTimes()
-
-			canSkip, err := CanSkipDefrag(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
-			Expect(err).ShouldNot(BeNil())
-			Expect(canSkip).Should(BeFalse())
 		})
 	})
 })

--- a/pkg/miscellaneous/miscellaneous_test.go
+++ b/pkg/miscellaneous/miscellaneous_test.go
@@ -1087,7 +1087,7 @@ initial-cluster: etcd1=http://0.0.0.0:2380`
 				return response, nil
 			}).Times(1)
 
-			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
+			canSkip, err := CanSkipDefrag(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
 			Expect(err).Should(BeNil())
 			Expect(canSkip).Should(BeFalse())
 		})
@@ -1103,7 +1103,7 @@ initial-cluster: etcd1=http://0.0.0.0:2380`
 				return response, nil
 			}).Times(1)
 
-			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
+			canSkip, err := CanSkipDefrag(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
 			Expect(err).Should(BeNil())
 			Expect(canSkip).Should(BeFalse())
 		})
@@ -1119,7 +1119,7 @@ initial-cluster: etcd1=http://0.0.0.0:2380`
 				return response, nil
 			}).Times(1)
 
-			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
+			canSkip, err := CanSkipDefrag(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
 			Expect(err).Should(BeNil())
 			Expect(canSkip).Should(BeTrue())
 		})
@@ -1130,7 +1130,7 @@ initial-cluster: etcd1=http://0.0.0.0:2380`
 
 			cm.EXPECT().Status(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("failed to connect to the dummy etcd")).AnyTimes()
 
-			canSkip, err := CanDefragSkip(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
+			canSkip, err := CanSkipDefrag(context.Background(), clientMaintenance, etcdConnectionConfig, defragConfig)
 			Expect(err).ShouldNot(BeNil())
 			Expect(canSkip).Should(BeFalse())
 		})

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -51,7 +51,7 @@ var (
 // NewBackupRestoreServer return new backup restore server.
 func NewBackupRestoreServer(logger *logrus.Logger, config *BackupRestoreComponentConfig) (*BackupRestoreServer, error) {
 	serverLogger := logger.WithField("actor", "backup-restore-server")
-	defragmentationSchedule, err := cron.ParseStandard(config.DefragmentationSchedule)
+	defragmentationSchedule, err := cron.ParseStandard(config.DefragConfig.DefragmentationSchedule)
 	if err != nil {
 		// Ideally this case should not occur, since this check is done at the config validaitions.
 		return nil, err
@@ -262,7 +262,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 				go handleSsrStopRequest(leCtx, b.logger, ssrStopCh)
 			}
 			go b.runEtcdProbeLoopWithSnapshotter(leCtx, handler, ssr, ss, ssrStopCh)
-			go defragmentor.DefragDataPeriodically(leCtx, b.config.EtcdConnectionConfig, b.defragmentationSchedule, defragCallBack, b.logger)
+			go defragmentor.DefragDataPeriodically(leCtx, b.config.EtcdConnectionConfig, b.config.DefragConfig, b.defragmentationSchedule, defragCallBack, b.logger)
 		},
 		OnStoppedLeading: func() {
 			if runServerWithSnapshotter {

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -28,7 +28,6 @@ import (
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/robfig/cron/v3"
 	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -37,10 +36,9 @@ import (
 
 // BackupRestoreServer holds the details for backup-restore server.
 type BackupRestoreServer struct {
-	logger                  *logrus.Entry
-	config                  *BackupRestoreComponentConfig
-	defragmentationSchedule cron.Schedule
-	backoffConfig           *backoff.ExponentialBackoff
+	logger        *logrus.Entry
+	config        *BackupRestoreComponentConfig
+	backoffConfig *backoff.ExponentialBackoff
 }
 
 var (
@@ -51,18 +49,12 @@ var (
 // NewBackupRestoreServer return new backup restore server.
 func NewBackupRestoreServer(logger *logrus.Logger, config *BackupRestoreComponentConfig) (*BackupRestoreServer, error) {
 	serverLogger := logger.WithField("actor", "backup-restore-server")
-	defragmentationSchedule, err := cron.ParseStandard(config.DefragConfig.DefragmentationSchedule)
-	if err != nil {
-		// Ideally this case should not occur, since this check is done at the config validaitions.
-		return nil, err
-	}
 	exponentialBackoffConfig := backoff.NewExponentialBackOffConfig(config.ExponentialBackoffConfig.AttemptLimit, config.ExponentialBackoffConfig.Multiplier, config.ExponentialBackoffConfig.ThresholdTime.Duration)
 
 	return &BackupRestoreServer{
-		logger:                  serverLogger,
-		config:                  config,
-		defragmentationSchedule: defragmentationSchedule,
-		backoffConfig:           exponentialBackoffConfig,
+		logger:        serverLogger,
+		config:        config,
+		backoffConfig: exponentialBackoffConfig,
 	}, nil
 }
 
@@ -262,7 +254,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 				go handleSsrStopRequest(leCtx, b.logger, ssrStopCh)
 			}
 			go b.runEtcdProbeLoopWithSnapshotter(leCtx, handler, ssr, ss, ssrStopCh)
-			go defragmentor.DefragDataPeriodically(leCtx, b.config.EtcdConnectionConfig, b.config.DefragConfig, b.defragmentationSchedule, defragCallBack, b.logger)
+			go defragmentor.DefragDataPeriodically(leCtx, b.config.EtcdConnectionConfig, b.config.DefragConfig, defragCallBack, b.logger)
 		},
 		OnStoppedLeading: func() {
 			if runServerWithSnapshotter {

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 
-	"github.com/robfig/cron/v3"
 	flag "github.com/spf13/pflag"
 )
 
@@ -27,7 +26,7 @@ func NewBackupRestoreComponentConfig() *BackupRestoreComponentConfig {
 		SecondarySnapstoreConfig: snapstore.NewSecondarySnapstoreConfig(),
 		CompressionConfig:        compressor.NewCompressorConfig(),
 		RestorationConfig:        brtypes.NewRestorationConfig(),
-		DefragmentationSchedule:  defaultDefragmentationSchedule,
+		DefragConfig:             brtypes.NewDefragConfig(),
 		HealthConfig:             brtypes.NewHealthConfig(),
 		LeaderElectionConfig:     brtypes.NewLeaderElectionConfig(),
 		ExponentialBackoffConfig: brtypes.NewExponentialBackOffConfig(),
@@ -47,8 +46,7 @@ func (c *BackupRestoreComponentConfig) AddFlags(fs *flag.FlagSet) {
 	c.LeaderElectionConfig.AddFlags(fs)
 	c.ExponentialBackoffConfig.AddFlags(fs)
 	c.SecondarySnapstoreConfig.AddFlags(fs)
-	// Miscellaneous
-	fs.StringVar(&c.DefragmentationSchedule, "defragmentation-schedule", c.DefragmentationSchedule, "schedule to defragment etcd data directory")
+	c.DefragConfig.AddFlags(fs)
 	fs.BoolVar(&c.UseEtcdWrapper, "use-etcd-wrapper", c.UseEtcdWrapper, "to enable backup-restore to use etcd-wrapper related functionality. Note: enable this flag only if etcd-wrapper is deployed.")
 }
 
@@ -75,9 +73,6 @@ func (c *BackupRestoreComponentConfig) Validate() error {
 	if err := c.HealthConfig.Validate(); err != nil {
 		return err
 	}
-	if _, err := cron.ParseStandard(c.DefragmentationSchedule); err != nil {
-		return err
-	}
 	if err := c.LeaderElectionConfig.Validate(); err != nil {
 		return err
 	}
@@ -86,6 +81,10 @@ func (c *BackupRestoreComponentConfig) Validate() error {
 	}
 
 	if err := c.SecondarySnapstoreConfig.Validate(); err != nil {
+		return err
+	}
+
+	if err := c.DefragConfig.Validate(); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -28,7 +28,7 @@ type BackupRestoreComponentConfig struct {
 	HealthConfig             *brtypes.HealthConfig             `json:"healthConfig,omitempty"`
 	LeaderElectionConfig     *brtypes.Config                   `json:"leaderElectionConfig,omitempty"`
 	ExponentialBackoffConfig *brtypes.ExponentialBackoffConfig `json:"exponentialBackoffConfig,omitempty"`
-	DefragmentationSchedule  string                            `json:"defragmentationSchedule"`
+	DefragConfig             *brtypes.DefragConfig             `json:"defragConfig,omitempty"`
 	UseEtcdWrapper           bool                              `json:"useEtcdWrapper,omitempty"`
 }
 

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	defaultServerPort              = 8080
-	defaultDefragmentationSchedule = "0 0 */3 * *"
+	defaultServerPort = 8080
 	// to enable backup-restore to use etcd-wrapper related functionality.
 	usageOfEtcdWrapperEnabled = false
 )

--- a/pkg/types/defragmentation.go
+++ b/pkg/types/defragmentation.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gardener/etcd-backup-restore/pkg/wrappers"
+	"github.com/robfig/cron/v3"
+
+	flag "github.com/spf13/pflag"
+)
+
+const (
+	// DefaultDefragSchedule is the default cron schedule for defragmentation (midnight every 3 days).
+	DefaultDefragSchedule = "0 0 */3 * *"
+	// DefaultDefragConnectionTimeout defines default timeout duration for ETCD defrag call.
+	DefaultDefragConnectionTimeout time.Duration = 8 * time.Minute
+	// DefragRetryPeriod is used as the duration after which a defragmentation is retried.
+	DefragRetryPeriod time.Duration = 1 * time.Minute
+	// DefaultFreeSpaceThreshold is the minimum default free space above which schedule defragmentation is triggered.
+	DefaultFreeSpaceThreshold = 1 * 1024 * 1024 * 1024 // 1GB
+)
+
+// DefragConfig holds the configuration for etcd defragmentation.
+type DefragConfig struct {
+	// DefragmentationSchedule is the cron schedule on which defragmentation of etcd data directory is triggered.
+	DefragmentationSchedule string `json:"defragmentationSchedule"`
+	// DefragTimeout is the timeout for a single etcd's defragmentation API call.
+	DefragTimeout wrappers.Duration `json:"defragTimeout,omitempty"`
+	// FreespaceThreshold is the minimum free space above which schedule defragmentation is triggered.
+	FreespaceThreshold int64 `json:"freespaceThreshold,omitempty"`
+}
+
+// NewDefragConfig returns a DefragConfig with default values.
+func NewDefragConfig() *DefragConfig {
+	return &DefragConfig{
+		DefragmentationSchedule: DefaultDefragSchedule,
+		FreespaceThreshold:      DefaultFreeSpaceThreshold,
+		DefragTimeout:           wrappers.Duration{Duration: DefaultDefragConnectionTimeout},
+	}
+}
+
+// AddFlags adds defragmentation-related flags to the given flag set.
+func (c *DefragConfig) AddFlags(fs *flag.FlagSet) {
+	fs.Int64Var(&c.FreespaceThreshold, "freespace-threshold", c.FreespaceThreshold, "minimum free-space in database only above which schedule defragmentation is triggered.")
+	fs.StringVar(&c.DefragmentationSchedule, "defragmentation-schedule", c.DefragmentationSchedule, "cron schedule to defragment etcd data directory")
+	fs.DurationVar(&c.DefragTimeout.Duration, "etcd-defrag-timeout", c.DefragTimeout.Duration, "timeout duration for etcd defrag call")
+}
+
+// Validate validates the DefragConfig fields.
+func (c *DefragConfig) Validate() error {
+	if c.DefragTimeout.Duration <= 0 {
+		return fmt.Errorf("etcd defrag timeout should be greater than zero")
+	}
+	if _, err := cron.ParseStandard(c.DefragmentationSchedule); err != nil {
+		return err
+	}
+	if c.FreespaceThreshold <= 0 {
+		return fmt.Errorf("freespace-threshold for schedule defrag must be greater than 0")
+	}
+	return nil
+}

--- a/pkg/types/defragmentation.go
+++ b/pkg/types/defragmentation.go
@@ -57,7 +57,7 @@ func (c *DefragConfig) Validate() error {
 		return fmt.Errorf("etcd defrag timeout should be greater than zero")
 	}
 	if _, err := cron.ParseStandard(c.DefragmentationSchedule); err != nil {
-		return err
+		return fmt.Errorf("error while parsing defragmentation schedule: %w", err)
 	}
 	if c.FreespaceThreshold <= 0 {
 		return fmt.Errorf("freespace-threshold for schedule defrag must be greater than 0")

--- a/pkg/types/defragmentation.go
+++ b/pkg/types/defragmentation.go
@@ -17,7 +17,7 @@ import (
 const (
 	// DefaultDefragSchedule is the default cron schedule for defragmentation (midnight every 3 days).
 	DefaultDefragSchedule = "0 0 */3 * *"
-	// DefaultDefragConnectionTimeout defines default timeout duration for ETCD defrag call.
+	// DefaultDefragConnectionTimeout defines the default timeout duration for Etcd's defrag api call.
 	DefaultDefragConnectionTimeout time.Duration = 8 * time.Minute
 	// DefragRetryPeriod is used as the duration after which a defragmentation is retried.
 	DefragRetryPeriod time.Duration = 1 * time.Minute
@@ -48,7 +48,7 @@ func NewDefragConfig() *DefragConfig {
 func (c *DefragConfig) AddFlags(fs *flag.FlagSet) {
 	fs.Int64Var(&c.FreespaceThreshold, "freespace-threshold", c.FreespaceThreshold, "minimum free-space in database only above which schedule defragmentation is triggered.")
 	fs.StringVar(&c.DefragmentationSchedule, "defragmentation-schedule", c.DefragmentationSchedule, "cron schedule to defragment etcd data directory")
-	fs.DurationVar(&c.DefragTimeout.Duration, "etcd-defrag-timeout", c.DefragTimeout.Duration, "timeout duration for etcd defrag call")
+	fs.DurationVar(&c.DefragTimeout.Duration, "etcd-defrag-timeout", c.DefragTimeout.Duration, "timeout duration for etcd's api defrag call")
 }
 
 // Validate validates the DefragConfig fields.

--- a/pkg/types/etcdconnection.go
+++ b/pkg/types/etcdconnection.go
@@ -18,13 +18,8 @@ const (
 
 	// DefaultEtcdConnectionTimeout defines default timeout duration for etcd client connection.
 	DefaultEtcdConnectionTimeout time.Duration = 30 * time.Second
-	// DefaultDefragConnectionTimeout defines default timeout duration for ETCD defrag call.
-	DefaultDefragConnectionTimeout time.Duration = 8 * time.Minute
 	// DefaultSnapshotTimeout defines default timeout duration for taking FullSnapshot.
 	DefaultSnapshotTimeout time.Duration = 15 * time.Minute
-
-	// DefragRetryPeriod is used as the duration after which a defragmentation is retried.
-	DefragRetryPeriod time.Duration = 1 * time.Minute
 )
 
 // EtcdConnectionConfig holds the etcd connection config.
@@ -40,7 +35,6 @@ type EtcdConnectionConfig struct {
 	Endpoints          []string          `json:"endpoints"`
 	ConnectionTimeout  wrappers.Duration `json:"connectionTimeout,omitempty"`
 	SnapshotTimeout    wrappers.Duration `json:"snapshotTimeout,omitempty"`
-	DefragTimeout      wrappers.Duration `json:"defragTimeout,omitempty"`
 	MaxCallSendMsgSize int               `json:"maxCallSendMsgSize,omitempty"`
 	InsecureTransport  bool              `json:"insecureTransport,omitempty"`
 	InsecureSkipVerify bool              `json:"insecureSkipVerify,omitempty"`
@@ -52,7 +46,6 @@ func NewEtcdConnectionConfig() *EtcdConnectionConfig {
 		Endpoints:          []string{defaultEtcdConnectionEndpoint},
 		ConnectionTimeout:  wrappers.Duration{Duration: DefaultEtcdConnectionTimeout},
 		SnapshotTimeout:    wrappers.Duration{Duration: DefaultSnapshotTimeout},
-		DefragTimeout:      wrappers.Duration{Duration: DefaultDefragConnectionTimeout},
 		InsecureTransport:  true,
 		InsecureSkipVerify: false,
 	}
@@ -66,7 +59,6 @@ func (c *EtcdConnectionConfig) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.Password, "etcd-password", c.Password, "etcd server password, if one is required")
 	fs.DurationVar(&c.ConnectionTimeout.Duration, "etcd-connection-timeout", c.ConnectionTimeout.Duration, "etcd client connection timeout")
 	fs.DurationVar(&c.SnapshotTimeout.Duration, "etcd-snapshot-timeout", c.SnapshotTimeout.Duration, "timeout duration for taking etcd snapshots")
-	fs.DurationVar(&c.DefragTimeout.Duration, "etcd-defrag-timeout", c.DefragTimeout.Duration, "timeout duration for etcd defrag call")
 	fs.BoolVar(&c.InsecureTransport, "insecure-transport", c.InsecureTransport, "disable transport security for client connections")
 	fs.BoolVar(&c.InsecureSkipVerify, "insecure-skip-tls-verify", c.InsecureTransport, "skip server certificate verification")
 	fs.StringVar(&c.CertFile, "cert", c.CertFile, "identify secure client using this TLS certificate file")
@@ -84,9 +76,6 @@ func (c *EtcdConnectionConfig) Validate() error {
 	}
 	if c.SnapshotTimeout.Duration < c.ConnectionTimeout.Duration {
 		return fmt.Errorf("snapshot timeout should be greater than or equal to connection timeout")
-	}
-	if c.DefragTimeout.Duration <= 0 {
-		return fmt.Errorf("etcd defrag timeout should be greater than zero")
 	}
 	return nil
 }


### PR DESCRIPTION
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
This PR enchances the schedule defragmentation to run only if it's beneficial:
It checks whether defragmentation can be skipped for a given etcd cluster.
- Can't be skipped:  when either TotalDBSize or available free space is greater than threshold.
  1. If TotalDBSize > 3GB
  2. If FreeSpaceAvailable > 1GB (configurable via flag `--freespace-threshold` )
- Can be skipped: when the TotalDBSize and available free space are below threshold, meaning defragmentation would have little benefit.



This PR also introduce defragConfig for all defrag related configuration.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Please note `DefragThreshold (3GiB DB-size check)`  is still a hardcoded constant in `miscellaneous.go`, it will be addressed in this issue https://github.com/gardener/etcd-backup-restore/issues/556.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Schedule/cron etcd defragmentation can be auto skipped if TotalDBSize < 3GB and FreeSpaceAvailable < 1GB (configurable via CLI flag `--freespace-threshold` )
```
