### PR TITLE
Fix restoration failures + verification condition when full snapshot and next delta have overlapping events.

### DIFF
--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -508,26 +508,18 @@ func (r *Restorer) applyFirstDeltaSnapshot(clientKV client.KVCloser, snap *brtyp
 	}
 	lastRevision := resp.Header.Revision
 
-	if lastRevision == snap.LastRevision {
-		// there is no need to apply this fist delta snapshot
-		// as it's completely overlaps with full snapshot data.
+	// remove all events that are already present in the restored database as it can be at, or even beyond the first delta's LastRevision
+	newEvents := FilterEventsAfterRevision(events, lastRevision)
+	if len(newEvents) == 0 {
+		// there is nothing to apply.
 		// please refer: https://github.com/gardener/etcd-backup-restore/issues/844
-		r.logger.Infof("First delta snapshot %s found to be completely overlap with full snapshot with db revisions: %d", path.Join(snap.SnapDir, snap.SnapName), lastRevision)
-		r.logger.Info("Skipping this delta snapshot...")
+		r.logger.Infof("First delta snapshot %s completely overlaps with the full snapshot (db revision: %d); skipping it.", path.Join(snap.SnapDir, snap.SnapName), lastRevision)
 		return nil
-	}
-
-	var newRevisionIndex int
-	for index, event := range events {
-		if event.EtcdEvent.Kv.ModRevision > lastRevision {
-			newRevisionIndex = index
-			break
-		}
 	}
 
 	r.logger.Infof("Applying first delta snapshot %s", path.Join(snap.SnapDir, snap.SnapName))
 
-	return applyEventsToEtcd(clientKV, events[newRevisionIndex:])
+	return applyEventsToEtcd(clientKV, newEvents)
 }
 
 func persistRawDeltaSnapshot(rc io.ReadCloser, tempFilePath string) error {
@@ -548,8 +540,25 @@ func persistRawDeltaSnapshot(rc io.ReadCloser, tempFilePath string) error {
 	return rc.Close()
 }
 
+// FilterEventsAfterRevision returns the sub-slice of events whose ModRevision is
+// strictly greater than currentRev, events are ordered ascending by ModRevision, which is guaranteed as they are
+// collected in-order from an etcd watch (see snapshotter.handleDeltaWatchEvents).
+func FilterEventsAfterRevision(events []brtypes.Event, currentRev int64) []brtypes.Event {
+	for index, event := range events {
+		if event.EtcdEvent.Kv.ModRevision > currentRev {
+			return events[index:]
+		}
+	}
+	return nil
+}
+
 // applyEventsToEtcd performs operations in events sequentially.
 func applyEventsToEtcd(clientKV client.KVCloser, events []brtypes.Event) error {
+	// just a sanity check to avoid sending empty transaction at the end of the func which generally is a no-op but just to be on the safer side to avoid any revision bump in etcd.
+	if len(events) == 0 {
+		return nil
+	}
+
 	var (
 		lastRev int64
 		ops     = []clientv3.Op{}
@@ -587,8 +596,11 @@ func verifySnapshotRevision(clientKV client.KVCloser, snap *brtypes.Snapshot) er
 		return fmt.Errorf("failed to connect to etcd KV client: %v", err)
 	}
 	etcdRevision := getResponse.Header.GetRevision()
-	if snap.LastRevision != etcdRevision {
-		return fmt.Errorf("mismatched event revision while applying delta snapshot, expected %d but applied %d ", snap.LastRevision, etcdRevision)
+	// The embedded etcd's revision must be at least the snapshot's LastRevision. It can also be higher when the snapshot fully overlaps data already present in the restored database
+	// eg: a full snapshot whose recorded revision lagged the actual data it contained, so the first delta snapshot is entirely contained in the full snapshot.
+	// So if the etcdRevision is less than than the applied snapshot's LastRevision, it then indicates missing events and is treated as an error.
+	if etcdRevision < snap.LastRevision {
+		return fmt.Errorf("mismatched event revision while applying delta snapshot, expected at least %d but applied %d ", snap.LastRevision, etcdRevision)
 	}
 	return nil
 }

--- a/pkg/snapshot/restorer/restorer.go
+++ b/pkg/snapshot/restorer/restorer.go
@@ -243,10 +243,6 @@ func (r *Restorer) applyDeltaSnapshots(clientFactory client.Factory, endPoints [
 
 	embeddedEtcdQuotaBytes := float64(ro.Config.EmbeddedEtcdQuotaBytes)
 
-	if err := verifySnapshotRevision(clientKV, snapList[0]); err != nil {
-		return err
-	}
-
 	// no more delta snapshots available
 	if len(snapList) == 1 {
 		return nil
@@ -466,7 +462,22 @@ func (r *Restorer) applySnaps(clientKV client.KVCloser, clientMaintenance client
 
 // applyEventsAndVerify applies events from one snapshot to the embedded etcd and verifies the correctness of the sequence of snapshot applied.
 func applyEventsAndVerify(clientKV client.KVCloser, events []brtypes.Event, snap *brtypes.Snapshot) error {
-	if err := applyEventsToEtcd(clientKV, events); err != nil {
+	// A snapshot's events can overlap with revisions already present in the store (e.g. the full snapshot
+	// running ahead of its recorded revision, or consecutive delta snapshots overlapping), so drop the
+	// already-present events before applying, to avoid advancing the revision beyond the snapshot's last revision.
+	lastRevision, err := getLatestRevision(clientKV)
+	if err != nil {
+		return fmt.Errorf("failed to get etcd latest revision for delta snapshot %s : %v", snap.SnapName, err)
+	}
+	newEvents := FilterEventsAfterRevision(events, lastRevision)
+	if len(newEvents) == 0 {
+		// The delta snapshot completely overlaps with the existing revisions, so there is nothing to apply.
+		// We deliberately do not verify the revision here: since nothing was applied, the etcd revision is
+		// already at or beyond this snapshot's last revision, so the strict equality check would wrongly fail.
+		return nil
+	}
+
+	if err := applyEventsToEtcd(clientKV, newEvents); err != nil {
 		return fmt.Errorf("failed to apply events to etcd for delta snapshot %s : %v", snap.SnapName, err)
 	}
 
@@ -476,7 +487,7 @@ func applyEventsAndVerify(clientKV client.KVCloser, events []brtypes.Event, snap
 	return nil
 }
 
-// applyFirstDeltaSnapshot applies the events from first delta snapshot to etcd.
+// applyFirstDeltaSnapshot fetches the first delta snapshot from the store and applies its events to etcd.
 func (r *Restorer) applyFirstDeltaSnapshot(clientKV client.KVCloser, snap *brtypes.Snapshot) error {
 	r.logger.Infof("Applying first delta snapshot %s", path.Join(snap.SnapDir, snap.SnapName))
 
@@ -495,31 +506,12 @@ func (r *Restorer) applyFirstDeltaSnapshot(clientKV client.KVCloser, snap *brtyp
 		return fmt.Errorf("failed to unmarshal events data from delta snapshot %s : %v", snap.SnapName, err)
 	}
 
-	// Note: Since revision in full snapshot file name might be lower than actual revision stored in snapshot.
-	// This is because of issue referred below. So, as per workaround used in our logic of taking delta snapshot,
-	// the latest revision from full snapshot may overlap with first few revision on first delta snapshot
-	// Hence, we have to additionally take care of that.
-	// Refer: https://github.com/coreos/etcd/issues/9037
-	ctx, cancel := context.WithTimeout(context.TODO(), etcdConnectionTimeout)
-	defer cancel()
-	resp, err := clientKV.Get(ctx, "", clientv3.WithLastRev()...)
-	if err != nil {
-		return fmt.Errorf("failed to get etcd latest revision: %v", err)
-	}
-	lastRevision := resp.Header.Revision
-
-	// remove all events that are already present in the restored database as it can be at, or even beyond the first delta's LastRevision
-	newEvents := FilterEventsAfterRevision(events, lastRevision)
-	if len(newEvents) == 0 {
-		// there is nothing to apply.
-		// please refer: https://github.com/gardener/etcd-backup-restore/issues/844
-		r.logger.Infof("First delta snapshot %s completely overlaps with the full snapshot (db revision: %d); skipping it.", path.Join(snap.SnapDir, snap.SnapName), lastRevision)
-		return nil
-	}
-
-	r.logger.Infof("Applying first delta snapshot %s", path.Join(snap.SnapDir, snap.SnapName))
-
-	return applyEventsToEtcd(clientKV, newEvents)
+	// Note: The revision in the full snapshot file name might be lower than the actual revision stored in the
+	// snapshot (refer https://github.com/coreos/etcd/issues/9037), so the latest revision from the full snapshot
+	// may overlap with the first few revisions of the first delta snapshot. applyEventsAndVerify filters out these
+	// already-present events before applying, so the overlap (including a complete overlap, refer
+	// https://github.com/gardener/etcd-backup-restore/issues/844) is handled the same way as for subsequent deltas.
+	return applyEventsAndVerify(clientKV, events, snap)
 }
 
 func persistRawDeltaSnapshot(rc io.ReadCloser, tempFilePath string) error {
@@ -540,25 +532,40 @@ func persistRawDeltaSnapshot(rc io.ReadCloser, tempFilePath string) error {
 	return rc.Close()
 }
 
-// FilterEventsAfterRevision returns the sub-slice of events whose ModRevision is
-// strictly greater than currentRev, events are ordered ascending by ModRevision, which is guaranteed as they are
-// collected in-order from an etcd watch (see snapshotter.handleDeltaWatchEvents).
-func FilterEventsAfterRevision(events []brtypes.Event, currentRev int64) []brtypes.Event {
-	for index, event := range events {
-		if event.EtcdEvent.Kv.ModRevision > currentRev {
-			return events[index:]
+// getLatestRevision returns the current revision of the etcd store backing clientKV.
+func getLatestRevision(clientKV client.KVCloser) (int64, error) {
+	ctx, cancel := context.WithTimeout(context.TODO(), etcdConnectionTimeout)
+	defer cancel()
+	resp, err := clientKV.Get(ctx, "", clientv3.WithLastRev()...)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get etcd latest revision: %v", err)
+	}
+	return resp.Header.Revision, nil
+}
+
+// FilterEventsAfterRevision returns the sub-slice of events whose ModRevision is strictly greater
+// than lastRevision. The events are ordered ascending by ModRevision, which is guaranteed as they
+// are collected in-order from an etcd watch (see snapshotter.handleDeltaWatchEvents), so a binary
+// search suffices to locate the first such event. An empty slice is returned when every event is
+// already present in the store (i.e. at or below lastRevision).
+func FilterEventsAfterRevision(events []brtypes.Event, lastRevision int64) []brtypes.Event {
+	// finalIndex defaults to len(events) so that a full overlap yields an empty slice.
+	finalIndex := len(events)
+	leftIndex, rightIndex := 0, len(events)-1
+	for leftIndex <= rightIndex {
+		curIndex := leftIndex + (rightIndex-leftIndex)/2
+		if events[curIndex].EtcdEvent.Kv.ModRevision > lastRevision {
+			finalIndex = curIndex
+			rightIndex = curIndex - 1
+		} else {
+			leftIndex = curIndex + 1
 		}
 	}
-	return nil
+	return events[finalIndex:]
 }
 
 // applyEventsToEtcd performs operations in events sequentially.
 func applyEventsToEtcd(clientKV client.KVCloser, events []brtypes.Event) error {
-	// just a sanity check to avoid sending empty transaction at the end of the func which generally is a no-op but just to be on the safer side to avoid any revision bump in etcd.
-	if len(events) == 0 {
-		return nil
-	}
-
 	var (
 		lastRev int64
 		ops     = []clientv3.Op{}
@@ -596,11 +603,10 @@ func verifySnapshotRevision(clientKV client.KVCloser, snap *brtypes.Snapshot) er
 		return fmt.Errorf("failed to connect to etcd KV client: %v", err)
 	}
 	etcdRevision := getResponse.Header.GetRevision()
-	// The embedded etcd's revision must be at least the snapshot's LastRevision. It can also be higher when the snapshot fully overlaps data already present in the restored database
-	// eg: a full snapshot whose recorded revision lagged the actual data it contained, so the first delta snapshot is entirely contained in the full snapshot.
-	// So if the etcdRevision is less than than the applied snapshot's LastRevision, it then indicates missing events and is treated as an error.
-	if etcdRevision < snap.LastRevision {
-		return fmt.Errorf("mismatched event revision while applying delta snapshot, expected at least %d but applied %d ", snap.LastRevision, etcdRevision)
+	// This is only called after applying a non-empty set of non-overlapping events, so the etcd revision
+	// must land exactly on the snapshot's last revision. Any deviation indicates a wrong sequence of applied events.
+	if snap.LastRevision != etcdRevision {
+		return fmt.Errorf("mismatched event revision while applying delta snapshot, expected %d but applied %d ", snap.LastRevision, etcdRevision)
 	}
 	return nil
 }

--- a/pkg/snapshot/restorer/restorer_test.go
+++ b/pkg/snapshot/restorer/restorer_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gardener/etcd-backup-restore/test/utils"
 
 	"github.com/sirupsen/logrus"
+	"go.etcd.io/etcd/api/v3/mvccpb"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/mock/gomock"
@@ -1230,6 +1231,83 @@ var _ = Describe("Unit testing individual functions for restorer package", func(
 
 				err := ErrorArrayToError(errs)
 				Expect(err).Should(Equal(expectedErr))
+			})
+		})
+	})
+
+	Describe("testing FilterEventsAfterRevision", func() {
+		// makeEvents builds an ascending-by-ModRevision event slice from the given revisions.
+		makeEvents := func(revs ...int64) []brtypes.Event {
+			events := make([]brtypes.Event, 0, len(revs))
+			for _, rev := range revs {
+				events = append(events, brtypes.Event{
+					EtcdEvent: &clientv3.Event{
+						Type: mvccpb.PUT,
+						Kv:   &mvccpb.KeyValue{Key: []byte("k"), ModRevision: rev},
+					},
+				})
+			}
+			return events
+		}
+		modRevs := func(events []brtypes.Event) []int64 {
+			revs := make([]int64, 0, len(events))
+			for _, e := range events {
+				revs = append(revs, e.EtcdEvent.Kv.ModRevision)
+			}
+			return revs
+		}
+
+		Context("when no event overlaps (current revision below all events)", func() {
+			It("should return all events unchanged", func() {
+				events := makeEvents(101, 102, 103, 104)
+				filtered := FilterEventsAfterRevision(events, 100)
+				Expect(modRevs(filtered)).To(Equal([]int64{101, 102, 103, 104}))
+			})
+		})
+
+		Context("when the current revision partially overlaps the events", func() {
+			It("should drop the already-applied prefix and keep the rest", func() {
+				events := makeEvents(101, 102, 103, 104, 105)
+				filtered := FilterEventsAfterRevision(events, 103)
+				Expect(modRevs(filtered)).To(Equal([]int64{104, 105}))
+			})
+		})
+
+		Context("when an event's ModRevision equals the current revision", func() {
+			It("should skip that event (strictly greater only)", func() {
+				events := makeEvents(101, 102, 103)
+				filtered := FilterEventsAfterRevision(events, 102)
+				Expect(modRevs(filtered)).To(Equal([]int64{103}))
+			})
+		})
+
+		Context("when the current revision is at the last revision of the delta", func() {
+			It("should return no events", func() {
+				events := makeEvents(101, 102, 103, 104)
+				filtered := FilterEventsAfterRevision(events, 104)
+				Expect(filtered).To(BeEmpty())
+			})
+		})
+
+		Context("when the current revision is beyond the entire delta (full overlap)", func() {
+			It("should return no events", func() {
+				events := makeEvents(101, 102, 103, 104)
+				filtered := FilterEventsAfterRevision(events, 108)
+				Expect(filtered).To(BeEmpty())
+			})
+		})
+
+		Context("when the events slice is empty", func() {
+			It("should return no events", func() {
+				Expect(FilterEventsAfterRevision([]brtypes.Event{}, 100)).To(BeEmpty())
+			})
+		})
+
+		Context("when multiple events share the same ModRevision at the boundary", func() {
+			It("should cut at the first strictly-greater element", func() {
+				events := makeEvents(101, 102, 102, 103)
+				filtered := FilterEventsAfterRevision(events, 102)
+				Expect(modRevs(filtered)).To(Equal([]int64{103}))
 			})
 		})
 	})

--- a/pkg/snapshot/restorer/restorer_test.go
+++ b/pkg/snapshot/restorer/restorer_test.go
@@ -1250,6 +1250,9 @@ var _ = Describe("Unit testing individual functions for restorer package", func(
 			return events
 		}
 		modRevs := func(events []brtypes.Event) []int64 {
+			if len(events) == 0 {
+				return nil
+			}
 			revs := make([]int64, 0, len(events))
 			for _, e := range events {
 				revs = append(revs, e.EtcdEvent.Kv.ModRevision)
@@ -1257,57 +1260,50 @@ var _ = Describe("Unit testing individual functions for restorer package", func(
 			return revs
 		}
 
-		Context("when no event overlaps (current revision below all events)", func() {
-			It("should return all events unchanged", func() {
-				events := makeEvents(101, 102, 103, 104)
-				filtered := FilterEventsAfterRevision(events, 100)
-				Expect(modRevs(filtered)).To(Equal([]int64{101, 102, 103, 104}))
-			})
-		})
-
-		Context("when the current revision partially overlaps the events", func() {
-			It("should drop the already-applied prefix and keep the rest", func() {
-				events := makeEvents(101, 102, 103, 104, 105)
-				filtered := FilterEventsAfterRevision(events, 103)
-				Expect(modRevs(filtered)).To(Equal([]int64{104, 105}))
-			})
-		})
-
-		Context("when an event's ModRevision equals the current revision", func() {
-			It("should skip that event (strictly greater only)", func() {
-				events := makeEvents(101, 102, 103)
-				filtered := FilterEventsAfterRevision(events, 102)
-				Expect(modRevs(filtered)).To(Equal([]int64{103}))
-			})
-		})
-
-		Context("when the current revision is at the last revision of the delta", func() {
-			It("should return no events", func() {
-				events := makeEvents(101, 102, 103, 104)
-				filtered := FilterEventsAfterRevision(events, 104)
-				Expect(filtered).To(BeEmpty())
-			})
-		})
-
-		Context("when the current revision is beyond the entire delta (full overlap)", func() {
-			It("should return no events", func() {
-				events := makeEvents(101, 102, 103, 104)
-				filtered := FilterEventsAfterRevision(events, 108)
-				Expect(filtered).To(BeEmpty())
-			})
-		})
+		DescribeTable("should return only the events with ModRevision strictly greater than lastRevision",
+			func(eventRevs []int64, lastRevision int64, expectedRevs []int64) {
+				filtered := FilterEventsAfterRevision(makeEvents(eventRevs...), lastRevision)
+				Expect(modRevs(filtered)).To(Equal(expectedRevs))
+			},
+			// no overlap: lastRevision below every event, so all events are returned.
+			Entry("no overlap", []int64{101, 102, 103, 104}, int64(100), []int64{101, 102, 103, 104}),
+			// partial overlap: the already-applied prefix is dropped.
+			Entry("partial overlap", []int64{101, 102, 103, 104, 105}, int64(103), []int64{104, 105}),
+			// lastRevision equal to an event's ModRevision: that event is already applied and skipped (strictly greater only).
+			Entry("boundary equals an event", []int64{101, 102, 103}, int64(102), []int64{103}),
+			// lastRevision below the smallest event but not zero.
+			Entry("lastRevision just below first event", []int64{5, 6, 7}, int64(4), []int64{5, 6, 7}),
+			// lastRevision is zero: every real event (ModRevision >= 1) is returned.
+			Entry("zero lastRevision returns all", []int64{1, 2, 3}, int64(0), []int64{1, 2, 3}),
+			// only the last event qualifies.
+			Entry("only the last event qualifies", []int64{101, 102, 103, 104}, int64(103), []int64{104}),
+			// single event, below lastRevision.
+			Entry("single event below lastRevision", []int64{50}, int64(60), []int64(nil)),
+			// single event, equal to lastRevision.
+			Entry("single event equal to lastRevision", []int64{50}, int64(50), []int64(nil)),
+			// single event, above lastRevision.
+			Entry("single event above lastRevision", []int64{50}, int64(49), []int64{50}),
+			// two events, boundary between them.
+			Entry("two events boundary in the middle", []int64{10, 20}, int64(10), []int64{20}),
+			// larger list forcing multiple bisection steps, boundary in the middle.
+			Entry("large list boundary in the middle", []int64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}, int64(55), []int64{60, 70, 80, 90, 100}),
+			// duplicate ModRevisions straddling the boundary: cut before the first strictly-greater element.
+			Entry("duplicates straddling the boundary", []int64{101, 102, 102, 103}, int64(102), []int64{103}),
+			// duplicate ModRevisions all equal to lastRevision: nothing qualifies.
+			Entry("all events equal to lastRevision", []int64{7, 7, 7}, int64(7), []int64(nil)),
+			// full overlap: lastRevision beyond every event.
+			Entry("full overlap beyond the last event", []int64{101, 102, 103, 104}, int64(108), []int64(nil)),
+		)
 
 		Context("when the events slice is empty", func() {
-			It("should return no events", func() {
+			It("should return no events without panicking", func() {
 				Expect(FilterEventsAfterRevision([]brtypes.Event{}, 100)).To(BeEmpty())
 			})
 		})
 
-		Context("when multiple events share the same ModRevision at the boundary", func() {
-			It("should cut at the first strictly-greater element", func() {
-				events := makeEvents(101, 102, 102, 103)
-				filtered := FilterEventsAfterRevision(events, 102)
-				Expect(modRevs(filtered)).To(Equal([]int64{103}))
+		Context("when the events slice is nil", func() {
+			It("should return no events without panicking", func() {
+				Expect(FilterEventsAfterRevision(nil, 100)).To(BeEmpty())
 			})
 		})
 	})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area backup
/area robustness
/kind bug

**What this PR does / why we need it**:

This PR fixes a restoration failure issue that showed up during our regular compaction job occurrence which caught a particular issue where the applied revision on the etcd was coming out to be higher than the expected revision which caused failures in restoration.

The issue is also covered in the issue opened at #1044 , basically it's because of the non-atomicity between the get call that records the full snapshot's revision and the actual `Maintenance.Snapshot()` call that streams the db while taking a full snapshot, so by the time we note down the revision `R` , the snapshot db would have actually increased and streamed more events to the snapshot, so it might contain `R+k` revisions in actual but the full snapshot recorded revision in it's name contains only `R` like `Full-0-R-<timestamp>`. 

This PR also improves the verification of restoration by fixing an issue with error handling while restoring where currently the error is as shown below:

https://github.com/gardener/etcd-backup-restore/blob/debd95bd77352280dada2a9a94efa9d1d20bbb78/pkg/snapshot/restorer/restorer.go#L590-L592

But the problem with that is it expects the `etcdRevision/curRevision` of the etcd db to be always the same as the `LastRevision` of the most recently applied delta snapshot, if not, it throws a validation error to fail the restoration. But the verification needs to be improved because the following revisions are possible:

Snapshotting
  ════════════

    full            in store  →  Full-0-R-T₀
    ●───────────────●                 (recorded end revision = R)
    0            R + K  ← actual db content reaches R+K, but only R is recorded


    Delta-1 (D₁)    in store  →  Incr-(R+1)-R₁-T₁
    ●───────────────●                 no. of events = R₁ - R
    R+1            R₁


    Delta-2 (D₂)    in store  →  Incr-(R₁+1)-R₂-T₂
    ●───────────────●                 no. of events = R₂ - R₁
    R₁+1           R₂


  Restoring
  ═════════

    ①  ← full      →  rev = R + K
    ②  ← Delta-1   →  rev = (R + K) + (no. of events in D₁)
                          = R̶ + K + R₁ - R̶
                          = R₁ + K
    ③  ← Delta-2   →  rev = (R₁ + K) + (no. of events in D₂)
                          = R̶₁ + K + R₂ - R̶₁
                          = R₂ + K      ← actual revision after restore

So in conclusion, the actual revision (R2+K) is always >= R2 ( as K>=0), meaning => `etcdRevision >= snap.LastRevision` always. If not, then that's an issue with the verification. The new verification reflects the decision from the above math.

**Which issue(s) this PR fixes**:
Fixes part of #1044 

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
fix a restoration failure & verification mechanism that could occur during restoration when the full snapshot's recorded revision lagged the actual data it contained, causing the first delta snapshot to be incorrectly re-applied and the revision verification to fail.
```
