### PR TITLE
Revert "Remove deprecated support for passing endpoint via credential secrets"

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-backup-secret.yaml
@@ -21,15 +21,30 @@ data:
   {{- if .Values.backup.s3.s3ForcePathStyle }}
   s3ForcePathStyle: {{ .Values.backup.s3.s3ForcePathStyle | b64enc}}
   {{- end }}
+  {{- if .Values.backup.s3.endpoint }}
+  endpoint: {{ .Values.backup.s3.endpoint | b64enc }}
+  {{- end }}
 {{- else if eq .Values.backup.storageProvider "ABS" }}
   storageAccount: {{ .Values.backup.abs.storageAccount | b64enc }}
   storageKey : {{ .Values.backup.abs.storageKey | b64enc }}
+  {{- if .Values.backup.abs.emulatorEnabled }}
+  emulatorEnabled: {{ .Values.backup.abs.emulatorEnabled | b64enc}}
+  {{- end }}
+  {{- if .Values.backup.abs.domain }}
+  domain: {{ .Values.backup.abs.domain | b64enc}}
+  {{- end }}
 {{- else if eq .Values.backup.storageProvider "GCS" }}
   {{- if .Values.backup.tokenAuth.enabled }}
   credentialsConfig: {{ include "gcs.credentialsConfig" . | fromYaml | toJson | b64enc }}
   projectID: {{ .Values.backup.gcs.projectID }}
   {{- else }}
   serviceaccount.json : {{ .Values.backup.gcs.serviceAccountJson | b64enc }}
+  {{- end }}
+  {{- if .Values.backup.gcs.storageAPIEndpoint }}
+  storageAPIEndpoint: {{ .Values.backup.gcs.storageAPIEndpoint | b64enc}}
+  {{- end }}
+  {{- if .Values.backup.gcs.emulatorEnabled }}
+  emulatorEnabled: {{ .Values.backup.gcs.emulatorEnabled | b64enc}}
   {{- end }}
 {{- else if eq .Values.backup.storageProvider "Swift" }}
   authURL: {{ .Values.backup.swift.authURL | b64enc }}

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -211,6 +211,14 @@ spec:
   {{- if eq .Values.backup.storageProvider "S3" }}
         - name: "AWS_APPLICATION_CREDENTIALS"
           value: "/var/etcd-backup"
+    {{- if .Values.backup.s3.endpoint }}
+        - name: "AWS_ENDPOINT_URL_S3"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-etcd-backup
+              key: "endpoint"
+              optional: true
+    {{- end }}
   {{- else if eq .Values.backup.storageProvider "ABS" }}
         - name: "AZURE_APPLICATION_CREDENTIALS"
           value: "/var/etcd-backup"

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -107,6 +107,7 @@ backup:
   #   region: region-where-bucket-exists
   #   secretAccessKey: secret-access-key-with-object-storage-privileges
   #   accessKeyID: access-key-id-with-route53-privileges
+  #   endpoint: endpoint-override-for-s3 # optional
   #   s3ForcePathStyle: "true" # optional
   #   sseCustomerKey: aes-256-sse-customer-key # optional
   #   sseCustomerAlgorithm: aes-256-sse-customer-algorithm # optional
@@ -121,9 +122,13 @@ backup:
   #     token_url: "https://sts.googleapis.com/v1/token"
   #     service_account_impersonation_url: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/<service_account_email>:generateAccessToken" # optional
   #   projectID: project
+  #   storageAPIEndpoint: endpoint-override-for-storage-api # optional
+  #   emulatorEnabled: boolean-flag-to-configure-etcdbr-to-use-gcs-emulator # optional
   # abs:
   #   storageAccount: storage-account-with-object-storage-privileges
   #   storageKey: storage-key-with-object-storage-privileges
+  #   domain: non-default-domain-for-object-storage-service # optional
+  #   emulatorEnabled: boolean-float-to-enable-e2e-tests-to-use-azure-emulator # optional
   # swift:
   #   authURL: identity-server-url
   #   domainName: domain-name

--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/sirupsen/logrus"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -88,9 +89,10 @@ type ABSSnapStore struct {
 }
 
 type absCredentials struct {
-	BucketName     string `json:"bucketName"`
-	StorageAccount string `json:"storageAccount"`
-	StorageKey     string `json:"storageKey"`
+	Domain         *string `json:"domain,omitempty"`
+	BucketName     string  `json:"bucketName"`
+	StorageAccount string  `json:"storageAccount"`
+	StorageKey     string  `json:"storageKey"`
 }
 
 // NewABSSnapStore creates a new ABSSnapStore using a shared configuration and a specified bucket
@@ -106,9 +108,15 @@ func NewABSSnapStore(config *brtypes.SnapstoreConfig) (*ABSSnapStore, error) {
 	}
 
 	// Construct the ABS Container endpoint.
-	containerURL := fmt.Sprintf("https://%s.%s/%s", absCreds.StorageAccount, brtypes.AzureBlobStorageGlobalDomain, config.Container)
+	// TODO: @renormalize support for passing Domain through the credential file must be removed in v0.42.0.
+	domain := brtypes.AzureBlobStorageGlobalDomain
+	if absCreds.Domain != nil {
+		logrus.Warnf("Passing endpoint override through the credential file is now deprecated. Please use the `--store-endpoint-override` flag instead.")
+		domain = *absCreds.Domain
+	}
+	containerURL := fmt.Sprintf("https://%s.%s/%s", absCreds.StorageAccount, domain, config.Container)
 
-	// endpoint override specified as a CLI flag takes precedence over the default.
+	// endpoint override specified as a CLI flag takes precedence over configuration passed in the credential file.
 	if config.EndpointOverride != "" {
 		containerURL, err = url.JoinPath(config.EndpointOverride, config.Container)
 		if err != nil {
@@ -216,6 +224,12 @@ func readABSCredentialFiles(dirname string) (*absCredentials, error) {
 				return nil, err
 			}
 			absConfig.StorageKey = string(data)
+		} else if file.Name() == "domain" {
+			data, err := os.ReadFile(path.Join(dirname, file.Name())) // #nosec G304 -- this is a trusted file, obtained via mounted secret.
+			if err != nil {
+				return nil, err
+			}
+			absConfig.Domain = ptr.To(string(data))
 		}
 	}
 

--- a/pkg/snapstore/abs_snapstore.go
+++ b/pkg/snapstore/abs_snapstore.go
@@ -108,7 +108,7 @@ func NewABSSnapStore(config *brtypes.SnapstoreConfig) (*ABSSnapStore, error) {
 	}
 
 	// Construct the ABS Container endpoint.
-	// TODO: @renormalize support for passing Domain through the credential file must be removed in v0.42.0.
+	// TODO: @renormalize support for passing Domain through the credential file must be removed.
 	domain := brtypes.AzureBlobStorageGlobalDomain
 	if absCreds.Domain != nil {
 		logrus.Warnf("Passing endpoint override through the credential file is now deprecated. Please use the `--store-endpoint-override` flag instead.")

--- a/pkg/snapstore/gcs_snapstore.go
+++ b/pkg/snapstore/gcs_snapstore.go
@@ -36,6 +36,7 @@ const (
 	envStoreCredentials          = "GOOGLE_APPLICATION_CREDENTIALS" // #nosec G101 -- This is not a hardcoded password, but only the environment variable to the credentials.
 	envSourceStoreCredentials    = "SOURCE_GOOGLE_APPLICATION_CREDENTIALS"
 	envGoogleStorageEmulatorHost = "STORAGE_EMULATOR_HOST"
+	fileNameStorageAPIEndpoint   = "storageAPIEndpoint"
 	// serviceAccountCredentialType is the type of the credentials contained in the serviceaccount.json file.
 	serviceAccountCredentialType = "service_account"
 	// externalAccountCredentialType is the type of credentials contained in the credentialsConfig file.
@@ -82,8 +83,21 @@ func NewGCSSnapStore(config *brtypes.SnapstoreConfig) (*GCSSnapStore, error) {
 	if err := validateGCSCredential(config); err != nil {
 		return nil, err
 	}
+	// TODO: @renormalize support for passing Endpoint through the credential file must be removed in v0.42.0.
+	endpoint, err := getGCSStorageAPIEndpointFromFile(config)
+	if err != nil {
+		return nil, err
+	}
+	if endpoint != "" {
+		logrus.Warnf("Passing endpoint override through the credential file is now deprecated. Please use the `--store-endpoint-override` flag instead.")
+	}
 
-	opts, err := configureClientOptions(config, config.EndpointOverride)
+	// endpoint override specified as a CLI flag takes precedence over configuration passed in the credential file.
+	if config.EndpointOverride != "" {
+		endpoint = config.EndpointOverride
+	}
+
+	opts, err := configureClientOptions(config, endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure client options for GCS client with error: %w", err)
 	}
@@ -127,6 +141,22 @@ func configureClientOptions(config *brtypes.SnapstoreConfig, endpoint string) ([
 	}
 
 	return opts, nil
+}
+
+func getGCSStorageAPIEndpointFromFile(config *brtypes.SnapstoreConfig) (string, error) {
+	if gcsApplicationCredentialsPath, isSet := os.LookupEnv(getEnvPrefixString(config) + envStoreCredentials); isSet {
+		storageAPIEndpointFilePath := path.Join(path.Dir(gcsApplicationCredentialsPath), fileNameStorageAPIEndpoint)
+		if _, err := os.Stat(storageAPIEndpointFilePath); err != nil {
+			// if the file does not exist, then there is no override for the storage API endpoint
+			return "", nil
+		}
+		endpoint, err := os.ReadFile(storageAPIEndpointFilePath) // #nosec G304 -- this is a trusted file, obtained from mounted secret.
+		if err != nil {
+			return "", fmt.Errorf("error getting storage API endpoint from %v", storageAPIEndpointFilePath)
+		}
+		return string(endpoint), nil
+	}
+	return "", nil
 }
 
 // NewGCSSnapStoreFromClient create new GCSSnapStore from shared configuration with specified bucket.

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -210,7 +210,7 @@ func awsCredentialsFromConfig(awsConfig *awsCredentials) ([]func(*awsconfig.Load
 	}
 	cfgOpts = append(cfgOpts, awsconfig.WithCredentialsProvider(aws.NewCredentialsCache(credentialsProvider)))
 
-	// TODO: @renormalize support for passing Endpoint through the credential file must be removed in v0.42.0.
+	// TODO: @renormalize support for passing Endpoint through the credential file must be removed.
 	if awsConfig.Endpoint != nil {
 		logrus.Warnf("Passing endpoint override through the credential file is now deprecated. Please use the `--store-endpoint-override` flag instead.")
 		cfgOpts = append(cfgOpts, awsconfig.WithBaseEndpoint(*awsConfig.Endpoint))

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -50,7 +50,7 @@ const (
 type awsCredentials struct {
 	SSECustomerAlgorithm       *string `json:"sseCustomerAlgorithm,omitempty"`
 	SSECustomerKey             *string `json:"sseCustomerKey,omitempty"`
-
+	Endpoint                   *string `json:"endpoint,omitempty"`
 	S3ForcePathStyle           *bool   `json:"s3ForcePathStyle,omitempty"`
 	InsecureSkipVerify         *bool   `json:"insecureSkipVerify,omitempty"`
 	TrustedCaCert              *string `json:"trustedCaCert,omitempty"`
@@ -210,6 +210,12 @@ func awsCredentialsFromConfig(awsConfig *awsCredentials) ([]func(*awsconfig.Load
 	}
 	cfgOpts = append(cfgOpts, awsconfig.WithCredentialsProvider(aws.NewCredentialsCache(credentialsProvider)))
 
+	// TODO: @renormalize support for passing Endpoint through the credential file must be removed in v0.42.0.
+	if awsConfig.Endpoint != nil {
+		logrus.Warnf("Passing endpoint override through the credential file is now deprecated. Please use the `--store-endpoint-override` flag instead.")
+		cfgOpts = append(cfgOpts, awsconfig.WithBaseEndpoint(*awsConfig.Endpoint))
+	}
+
 	if awsConfig.S3ForcePathStyle != nil {
 		cliOpts = append(cliOpts, func(o *s3.Options) {
 			o.UsePathStyle = *awsConfig.S3ForcePathStyle
@@ -292,6 +298,12 @@ func readAWSCredentialFromDir(dirname string) (*awsCredentials, error) {
 				return nil, err
 			}
 			awsConfig.SecretAccessKey = string(data)
+		case "endpoint":
+			data, err := os.ReadFile(filepath.Join(dirname, "endpoint")) // #nosec G304 -- this is a trusted file, obtained via user input.
+			if err != nil {
+				return nil, err
+			}
+			awsConfig.Endpoint = ptr.To(string(data))
 		case "s3ForcePathStyle":
 			data, err := os.ReadFile(filepath.Join(dirname, "s3ForcePathStyle")) // #nosec G304 -- this is a trusted file, obtained via user input.
 			if err != nil {


### PR DESCRIPTION
Reverts gardener/etcd-backup-restore#1000

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
REVERTED: Removed deprecated support for passing storage endpoint via credential secrets for AWS, GCP & Azure. Users must now use the [--store-endpoint-override](https://github.com/gardener/etcd-backup-restore/blob/36243e6fca29ac92342cd5ce92f67462b6e57c06/docs/deployment/getting_started.md?plain=1#L21) flag for custom endpoints (emulators, S3-compatible providers, regional endpoints). The following credential secret fields are no longer supported: `endpoint` (S3), `domain`/`emulatorEnabled` (Azure), `storageAPIEndpoint`/`emulatorEnabled` (GCS).
```
