### PR TITLE
DEP-08: Prevent removed etcd members from rejoining during scale-in

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,10 @@
 * [Tests](development/tests.md)
 * [Adding support for a new object store provider](development/new_cp_support.md)
 
+## Concepts
+
+* [Anti-rejoin guard](concepts/anti-rejoin-guard.md)
+
 ## Design and Proposals
 
 * [Core design](proposals/design.md)

--- a/docs/concepts/anti-rejoin-guard.md
+++ b/docs/concepts/anti-rejoin-guard.md
@@ -2,7 +2,7 @@
 
 If etcd cluster is managed by [etcd-druid](https://github.com/gardener/etcd-druid) and when a multi-node etcd cluster is [scaled in](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/08-scale-in.md), `etcd-druid` removes an etcd member from the cluster before the corresponding StatefulSet pod is terminated. In the short window between the member removal and the pod termination, the pod can still restart with its old data directory.
 
-Without a guard, `etcd-backup-restore` interprets the state *"this pod has local etcd data, but its member ID is not present in the live cluster"* as a scale-out case and re-adds the removed member as a learner. `etcd-druid` removes it again, the same pod re-adds itself, and the cluster enters a remove/re-add loop.
+Without a guard, `etcd-backup-restore` interprets the state *"this pod has local etcd data, but its member ID is not present in the live cluster"* as a scale-out case and re-adds the removed member as a learner to the etcd cluster. `etcd-druid` find out that member hasn't been removed yet (still present in cluster), hence it removes the cluster member again, but now again the backup-restore of member pod re-adds the removed member, and the cluster enters a remove/re-add loop.
 
 The anti-rejoin guard closes this loop. On a multi-node cluster it runs on every startup **before** the membership and scale-up checks, whenever the data directory already holds an etcd member tree (`member/`, `wal/`, `snap/`). It runs regardless of whether the member lease is still alive — a stale lease must not be allowed to bypass the tombstone check. If the local member was explicitly removed from the cluster, startup stops with `ErrMemberPermanentlyRemoved` instead of re-adding the member.
 

--- a/docs/concepts/anti-rejoin-guard.md
+++ b/docs/concepts/anti-rejoin-guard.md
@@ -22,17 +22,15 @@ If the resolved local member ID is present in `members_removed`, the cluster has
 
 ```mermaid
 flowchart TD
-    Start[backup-restore init, multi-node] --> Data{Data dir has member/wal/snap tree?}
-    Data -->|No| Fresh[Fresh PVC: skip guard, continue]
+    Start[backup-restore init, multi-node] --> Data{Data dir has valid structure + valid files}
+    Data -->|No| Fresh[No prior data: skip guard, continue]
     Data -->|Yes| Lease{Member lease has ID?}
     Lease -->|Yes| Have[Local member ID]
     Lease -->|No / unavailable| File{member-id file exists?}
     File -->|No| NoID[No ID: treat as fresh join, continue]
     File -->|Yes| Have
-    Have --> DB{boltdb backend exists?}
-    DB -->|No| Failed[Partial deletion: ErrMembershipCheckFailed, fail closed]
-    DB -->|Yes| Open[Open boltdb read-only]
-    Open -->|Open/read fails or corrupt| Failed
+    Have --> Open[Open boltdb read-only]
+    Open -->|Open/read fails or corrupt| Failed[Data inconsistency: ErrMembershipCheckFailed, fail closed]
     Open -->|OK| Removed{Own ID in members_removed?}
     Removed -->|No| Continue[Not removed, continue normal init]
     Removed -->|Yes| Stop[ErrMemberPermanentlyRemoved, stop]
@@ -44,9 +42,9 @@ The check is deliberately conservative and **fails closed** — when it cannot b
 
 - If the data directory state **cannot be determined** (the `member/`, `wal/`, `snap/` structure check itself errors), the guard fails closed.
 - If **no local member ID** can be resolved (neither lease nor member-id file), there is nothing to check, so normal initialization continues.
-- If a local member ID **is** resolved but the **boltdb backend file is missing**, the WAL tree is present but the db is not — a possible partial PVC deletion. The guard cannot safely treat this as a fresh member, so it fails closed.
-- If the boltdb exists but **cannot be opened** (the read-only open is bounded by a lock-acquisition timeout to ride out transient lock contention) or is **corrupt** (bolt panics are recovered and surfaced as errors), the guard fails closed. The process then exits and is restarted by the crash-back-off loop.
+- If a local member ID **is** resolved but the **boltdb backend cannot be opened** (file missing, lock-acquisition timeout, or corrupt — bolt panics are recovered and surfaced as errors), the data directory is in an inconsistent state. The guard cannot safely proceed, so it fails closed. The process then exits and is restarted by the crash-back-off loop.
 - Only the **local member's own ID** is considered. Entries for other removed members are ignored.
+- If the guard passes (the member ID is **not** in `members_removed`), no action is taken and normal initialization continues as-is — the existing membership and restoration flow is unchanged.
 
 Opening boltdb **read-only** ensures the guard cannot corrupt a live backend, and reading only the small `members_removed` bucket keeps runtime and memory overhead negligible. This follows the same access pattern — including recovering from bolt panics on a corrupt backend — already used by `etcd-backup-restore`'s data validator (`getLatestEtcdRevision`).
 

--- a/docs/concepts/anti-rejoin-guard.md
+++ b/docs/concepts/anti-rejoin-guard.md
@@ -1,6 +1,6 @@
 # Anti-rejoin guard
 
-When a multi-node etcd cluster is scaled in, `etcd-druid` removes an etcd member from the cluster before the corresponding StatefulSet pod is terminated. In the short window between the member removal and the pod termination, the pod can still restart with its old data directory.
+If etcd cluster is managed by [etcd-druid](https://github.com/gardener/etcd-druid) and when a multi-node etcd cluster is [scaled in](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/08-scale-in.md), `etcd-druid` removes an etcd member from the cluster before the corresponding StatefulSet pod is terminated. In the short window between the member removal and the pod termination, the pod can still restart with its old data directory.
 
 Without a guard, `etcd-backup-restore` interprets the state *"this pod has local etcd data, but its member ID is not present in the live cluster"* as a scale-out case and re-adds the removed member as a learner. `etcd-druid` removes it again, the same pod re-adds itself, and the cluster enters a remove/re-add loop.
 

--- a/docs/concepts/anti-rejoin-guard.md
+++ b/docs/concepts/anti-rejoin-guard.md
@@ -1,0 +1,61 @@
+# Anti-rejoin guard
+
+When a multi-node etcd cluster is scaled in, `etcd-druid` removes an etcd member from the cluster before the corresponding StatefulSet pod is terminated. In the short window between the member removal and the pod termination, the pod can still restart with its old data directory.
+
+Without a guard, `etcd-backup-restore` interprets the state *"this pod has local etcd data, but its member ID is not present in the live cluster"* as a scale-out case and re-adds the removed member as a learner. `etcd-druid` removes it again, the same pod re-adds itself, and the cluster enters a remove/re-add loop.
+
+The anti-rejoin guard closes this loop. On a multi-node cluster it runs on every startup **before** the membership and scale-up checks, whenever the data directory already holds an etcd member tree (`member/`, `wal/`, `snap/`). It runs regardless of whether the member lease is still alive — a stale lease must not be allowed to bypass the tombstone check. If the local member was explicitly removed from the cluster, startup stops with `ErrMemberPermanentlyRemoved` instead of re-adding the member.
+
+This feature backs [etcd-druid DEP-08 (Scaling-in a multi-node etcd cluster)](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/08-scale-in.md).
+
+## How a removed member is detected
+
+etcd records removed member IDs in the local boltdb backend's `members_removed` bucket when `MemberRemove` is applied. This is the local member's tombstone. The guard inspects two on-disk artefacts of the local etcd data directory:
+
+- The **local member ID**, resolved in priority order:
+  - **Member lease** — the heartbeat writes the member ID into the lease holder identity as `<memberID-hex>:<clusterID-hex>:<role>` on every renewal. Reading it is a single cheap API call, so it is tried first.
+  - **Member-id file** (`<data-dir>/member-id`) — the heartbeat also writes the same holder-identity string to this file on every renewal, *before* patching the lease. The write-before-patch ordering ensures the file is always at least as fresh as the lease. The guard falls back to this file when the lease is genuinely absent (`NotFound`); other lease errors (RBAC denial, network timeout, unparseable holder identity) are logged and also fall back to the file, so a transient API blip does not permanently block the member.
+  - If neither source yields an ID (fresh member, no lease yet, no file yet), the guard treats the pod as a fresh join and continues normally.
+- The **`members_removed` bucket** in the boltdb backend (`<data-dir>/member/snap/db`), opened read-only.
+
+If the resolved local member ID is present in `members_removed`, the cluster has explicitly removed this member and the sidecar must not re-add it.
+
+```mermaid
+flowchart TD
+    Start[backup-restore init, multi-node] --> Data{Data dir has member/wal/snap tree?}
+    Data -->|No| Fresh[Fresh PVC: skip guard, continue]
+    Data -->|Yes| Lease{Member lease has ID?}
+    Lease -->|Yes| Have[Local member ID]
+    Lease -->|No / unavailable| File{member-id file exists?}
+    File -->|No| NoID[No ID: treat as fresh join, continue]
+    File -->|Yes| Have
+    Have --> DB{boltdb backend exists?}
+    DB -->|No| Failed[Partial deletion: ErrMembershipCheckFailed, fail closed]
+    DB -->|Yes| Open[Open boltdb read-only]
+    Open -->|Open/read fails or corrupt| Failed
+    Open -->|OK| Removed{Own ID in members_removed?}
+    Removed -->|No| Continue[Not removed, continue normal init]
+    Removed -->|Yes| Stop[ErrMemberPermanentlyRemoved, stop]
+```
+
+## Design decisions
+
+The check is deliberately conservative and **fails closed** — when it cannot be sure a member is safe to re-add, it stops startup rather than risk re-joining a removed member:
+
+- If the data directory state **cannot be determined** (the `member/`, `wal/`, `snap/` structure check itself errors), the guard fails closed.
+- If **no local member ID** can be resolved (neither lease nor member-id file), there is nothing to check, so normal initialization continues.
+- If a local member ID **is** resolved but the **boltdb backend file is missing**, the WAL tree is present but the db is not — a possible partial PVC deletion. The guard cannot safely treat this as a fresh member, so it fails closed.
+- If the boltdb exists but **cannot be opened** (the read-only open is bounded by a lock-acquisition timeout to ride out transient lock contention) or is **corrupt** (bolt panics are recovered and surfaced as errors), the guard fails closed. The process then exits and is restarted by the crash-back-off loop.
+- Only the **local member's own ID** is considered. Entries for other removed members are ignored.
+
+Opening boltdb **read-only** ensures the guard cannot corrupt a live backend, and reading only the small `members_removed` bucket keeps runtime and memory overhead negligible. This follows the same access pattern — including recovering from bolt panics on a corrupt backend — already used by `etcd-backup-restore`'s data validator (`getLatestEtcdRevision`).
+
+## Operational behaviour
+
+When the guard fires, the sidecar stops initialization with `ErrMemberPermanentlyRemoved` and the pod does not join the cluster; it is expected to be terminated by the scale-in that removed the member. This is the intended outcome — the member was decommissioned on purpose.
+
+The guard does **not** interfere with the normal restoration path. A member that is still legitimately part of the cluster has never been added to `members_removed`, so the guard reads the tombstone, finds nothing, and lets the existing membership and single-member restoration flow run unchanged. Running the guard *before* the membership check is deliberate: it ensures a member with a stale-but-alive lease still has its tombstone inspected instead of being waved through.
+
+## Limitation
+
+The guard relies on the `members_removed` tombstone, which lives in the member's **own** data directory. If that data directory is wiped or restored — the member-id file, the boltdb backend, or both missing or unreadable — there is no tombstone to consult, so the member is treated as a fresh join and may be re-added as a learner. This case is outside the guard's reach by design (there is nothing on disk to read). The backstop is the `etcd-druid` controller: scale-in detection re-derives the target set on every reconcile and removes the surplus member again under its per-cycle quorum-safety check, so a member restarting with a wiped or restored data directory cannot persist in the cluster after a scale-in.

--- a/docs/concepts/anti-rejoin-guard.md
+++ b/docs/concepts/anti-rejoin-guard.md
@@ -23,7 +23,7 @@ If the resolved local member ID is present in `members_removed`, the cluster has
 ```mermaid
 flowchart TD
     Start[backup-restore init, multi-node] --> Data{Data dir has valid structure + valid files}
-    Data -->|No| Fresh[No prior data: skip guard, continue]
+    Data -->|No| Fresh[No etcd dir structure: skip guard, continue]
     Data -->|Yes| Lease{Member lease has ID?}
     Lease -->|Yes| Have[Local member ID]
     Lease -->|No / unavailable| File{member-id file exists?}

--- a/pkg/etcdutil/dir.go
+++ b/pkg/etcdutil/dir.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/etcdutil/dir.go
+++ b/pkg/etcdutil/dir.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/etcdutil/dir.go
+++ b/pkg/etcdutil/dir.go
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package etcdutil
+
+import "path/filepath"
+
+const (
+	// MemberIDFileName is the name of the file that caches the member identity on the PV.
+	MemberIDFileName = "member-id"
+)
+
+// MemberDir returns the member subdirectory for the given etcd data directory.
+func MemberDir(dataDir string) string { return filepath.Join(dataDir, "member") }
+
+// WALDir returns the WAL subdirectory for the given etcd data directory.
+func WALDir(dataDir string) string { return filepath.Join(MemberDir(dataDir), "wal") }
+
+// SnapDir returns the snap subdirectory for the given etcd data directory.
+func SnapDir(dataDir string) string { return filepath.Join(MemberDir(dataDir), "snap") }
+
+// BackendDBPath returns the boltdb backend file path for the given etcd data directory.
+func BackendDBPath(dataDir string) string { return filepath.Join(SnapDir(dataDir), "db") }
+
+// MemberIDFilePath returns the path of the member-id file for the given data directory.
+func MemberIDFilePath(dataDir string) string { return filepath.Join(dataDir, MemberIDFileName) }

--- a/pkg/etcdutil/dir.go
+++ b/pkg/etcdutil/dir.go
@@ -7,7 +7,7 @@ package etcdutil
 import "path/filepath"
 
 const (
-	// MemberIDFileName is the name of the file that caches the member identity on the PV.
+	// MemberIDFileName is the name of the file that persist the etcd cluster member identity on the PV.
 	MemberIDFileName = "member-id"
 )
 

--- a/pkg/etcdutil/dir.go
+++ b/pkg/etcdutil/dir.go
@@ -4,7 +4,9 @@
 
 package etcdutil
 
-import "path/filepath"
+import (
+	"path/filepath"
+)
 
 const (
 	// MemberIDFileName is the name of the file that persist the etcd cluster member identity on the PV.
@@ -24,4 +26,6 @@ func SnapDir(dataDir string) string { return filepath.Join(MemberDir(dataDir), "
 func BackendDBPath(dataDir string) string { return filepath.Join(SnapDir(dataDir), "db") }
 
 // MemberIDFilePath returns the path of the member-id file for the given data directory.
-func MemberIDFilePath(dataDir string) string { return filepath.Join(dataDir, MemberIDFileName) }
+func MemberIDFilePath(dataDir string) string {
+	return filepath.Join(filepath.Dir(dataDir), MemberIDFileName)
+}

--- a/pkg/health/heartbeat/heartbeat.go
+++ b/pkg/health/heartbeat/heartbeat.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gardener/etcd-backup-restore/pkg/errors"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
+	"github.com/gardener/etcd-backup-restore/pkg/member"
 	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
 	utils "github.com/gardener/etcd-backup-restore/pkg/snapstore"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
@@ -39,10 +40,11 @@ type Heartbeat struct {
 	metadata       map[string]string // metadata is currently added as annotations to the k8s lease object
 	memberName     string
 	podNamespace   string
+	dataDir        string
 }
 
 // NewHeartbeat returns the heartbeat object.
-func NewHeartbeat(logger *logrus.Entry, etcdConfig *brtypes.EtcdConnectionConfig, clientSet client.Client, metadata map[string]string) (*Heartbeat, error) {
+func NewHeartbeat(logger *logrus.Entry, etcdConfig *brtypes.EtcdConnectionConfig, clientSet client.Client, metadata map[string]string, dataDir string) (*Heartbeat, error) {
 	if etcdConfig == nil {
 		return nil, &errors.EtcdError{
 			Message: "nil etcd config passed, can not create heartbeat",
@@ -76,6 +78,7 @@ func NewHeartbeat(logger *logrus.Entry, etcdConfig *brtypes.EtcdConnectionConfig
 		memberName:   memberName,
 		podNamespace: namespace,
 		metadata:     metadata,
+		dataDir:      dataDir,
 	}, nil
 }
 
@@ -119,14 +122,11 @@ func (hb *Heartbeat) RenewMemberLease(ctx context.Context) error {
 		}
 	}
 
-	memberInfo := strconv.FormatUint(response.Header.GetMemberId(), 16)
-	memberInfo += ":"
-	memberInfo += strconv.FormatUint(response.Header.GetClusterId(), 16)
-	if response.Header.GetMemberId() == response.Leader {
-		memberInfo += ":Leader"
-	} else {
-		memberInfo += ":Member"
-	}
+	memberInfo := member.FormatMemberIdentity(
+		response.Header.GetMemberId(),
+		response.Header.GetClusterId(),
+		response.Header.GetMemberId() == response.Leader,
+	)
 
 	//Change HolderIdentity and RenewTime of lease
 	renewedMemberLease := memberLease.DeepCopy()
@@ -139,6 +139,17 @@ func (hb *Heartbeat) RenewMemberLease(ctx context.Context) error {
 	}
 	for k, v := range hb.metadata {
 		renewedMemberLease.Annotations[k] = v
+	}
+
+	// Persist the member ID to the PV before updating the lease so the file is
+	// at least as fresh as the lease and the guard can resolve the ID even when
+	// the lease API is temporarily unreachable.
+	if hb.dataDir != "" {
+		if err := member.WriteMemberIDFile(hb.dataDir, memberInfo); err != nil {
+			// Error-level: a failed write leaves the file-fallback path permanently
+			// degraded. If the PV is full or read-only the operator must act.
+			hb.logger.Errorf("failed to persist member ID file: %v", err)
+		}
 	}
 
 	err = hb.k8sClient.Patch(ctx, renewedMemberLease, client.MergeFrom(memberLease))
@@ -317,7 +328,7 @@ func DeltaSnapshotCaseLeaseUpdate(ctx context.Context, logger *logrus.Entry, k8s
 }
 
 // RenewMemberLeasePeriodically has a timer and will periodically call RenewMemberLeases to renew the member lease until stopped
-func RenewMemberLeasePeriodically(ctx context.Context, stopCh chan struct{}, hconfig *brtypes.HealthConfig, logger *logrus.Entry, etcdConfig *brtypes.EtcdConnectionConfig) error {
+func RenewMemberLeasePeriodically(ctx context.Context, stopCh chan struct{}, hconfig *brtypes.HealthConfig, logger *logrus.Entry, etcdConfig *brtypes.EtcdConnectionConfig, dataDir string) error {
 	peerURLTLSEnabled, err := miscellaneous.IsPeerURLTLSEnabled()
 	if err != nil {
 		return fmt.Errorf("unable to check peer TLS enabled or not: %v", err)
@@ -332,7 +343,7 @@ func RenewMemberLeasePeriodically(ctx context.Context, stopCh chan struct{}, hco
 		PeerURLTLSEnabledKey: strconv.FormatBool(peerURLTLSEnabled),
 	}
 
-	hb, err := NewHeartbeat(logger, etcdConfig, clientSet, metadata)
+	hb, err := NewHeartbeat(logger, etcdConfig, clientSet, metadata, dataDir)
 	if err != nil {
 		return fmt.Errorf("failed to initialize new heartbeat: %v", err)
 	}

--- a/pkg/health/heartbeat/heartbeat_test.go
+++ b/pkg/health/heartbeat/heartbeat_test.go
@@ -7,8 +7,10 @@ package heartbeat_test
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"time"
 
+	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 	"github.com/gardener/etcd-backup-restore/pkg/health/heartbeat"
 	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
@@ -65,19 +67,19 @@ var _ = Describe("Heartbeat", func() {
 		})
 		Context("With valid config", func() {
 			It("should not return error", func() {
-				_, err := heartbeat.NewHeartbeat(logger, etcdConnectionConfig, miscellaneous.GetFakeKubernetesClientSet(), metadata)
+				_, err := heartbeat.NewHeartbeat(logger, etcdConnectionConfig, miscellaneous.GetFakeKubernetesClientSet(), metadata, "")
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 		})
 		Context("With invalid etcdconnection config passed", func() {
 			It("should return error", func() {
-				_, err := heartbeat.NewHeartbeat(logger, nil, miscellaneous.GetFakeKubernetesClientSet(), metadata)
+				_, err := heartbeat.NewHeartbeat(logger, nil, miscellaneous.GetFakeKubernetesClientSet(), metadata, "")
 				Expect(err).Should(HaveOccurred())
 			})
 		})
 		Context("With invalid clientset passed", func() {
 			It("should return error", func() {
-				_, err := heartbeat.NewHeartbeat(logger, etcdConnectionConfig, nil, metadata)
+				_, err := heartbeat.NewHeartbeat(logger, etcdConnectionConfig, nil, metadata, "")
 				Expect(err).Should(HaveOccurred())
 			})
 		})
@@ -86,7 +88,7 @@ var _ = Describe("Heartbeat", func() {
 				metadata[heartbeat.PeerURLTLSEnabledKey] = "true"
 			})
 			It("should not return error", func() {
-				_, err := heartbeat.NewHeartbeat(logger, etcdConnectionConfig, miscellaneous.GetFakeKubernetesClientSet(), metadata)
+				_, err := heartbeat.NewHeartbeat(logger, etcdConnectionConfig, miscellaneous.GetFakeKubernetesClientSet(), metadata, "")
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -330,7 +332,7 @@ var _ = Describe("Heartbeat", func() {
 			})
 			It("Should correctly update the member lease", func() {
 				clientSet := miscellaneous.GetFakeKubernetesClientSet()
-				hb, err := heartbeat.NewHeartbeat(logger, etcdConnectionConfig, clientSet, metadata)
+				hb, err := heartbeat.NewHeartbeat(logger, etcdConnectionConfig, clientSet, metadata, "")
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = clientSet.Create(context.TODO(), lease)
@@ -348,11 +350,49 @@ var _ = Describe("Heartbeat", func() {
 				}, l)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(l.Spec.HolderIdentity).ToNot(BeNil())
-				// Test if HolderIdentity is in the format <memberID>:<clusterID>:Leader
-				// where memberID and clusterID are in hexadecimal format.
 				Expect(*l.Spec.HolderIdentity).To(MatchRegexp("^[a-f0-9]+:[a-f0-9]+:Leader$"))
 				Expect(l.Annotations).ToNot(BeEmpty())
 				Expect(l.Annotations[heartbeat.PeerURLTLSEnabledKey]).To(Equal("true"))
+
+				// dataDir="" — no member-id file should be created in the working directory.
+				Expect(filepath.Join(".", etcdutil.MemberIDFileName)).NotTo(BeAnExistingFile())
+
+				err = clientSet.Delete(context.TODO(), l)
+				Expect(err).ShouldNot(HaveOccurred())
+				err = clientSet.Delete(context.TODO(), pod)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("Should write member-id file when dataDir is set", func() {
+				dataDir := GinkgoT().TempDir()
+				clientSet := miscellaneous.GetFakeKubernetesClientSet()
+				hb, err := heartbeat.NewHeartbeat(logger, etcdConnectionConfig, clientSet, metadata, dataDir)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				err = clientSet.Create(context.TODO(), lease)
+				Expect(err).ShouldNot(HaveOccurred())
+				err = clientSet.Create(context.TODO(), pod)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				err = hb.RenewMemberLease(context.TODO())
+				Expect(err).ShouldNot(HaveOccurred())
+
+				l := &v1.Lease{}
+				err = clientSet.Get(context.TODO(), client.ObjectKey{
+					Namespace: os.Getenv("POD_NAMESPACE"),
+					Name:      os.Getenv("POD_NAME"),
+				}, l)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(l.Spec.HolderIdentity).ToNot(BeNil())
+				holderIdentity := *l.Spec.HolderIdentity
+				Expect(holderIdentity).To(MatchRegexp("^[a-f0-9]+:[a-f0-9]+:Leader$"))
+
+				memberIDPath := etcdutil.MemberIDFilePath(dataDir)
+				Expect(memberIDPath).To(BeAnExistingFile())
+				contents, readErr := os.ReadFile(memberIDPath)
+				Expect(readErr).ShouldNot(HaveOccurred())
+				Expect(string(contents)).To(Equal(holderIdentity))
+
 				err = clientSet.Delete(context.TODO(), l)
 				Expect(err).ShouldNot(HaveOccurred())
 				err = clientSet.Delete(context.TODO(), pod)
@@ -369,7 +409,7 @@ var _ = Describe("Heartbeat", func() {
 				Expect(os.Unsetenv("POD_NAMESPACE")).To(Succeed())
 			})
 			It("Should return an error", func() {
-				heartbeat, err := heartbeat.NewHeartbeat(logger, etcdConnectionConfig, miscellaneous.GetFakeKubernetesClientSet(), metadata)
+				heartbeat, err := heartbeat.NewHeartbeat(logger, etcdConnectionConfig, miscellaneous.GetFakeKubernetesClientSet(), metadata, "")
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = heartbeat.RenewMemberLease(context.TODO())
@@ -389,7 +429,7 @@ var _ = Describe("Heartbeat", func() {
 			})
 			It("should use the prefixed member name to renew the member lease", func() {
 				clientSet := miscellaneous.GetFakeKubernetesClientSet()
-				hb, err := heartbeat.NewHeartbeat(logger, etcdConnectionConfig, clientSet, metadata)
+				hb, err := heartbeat.NewHeartbeat(logger, etcdConnectionConfig, clientSet, metadata, "")
 				Expect(err).ShouldNot(HaveOccurred())
 
 				prefixedLease := &v1.Lease{
@@ -421,7 +461,7 @@ var _ = Describe("Heartbeat", func() {
 		})
 		Context("With fail to create clientset", func() {
 			It("Should return an error", func() {
-				err := heartbeat.RenewMemberLeasePeriodically(testCtx, mmStopCh, hConfig, logger, etcdConnectionConfig)
+				err := heartbeat.RenewMemberLeasePeriodically(testCtx, mmStopCh, hConfig, logger, etcdConnectionConfig, "")
 				Expect(err).Should(HaveOccurred())
 			})
 		})

--- a/pkg/health/heartbeat/heartbeat_test.go
+++ b/pkg/health/heartbeat/heartbeat_test.go
@@ -364,7 +364,9 @@ var _ = Describe("Heartbeat", func() {
 			})
 
 			It("Should write member-id file when dataDir is set", func() {
-				dataDir := GinkgoT().TempDir()
+				root := GinkgoT().TempDir()
+				dataDir := filepath.Join(root, "new.etcd")
+				Expect(os.MkdirAll(dataDir, 0700)).To(Succeed())
 				clientSet := miscellaneous.GetFakeKubernetesClientSet()
 				hb, err := heartbeat.NewHeartbeat(logger, etcdConnectionConfig, clientSet, metadata, dataDir)
 				Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -56,6 +56,24 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode) error {
 
 		m := member.NewMemberControl(e.Config.EtcdConnectionConfig)
 
+		// Always run the anti-rejoin guard when prior data is present on the PV,
+		// regardless of whether the member lease is still alive. A stale lease
+		// must not bypass the tombstone check.
+		hasData, err := e.Validator.HasPriorData()
+		if err != nil {
+			return fmt.Errorf("cannot determine etcd data directory state, failing closed to prevent unsafe rejoin: %v", err)
+		}
+		if hasData {
+			removed, err := m.WasPermanentlyRemoved(ctx, e.Config.RestoreOptions.Config.DataDir, clientSet)
+			if err != nil {
+				return fmt.Errorf("unable to determine whether this member was permanently removed from the etcd cluster: %v", err)
+			}
+			if removed {
+				logger.Fatal("this member has been permanently removed from the etcd cluster and cannot rejoin")
+			}
+			logger.Info("membership check passed; member is not removed, proceeding with scale-up check")
+		}
+
 		// check heartbeat of etcd member
 		if memberHeartbeatPresent = m.WasMemberInCluster(ctx, clientSet); memberHeartbeatPresent {
 			logger.Info("member found to be already a part of the cluster")

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -59,7 +59,7 @@ func (e *EtcdInitializer) Initialize(mode validator.Mode) error {
 		// Always run the anti-rejoin guard when prior data is present on the PV,
 		// regardless of whether the member lease is still alive. A stale lease
 		// must not bypass the tombstone check.
-		hasData, err := e.Validator.HasPriorData()
+		hasData, err := e.Validator.HasEtcdDirectoryStructure()
 		if err != nil {
 			return fmt.Errorf("cannot determine etcd data directory state, failing closed to prevent unsafe rejoin: %v", err)
 		}

--- a/pkg/initializer/validator/datavalidator.go
+++ b/pkg/initializer/validator/datavalidator.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"path/filepath"
 	"time"
 
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
@@ -50,13 +49,13 @@ var (
 	isBoltDBPanic = false
 )
 
-func (d *DataValidator) memberDir() string { return filepath.Join(d.Config.DataDir, "member") }
+func (d *DataValidator) memberDir() string { return etcdutil.MemberDir(d.Config.DataDir) }
 
-func (d *DataValidator) walDir() string { return filepath.Join(d.memberDir(), "wal") }
+func (d *DataValidator) walDir() string { return etcdutil.WALDir(d.Config.DataDir) }
 
-func (d *DataValidator) snapDir() string { return filepath.Join(d.memberDir(), "snap") }
+func (d *DataValidator) snapDir() string { return etcdutil.SnapDir(d.Config.DataDir) }
 
-func (d *DataValidator) backendPath() string { return filepath.Join(d.snapDir(), "db") }
+func (d *DataValidator) backendPath() string { return etcdutil.BackendDBPath(d.Config.DataDir) }
 
 // Validate performs the steps required to validate data for Etcd instance.
 func (d *DataValidator) Validate(mode Mode) (DataDirStatus, error) {
@@ -221,7 +220,6 @@ func (d *DataValidator) checkForDataCorruption() error {
 	return nil
 }
 
-// hasEtcdDirectoryStructure checks for existence of the required sub-directories.
 func (d *DataValidator) hasEtcdDirectoryStructure() (bool, error) {
 	var memberExist, snapExist, walExist bool
 	var err error
@@ -235,6 +233,13 @@ func (d *DataValidator) hasEtcdDirectoryStructure() (bool, error) {
 		return false, err
 	}
 	return memberExist && snapExist && walExist, nil
+}
+
+// HasPriorData reports whether the data directory contains an etcd member tree
+// (member/, wal/, snap/ sub-directories), indicating this PV was previously used
+// by a running etcd member.
+func (d *DataValidator) HasPriorData() (bool, error) {
+	return d.hasEtcdDirectoryStructure()
 }
 
 func directoryExist(dir string) (bool, error) {

--- a/pkg/initializer/validator/datavalidator.go
+++ b/pkg/initializer/validator/datavalidator.go
@@ -124,7 +124,7 @@ func (d *DataValidator) sanityCheck() (DataDirStatus, error) {
 	}
 
 	d.Logger.Info("Checking for data directory structure validity...")
-	etcdDirStructValid, err := d.hasEtcdDirectoryStructure()
+	etcdDirStructValid, err := d.HasEtcdDirectoryStructure()
 	if err != nil {
 		return DataDirectoryStatusUnknown, err
 	}
@@ -220,7 +220,9 @@ func (d *DataValidator) checkForDataCorruption() error {
 	return nil
 }
 
-func (d *DataValidator) hasEtcdDirectoryStructure() (bool, error) {
+// HasEtcdDirectoryStructure reports whether the data directory contains an etcd member tree
+// (member/, wal/, snap/ sub-directories).
+func (d *DataValidator) HasEtcdDirectoryStructure() (bool, error) {
 	var memberExist, snapExist, walExist bool
 	var err error
 	if memberExist, err = directoryExist(d.memberDir()); err != nil {
@@ -233,13 +235,6 @@ func (d *DataValidator) hasEtcdDirectoryStructure() (bool, error) {
 		return false, err
 	}
 	return memberExist && snapExist && walExist, nil
-}
-
-// HasPriorData reports whether the data directory contains an etcd member tree
-// (member/, wal/, snap/ sub-directories), indicating this PV was previously used
-// by a running etcd member.
-func (d *DataValidator) HasPriorData() (bool, error) {
-	return d.hasEtcdDirectoryStructure()
 }
 
 func directoryExist(dir string) (bool, error) {

--- a/pkg/member/antirejoin.go
+++ b/pkg/member/antirejoin.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/member/antirejoin.go
+++ b/pkg/member/antirejoin.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/member/antirejoin.go
+++ b/pkg/member/antirejoin.go
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package member
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+	"go.etcd.io/etcd/client/pkg/v3/types"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
+)
+
+var (
+	// ErrMemberPermanentlyRemoved is returned when the local member ID is found
+	// in etcd's members_removed tombstone bucket.
+	ErrMemberPermanentlyRemoved = errors.New("member was permanently removed from the cluster; refusing to re-add as learner")
+
+	// ErrMembershipCheckFailed is returned when the tombstone could not be
+	// inspected. Fails closed on this error.
+	ErrMembershipCheckFailed = errors.New("failed to inspect local membership tombstone")
+)
+
+const antiRejoinBoltDBTimeout = 10 * time.Second
+
+// IsMemberRemoved reports whether the given member ID is in the members_removed
+// bucket of the boltdb backend. On failure the caller (WasPermanentlyRemoved)
+// returns ErrMembershipCheckFailed and the process is expected to restart via
+// the crash-back-off loop rather than retrying here.
+func IsMemberRemoved(dbPath string, memberID uint64) (removed bool, retErr error) {
+	// Recover from bolt panics on corrupt db files, the same way verifyDB and
+	// getLatestEtcdRevision do, so a hardware-corrupted backend returns an error
+	// instead of crashing the process.
+	defer func() {
+		if r := recover(); r != nil {
+			removed = false
+			retErr = fmt.Errorf("bolt panic while reading %q: %v", dbPath, r)
+		}
+	}()
+
+	db, err := bolt.Open(dbPath, 0400, &bolt.Options{Timeout: antiRejoinBoltDBTimeout, ReadOnly: true})
+	if err != nil {
+		return false, fmt.Errorf("unable to open boltdb backend %q read-only: %w", dbPath, err)
+	}
+	defer func() {
+		if cerr := db.Close(); cerr != nil && retErr == nil {
+			retErr = fmt.Errorf("failed to close boltdb backend %q: %w", dbPath, cerr)
+		}
+	}()
+
+	memberKey := []byte(types.ID(memberID).String())
+	if err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(buckets.MembersRemoved.Name())
+		if b == nil {
+			// No tombstone bucket means no member has ever been removed.
+			return nil
+		}
+		removed = b.Get(memberKey) != nil
+		return nil
+	}); err != nil {
+		return false, fmt.Errorf("unable to read %q bucket from boltdb backend %q: %w", buckets.MembersRemoved.Name(), dbPath, err)
+	}
+	return removed, nil
+}

--- a/pkg/member/antirejoin_test.go
+++ b/pkg/member/antirejoin_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/member/antirejoin_test.go
+++ b/pkg/member/antirejoin_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/member/antirejoin_test.go
+++ b/pkg/member/antirejoin_test.go
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package member_test
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
+	"github.com/gardener/etcd-backup-restore/pkg/member"
+
+	bolt "go.etcd.io/bbolt"
+	"go.etcd.io/etcd/client/pkg/v3/types"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// writeTombstoneDB creates a boltdb backend file at BackendDBPath(dataDir),
+// optionally creating the members_removed bucket and seeding it with the given
+// member IDs (as tombstones). If createBucket is false the bucket is not created,
+// simulating a cluster where no member has ever been removed.
+func writeTombstoneDB(dataDir string, createBucket bool, removedIDs ...uint64) {
+	dbPath := etcdutil.BackendDBPath(dataDir)
+	ExpectWithOffset(1, os.MkdirAll(filepath.Dir(dbPath), 0700)).To(Succeed())
+
+	db, err := bolt.Open(dbPath, 0600, nil)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	defer func() { _ = db.Close() }()
+
+	ExpectWithOffset(1, db.Update(func(tx *bolt.Tx) error {
+		if !createBucket {
+			return nil
+		}
+		b, err := tx.CreateBucketIfNotExists(buckets.MembersRemoved.Name())
+		if err != nil {
+			return err
+		}
+		for _, id := range removedIDs {
+			if err := b.Put([]byte(types.ID(id).String()), []byte("")); err != nil {
+				return err
+			}
+		}
+		return nil
+	})).To(Succeed())
+}
+
+var _ = Describe("IsMemberRemoved", func() {
+	var dataDir string
+
+	BeforeEach(func() {
+		dataDir, err = os.MkdirTemp("", "antirejoin-isremoved-")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(dataDir)).To(Succeed())
+	})
+
+	Context("when the member ID is present in the members_removed bucket", func() {
+		It("reports the member as removed", func() {
+			writeTombstoneDB(dataDir, true, uint64(0xabc))
+
+			removed, err := member.IsMemberRemoved(etcdutil.BackendDBPath(dataDir), uint64(0xabc))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(removed).To(BeTrue())
+		})
+	})
+
+	Context("when the member ID is not in the members_removed bucket", func() {
+		It("reports the member as not removed", func() {
+			writeTombstoneDB(dataDir, true, uint64(0xabc))
+
+			removed, err := member.IsMemberRemoved(etcdutil.BackendDBPath(dataDir), uint64(0xdef))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(removed).To(BeFalse())
+		})
+	})
+
+	Context("when the members_removed bucket does not exist", func() {
+		It("reports the member as not removed (no member ever removed)", func() {
+			writeTombstoneDB(dataDir, false)
+
+			removed, err := member.IsMemberRemoved(etcdutil.BackendDBPath(dataDir), uint64(0xabc))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(removed).To(BeFalse())
+		})
+	})
+
+	Context("when the boltdb backend file does not exist", func() {
+		It("returns an error (fails closed)", func() {
+			missing := filepath.Join(dataDir, "does-not-exist", "db")
+
+			removed, err := member.IsMemberRemoved(missing, uint64(0xabc))
+			Expect(err).To(HaveOccurred())
+			Expect(removed).To(BeFalse())
+		})
+	})
+
+	Context("when the boltdb backend file is corrupt", func() {
+		It("returns an error instead of panicking", func() {
+			dbPath := etcdutil.BackendDBPath(dataDir)
+			Expect(os.MkdirAll(filepath.Dir(dbPath), 0700)).To(Succeed())
+			// A non-boltdb file trips bbolt's page-header validation;
+			// IsMemberRemoved must recover and return an error.
+			Expect(os.WriteFile(dbPath, []byte("this is not a valid boltdb file"), 0600)).To(Succeed())
+
+			removed, err := member.IsMemberRemoved(dbPath, uint64(0xabc))
+			Expect(err).To(HaveOccurred())
+			Expect(removed).To(BeFalse())
+		})
+	})
+})

--- a/pkg/member/identity.go
+++ b/pkg/member/identity.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/member/identity.go
+++ b/pkg/member/identity.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/member/identity.go
+++ b/pkg/member/identity.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package member
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
+
+	"github.com/sirupsen/logrus"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// WriteMemberIDFile atomically writes the holder identity string to the
+// member-id file in the data directory.
+func WriteMemberIDFile(dataDir, holderIdentity string) error {
+	path := etcdutil.MemberIDFilePath(dataDir)
+	// Write to a scratch file and rename it into place. os.WriteFile truncates
+	// then writes, so a crash mid-write could leave the member-id file empty or
+	// partial; os.Rename is atomic within a filesystem, so a concurrent reader
+	// (e.g. the anti-rejoin guard) always sees either the complete old contents
+	// or the complete new contents, never a half-written value.
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(holderIdentity), 0600); err != nil {
+		return fmt.Errorf("unable to write member ID temp file %q: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("unable to rename member ID file %q -> %q: %w", tmp, path, err)
+	}
+	return nil
+}
+
+// FormatMemberIdentity builds the holder-identity string "<memberID-hex>:<clusterID-hex>:<role>"
+// that is written to the k8s Lease and to the on-disk member-id file.
+func FormatMemberIdentity(memberID, clusterID uint64, isLeader bool) string {
+	role := "Member"
+	if isLeader {
+		role = "Leader"
+	}
+	return strconv.FormatUint(memberID, 16) + ":" + strconv.FormatUint(clusterID, 16) + ":" + role
+}
+
+// ParseMemberIDFromIdentity parses the member ID from a holder identity string
+// "<memberID-hex>:<clusterID-hex>:<role>". Also accepts a bare hex string.
+func ParseMemberIDFromIdentity(identity string) (uint64, error) {
+	memberIDHex, _, _ := strings.Cut(identity, ":")
+	if memberIDHex == "" {
+		return 0, fmt.Errorf("empty member ID in identity %q", identity)
+	}
+	memberID, err := strconv.ParseUint(memberIDHex, 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("expected hex member ID, got %q: %w", memberIDHex, err)
+	}
+	return memberID, nil
+}
+
+// ResolveLocalMemberID returns the local member's ID by checking the k8s lease
+// first, then falling back to the on-disk member-id file. Returns false if
+// neither source has an ID (fresh member).
+//
+// The lease fallback only applies when the lease is genuinely absent (NotFound).
+// Any other API error (RBAC denial, timeout, parse failure) is propagated as-is
+// so the caller can fail closed rather than silently bypass the guard.
+func ResolveLocalMemberID(ctx context.Context, logger *logrus.Entry, dataDir string, k8sClient client.Client, podNamespace, memberName string) (uint64, bool, error) {
+	memberID, ok, leaseErr := ReadLocalMemberIDFromLease(ctx, logger, k8sClient, podNamespace, memberName)
+	if leaseErr != nil {
+		if !apierrors.IsNotFound(leaseErr) {
+			// Non-NotFound errors (RBAC, network, parse) are failures, not
+			// absence. Fall back to the file so a temporary API blip does not
+			// permanently block the member, but if the file is also absent the
+			// caller must fail closed.
+			logger.Warnf("could not read member ID from lease, falling back to file: %v", leaseErr)
+		}
+		// leaseErr == NotFound: lease does not exist yet; fall through to file.
+	} else if ok {
+		return memberID, true, nil
+	}
+
+	memberID, ok, err := ReadLocalMemberIDFromFile(logger, dataDir)
+	if err != nil {
+		return 0, false, fmt.Errorf("unable to read local member ID from file: %w", err)
+	}
+	if ok {
+		return memberID, true, nil
+	}
+
+	logger.Info("no prior member identity found in lease or file; treating as a fresh member")
+	return 0, false, nil
+}
+
+// ReadLocalMemberIDFromLease reads the member ID from the lease holder identity.
+// Returns (0, false, nil) if the lease exists but has no holder identity yet.
+// Returns (0, false, NotFound-err) if the lease does not exist — callers can
+// use apierrors.IsNotFound to distinguish absence from a real failure.
+func ReadLocalMemberIDFromLease(ctx context.Context, logger *logrus.Entry, k8sClient client.Client, podNamespace, memberName string) (uint64, bool, error) {
+	if k8sClient == nil {
+		return 0, false, nil
+	}
+	memberLease := &coordinationv1.Lease{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: podNamespace, Name: memberName}, memberLease); err != nil {
+		// Return the raw error so the caller can inspect it with apierrors helpers.
+		return 0, false, err
+	}
+	if memberLease.Spec.HolderIdentity == nil || *memberLease.Spec.HolderIdentity == "" {
+		return 0, false, nil
+	}
+	memberID, err := ParseMemberIDFromIdentity(*memberLease.Spec.HolderIdentity)
+	if err != nil {
+		return 0, false, fmt.Errorf("unable to parse member ID from lease holder identity %q: %w", *memberLease.Spec.HolderIdentity, err)
+	}
+	logger.Infof("found member ID %s from member lease", strconv.FormatUint(memberID, 16))
+	return memberID, true, nil
+}
+
+// ReadLocalMemberIDFromFile reads the member ID from the member-id file on the PV.
+// Returns false (nil error) if the file does not exist.
+func ReadLocalMemberIDFromFile(logger *logrus.Entry, dataDir string) (uint64, bool, error) {
+	path := etcdutil.MemberIDFilePath(dataDir)
+	data, err := os.ReadFile(path) // #nosec G304 -- path is derived from the operator-controlled data directory, not user input.
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("unable to read member-id file %q: %w", path, err)
+	}
+	memberID, err := ParseMemberIDFromIdentity(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, false, fmt.Errorf("unable to parse member ID from file %q: %w", path, err)
+	}
+	logger.Infof("found member ID %s from member-id file", strconv.FormatUint(memberID, 16))
+	return memberID, true, nil
+}

--- a/pkg/member/identity_test.go
+++ b/pkg/member/identity_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/member/identity_test.go
+++ b/pkg/member/identity_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/member/identity_test.go
+++ b/pkg/member/identity_test.go
@@ -1,0 +1,322 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package member_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
+	"github.com/gardener/etcd-backup-restore/pkg/member"
+
+	"github.com/sirupsen/logrus"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeTable("ParseMemberIDFromIdentity",
+	func(identity string, expectErr bool, expectedID uint64) {
+		nodeID, err := member.ParseMemberIDFromIdentity(identity)
+		if expectErr {
+			Expect(err).To(HaveOccurred())
+		} else {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nodeID).To(Equal(expectedID))
+		}
+	},
+	// empty string — no member ID field at all
+	Entry("empty string", "", true, uint64(0)),
+	// bare hex with no colons — treated as memberID directly
+	Entry("bare hex no colon", "abcdef", false, uint64(0xabcdef)),
+	// leading colon — memberIDHex is "", parse must fail
+	Entry("leading colon makes empty memberIDHex", ":c1c1:Member", true, uint64(0)),
+	// non-hex first field
+	Entry("non-hex first field", "xyz:c1c1:Member", true, uint64(0)),
+	// standard Member role — role field is irrelevant to ID extraction
+	Entry("standard Member role", "abcdef:c1c1:Member", false, uint64(0xabcdef)),
+	// Leader role — same ID, role ignored
+	Entry("Leader role same as Member", "abcdef:c1c1:Leader", false, uint64(0xabcdef)),
+	// extra colons — only the first field is used
+	Entry("extra colons use first field only", "abcdef:b:c:d", false, uint64(0xabcdef)),
+)
+
+var _ = DescribeTable("FormatMemberIdentity",
+	func(memberID, clusterID uint64, isLeader bool, expected string) {
+		Expect(member.FormatMemberIdentity(memberID, clusterID, isLeader)).To(Equal(expected))
+	},
+	// non-leader → "Member" role suffix, IDs in lowercase hex
+	Entry("member role", uint64(0xabcdef), uint64(0xc1c1), false, "abcdef:c1c1:Member"),
+	// leader → "Leader" role suffix
+	Entry("leader role", uint64(0xabcdef), uint64(0xc1c1), true, "abcdef:c1c1:Leader"),
+	// zero IDs still format as "0"
+	Entry("zero ids", uint64(0), uint64(0), false, "0:0:Member"),
+)
+
+// FormatMemberIdentity output must round-trip through ParseMemberIDFromIdentity.
+var _ = DescribeTable("FormatMemberIdentity round-trips through ParseMemberIDFromIdentity",
+	func(memberID, clusterID uint64, isLeader bool) {
+		identity := member.FormatMemberIdentity(memberID, clusterID, isLeader)
+		parsed, err := member.ParseMemberIDFromIdentity(identity)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parsed).To(Equal(memberID))
+	},
+	Entry("member", uint64(0xabcdef), uint64(0xc1c1), false),
+	Entry("leader", uint64(0x1), uint64(0x2), true),
+	Entry("large ids", uint64(0xffffffffffffffff), uint64(0x1234), false),
+)
+
+var _ = Describe("WriteMemberIDFile", func() {
+	var dataDir string
+
+	BeforeEach(func() {
+		dataDir, err = os.MkdirTemp("", "identity-writefile-")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(dataDir)).To(Succeed())
+	})
+
+	It("writes the identity string to the member-id file", func() {
+		Expect(member.WriteMemberIDFile(dataDir, "abcdef:c1c1:Member")).To(Succeed())
+
+		data, err := os.ReadFile(etcdutil.MemberIDFilePath(dataDir))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("abcdef:c1c1:Member"))
+	})
+
+	It("overwrites an existing member-id file atomically", func() {
+		Expect(member.WriteMemberIDFile(dataDir, "aaaa:c1c1:Member")).To(Succeed())
+		Expect(member.WriteMemberIDFile(dataDir, "bbbb:c1c1:Leader")).To(Succeed())
+
+		data, err := os.ReadFile(etcdutil.MemberIDFilePath(dataDir))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("bbbb:c1c1:Leader"))
+		// The scratch file must not be left behind.
+		_, statErr := os.Stat(etcdutil.MemberIDFilePath(dataDir) + ".tmp")
+		Expect(os.IsNotExist(statErr)).To(BeTrue())
+	})
+
+	It("returns an error when the data directory does not exist", func() {
+		err := member.WriteMemberIDFile(filepath.Join(dataDir, "missing-subdir"), "abcdef:c1c1:Member")
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("ReadLocalMemberIDFromFile", func() {
+	var (
+		dataDir  string
+		logEntry = logrus.New().WithField("test", "read-file")
+	)
+
+	BeforeEach(func() {
+		dataDir, err = os.MkdirTemp("", "identity-readfile-")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(dataDir)).To(Succeed())
+	})
+
+	Context("when the member-id file does not exist", func() {
+		It("returns (0, false, nil)", func() {
+			id, ok, err := member.ReadLocalMemberIDFromFile(logEntry, dataDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+			Expect(id).To(Equal(uint64(0)))
+		})
+	})
+
+	Context("when the member-id file holds a valid identity", func() {
+		It("returns the parsed member ID", func() {
+			Expect(member.WriteMemberIDFile(dataDir, "abcdef:c1c1:Member")).To(Succeed())
+
+			id, ok, err := member.ReadLocalMemberIDFromFile(logEntry, dataDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(id).To(Equal(uint64(0xabcdef)))
+		})
+	})
+
+	Context("when the member-id file holds surrounding whitespace", func() {
+		It("trims and parses the member ID", func() {
+			Expect(member.WriteMemberIDFile(dataDir, "  abcdef:c1c1:Member\n")).To(Succeed())
+
+			id, ok, err := member.ReadLocalMemberIDFromFile(logEntry, dataDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(id).To(Equal(uint64(0xabcdef)))
+		})
+	})
+
+	Context("when the member-id file holds an unparseable identity", func() {
+		It("returns an error", func() {
+			Expect(member.WriteMemberIDFile(dataDir, "not-hex:c1c1:Member")).To(Succeed())
+
+			_, ok, err := member.ReadLocalMemberIDFromFile(logEntry, dataDir)
+			Expect(err).To(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("ReadLocalMemberIDFromLease", func() {
+	const (
+		leaseNamespace = "test-ns"
+		leaseName      = "etcd-test-0"
+	)
+	var logEntry = logrus.New().WithField("test", "read-lease")
+
+	newLease := func(holderIdentity *string) *coordinationv1.Lease {
+		return &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Name: leaseName, Namespace: leaseNamespace},
+			Spec:       coordinationv1.LeaseSpec{HolderIdentity: holderIdentity},
+		}
+	}
+
+	Context("when the k8s client is nil", func() {
+		It("returns (0, false, nil)", func() {
+			id, ok, err := member.ReadLocalMemberIDFromLease(context.Background(), logEntry, nil, leaseNamespace, leaseName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+			Expect(id).To(Equal(uint64(0)))
+		})
+	})
+
+	Context("when the lease does not exist", func() {
+		It("returns a NotFound error", func() {
+			cl := fake.NewClientBuilder().Build()
+
+			_, ok, err := member.ReadLocalMemberIDFromLease(context.Background(), logEntry, cl, leaseNamespace, leaseName)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Context("when the lease exists but has no holder identity", func() {
+		It("returns (0, false, nil)", func() {
+			cl := fake.NewClientBuilder().WithObjects(newLease(nil)).Build()
+
+			id, ok, err := member.ReadLocalMemberIDFromLease(context.Background(), logEntry, cl, leaseNamespace, leaseName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+			Expect(id).To(Equal(uint64(0)))
+		})
+	})
+
+	Context("when the lease holder identity is valid", func() {
+		It("returns the parsed member ID", func() {
+			identity := "abcdef:c1c1:Member"
+			cl := fake.NewClientBuilder().WithObjects(newLease(&identity)).Build()
+
+			id, ok, err := member.ReadLocalMemberIDFromLease(context.Background(), logEntry, cl, leaseNamespace, leaseName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(id).To(Equal(uint64(0xabcdef)))
+		})
+	})
+
+	Context("when the lease holder identity is unparseable", func() {
+		It("returns an error", func() {
+			identity := "not-hex:c1c1:Member"
+			cl := fake.NewClientBuilder().WithObjects(newLease(&identity)).Build()
+
+			_, ok, err := member.ReadLocalMemberIDFromLease(context.Background(), logEntry, cl, leaseNamespace, leaseName)
+			Expect(err).To(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("ResolveLocalMemberID", func() {
+	const (
+		ns        = "test-ns"
+		leaseName = "etcd-test-0"
+	)
+	var (
+		dataDir  string
+		logEntry = logrus.New().WithField("test", "resolve")
+	)
+
+	newLease := func(holderIdentity *string) *coordinationv1.Lease {
+		return &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Name: leaseName, Namespace: ns},
+			Spec:       coordinationv1.LeaseSpec{HolderIdentity: holderIdentity},
+		}
+	}
+
+	BeforeEach(func() {
+		dataDir, err = os.MkdirTemp("", "identity-resolve-")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(dataDir)).To(Succeed())
+	})
+
+	Context("when the lease holds a valid identity", func() {
+		It("resolves from the lease and does not consult the file", func() {
+			identity := "abcdef:c1c1:Member"
+			cl := fake.NewClientBuilder().WithObjects(newLease(&identity)).Build()
+
+			id, ok, err := member.ResolveLocalMemberID(context.Background(), logEntry, dataDir, cl, ns, leaseName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(id).To(Equal(uint64(0xabcdef)))
+		})
+	})
+
+	Context("when the lease is absent but the file holds a valid identity", func() {
+		It("falls back to the file", func() {
+			cl := fake.NewClientBuilder().Build() // lease NotFound
+			Expect(member.WriteMemberIDFile(dataDir, "beef:c1c1:Member")).To(Succeed())
+
+			id, ok, err := member.ResolveLocalMemberID(context.Background(), logEntry, dataDir, cl, ns, leaseName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(id).To(Equal(uint64(0xbeef)))
+		})
+	})
+
+	Context("when neither the lease nor the file has an identity", func() {
+		It("treats the member as fresh (0, false, nil)", func() {
+			cl := fake.NewClientBuilder().Build()
+
+			id, ok, err := member.ResolveLocalMemberID(context.Background(), logEntry, dataDir, cl, ns, leaseName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+			Expect(id).To(Equal(uint64(0)))
+		})
+	})
+
+	Context("when the nil client falls through to a valid file", func() {
+		It("resolves from the file", func() {
+			Expect(member.WriteMemberIDFile(dataDir, "beef:c1c1:Member")).To(Succeed())
+
+			id, ok, err := member.ResolveLocalMemberID(context.Background(), logEntry, dataDir, nil, ns, leaseName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(id).To(Equal(uint64(0xbeef)))
+		})
+	})
+
+	Context("when the file holds an unparseable identity", func() {
+		It("returns an error", func() {
+			cl := fake.NewClientBuilder().Build()
+			Expect(member.WriteMemberIDFile(dataDir, "not-hex:c1c1:Member")).To(Succeed())
+
+			_, ok, err := member.ResolveLocalMemberID(context.Background(), logEntry, dataDir, cl, ns, leaseName)
+			Expect(err).To(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+	})
+})

--- a/pkg/member/identity_test.go
+++ b/pkg/member/identity_test.go
@@ -77,12 +77,14 @@ var _ = Describe("WriteMemberIDFile", func() {
 	var dataDir string
 
 	BeforeEach(func() {
-		dataDir, err = os.MkdirTemp("", "identity-writefile-")
+		root, err := os.MkdirTemp("", "identity-writefile-")
 		Expect(err).NotTo(HaveOccurred())
+		dataDir = filepath.Join(root, "new.etcd")
+		Expect(os.MkdirAll(dataDir, 0700)).To(Succeed())
 	})
 
 	AfterEach(func() {
-		Expect(os.RemoveAll(dataDir)).To(Succeed())
+		Expect(os.RemoveAll(filepath.Dir(dataDir))).To(Succeed())
 	})
 
 	It("writes the identity string to the member-id file", func() {
@@ -106,7 +108,7 @@ var _ = Describe("WriteMemberIDFile", func() {
 	})
 
 	It("returns an error when the data directory does not exist", func() {
-		err := member.WriteMemberIDFile(filepath.Join(dataDir, "missing-subdir"), "abcdef:c1c1:Member")
+		err := member.WriteMemberIDFile(filepath.Join(dataDir, "missing-subdir", "new.etcd"), "abcdef:c1c1:Member")
 		Expect(err).To(HaveOccurred())
 	})
 })
@@ -118,12 +120,14 @@ var _ = Describe("ReadLocalMemberIDFromFile", func() {
 	)
 
 	BeforeEach(func() {
-		dataDir, err = os.MkdirTemp("", "identity-readfile-")
+		root, err := os.MkdirTemp("", "identity-readfile-")
 		Expect(err).NotTo(HaveOccurred())
+		dataDir = filepath.Join(root, "new.etcd")
+		Expect(os.MkdirAll(dataDir, 0700)).To(Succeed())
 	})
 
 	AfterEach(func() {
-		Expect(os.RemoveAll(dataDir)).To(Succeed())
+		Expect(os.RemoveAll(filepath.Dir(dataDir))).To(Succeed())
 	})
 
 	Context("when the member-id file does not exist", func() {
@@ -255,12 +259,14 @@ var _ = Describe("ResolveLocalMemberID", func() {
 	}
 
 	BeforeEach(func() {
-		dataDir, err = os.MkdirTemp("", "identity-resolve-")
+		root, err := os.MkdirTemp("", "identity-resolve-")
 		Expect(err).NotTo(HaveOccurred())
+		dataDir = filepath.Join(root, "new.etcd")
+		Expect(os.MkdirAll(dataDir, 0700)).To(Succeed())
 	})
 
 	AfterEach(func() {
-		Expect(os.RemoveAll(dataDir)).To(Succeed())
+		Expect(os.RemoveAll(filepath.Dir(dataDir))).To(Succeed())
 	})
 
 	Context("when the lease holds a valid identity", func() {

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"time"
 
@@ -57,6 +58,11 @@ type Control interface {
 
 	// WasMemberInCluster checks whether current members was part of the etcd cluster or not.
 	WasMemberInCluster(context.Context, client.Client) bool
+
+	// WasPermanentlyRemoved reports whether this member was explicitly removed
+	// from the cluster during a prior scale-in. Returns ErrMembershipCheckFailed
+	// if the check cannot be completed (fails closed).
+	WasPermanentlyRemoved(ctx context.Context, dataDir string, k8sClient client.Client) (bool, error)
 
 	// PromoteMember promotes an etcd member from a learner to a voting member of the cluster.
 	// This will succeed if and only if learner is in a healthy state and the learner is in sync with leader.
@@ -384,10 +390,43 @@ func (m *memberControl) WasMemberInCluster(ctx context.Context, clientSet client
 		return false
 	}
 
-	if memberLease.Spec.HolderIdentity == nil {
-		return false
+	return memberLease.Spec.HolderIdentity != nil
+}
+
+// WasPermanentlyRemoved checks whether this member was permanently removed from
+// the etcd cluster during a prior scale-in by inspecting the boltdb
+// members_removed tombstone bucket. It resolves the local member ID from the
+// k8s lease first, falling back to the on-disk member-id file.
+func (m *memberControl) WasPermanentlyRemoved(ctx context.Context, dataDir string, k8sClient client.Client) (bool, error) {
+	logger := m.logger.WithField("actor", "anti-rejoin")
+	memberID, ok, err := ResolveLocalMemberID(ctx, logger, dataDir, k8sClient, m.podNamespace, m.memberName)
+	if err != nil {
+		return false, fmt.Errorf("%w: unable to determine local member ID: %w", ErrMembershipCheckFailed, err)
 	}
-	return true
+	if !ok {
+		return false, nil
+	}
+
+	dbPath := etcdutil.BackendDBPath(dataDir)
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			// WAL directories exist (hasData was true) but the db file is gone —
+			// partial PVC deletion. We have a resolved memberID so we cannot safely
+			// treat this as a fresh member; fail closed.
+			return false, fmt.Errorf("%w: member ID %s resolved but boltdb backend %q does not exist — possible partial deletion; failing closed",
+				ErrMembershipCheckFailed, strconv.FormatUint(memberID, 16), dbPath)
+		}
+		return false, fmt.Errorf("%w: unable to stat boltdb backend %q: %w", ErrMembershipCheckFailed, dbPath, err)
+	}
+
+	removed, err := IsMemberRemoved(dbPath, memberID)
+	if err != nil {
+		return false, fmt.Errorf("%w: %w", ErrMembershipCheckFailed, err)
+	}
+	if removed {
+		logger.Infof("member %s was permanently removed from the etcd cluster", strconv.FormatUint(memberID, 16))
+	}
+	return removed, nil
 }
 
 // AddLearnerWithRetry add a new member as a learner with exponential backoff.

--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -395,7 +395,7 @@ func (m *memberControl) WasMemberInCluster(ctx context.Context, clientSet client
 
 // WasPermanentlyRemoved checks whether this member was permanently removed from
 // the etcd cluster during a prior scale-in by inspecting the boltdb
-// members_removed tombstone bucket. It resolves the local member ID from the
+// "members_removed" tombstone bucket. It resolves the local member ID from the
 // k8s lease first, falling back to the on-disk member-id file.
 func (m *memberControl) WasPermanentlyRemoved(ctx context.Context, dataDir string, k8sClient client.Client) (bool, error) {
 	logger := m.logger.WithField("actor", "anti-rejoin")

--- a/pkg/member/member_control_test.go
+++ b/pkg/member/member_control_test.go
@@ -17,6 +17,9 @@ import (
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/mock/gomock"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -234,6 +237,97 @@ auto-compaction-retention: 30m` + prefixLine
 				isScaleUp, err := m.IsClusterScaledUp(testCtx)
 				Expect(isScaleUp).Should(BeFalse())
 				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("Checking whether the member was permanently removed", func() {
+		// WasPermanentlyRemoved resolves the local member ID (from the lease named
+		// after the member, falling back to the member-id file) and then inspects
+		// the boltdb members_removed tombstone bucket. memberName == podName ==
+		// "etcd-test-0" and podNamespace == "test-podnamespace" here, matching the
+		// env vars set in the outer BeforeEach.
+		var (
+			dataDir string
+			m       member.Control
+		)
+
+		newLease := func(holderIdentity *string) *coordinationv1.Lease {
+			return &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: podNamespace},
+				Spec:       coordinationv1.LeaseSpec{HolderIdentity: holderIdentity},
+			}
+		}
+
+		BeforeEach(func() {
+			dataDir, err = os.MkdirTemp("", "was-removed-")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		JustBeforeEach(func() {
+			m = member.NewMemberControl(etcdConnectionConfig)
+		})
+
+		AfterEach(func() {
+			Expect(os.RemoveAll(dataDir)).To(Succeed())
+		})
+
+		Context("when the local member ID cannot be resolved (no lease, no file)", func() {
+			It("returns false without inspecting the tombstone", func() {
+				cl := fake.NewClientBuilder().Build()
+
+				removed, err := m.WasPermanentlyRemoved(testCtx, dataDir, cl)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(removed).To(BeFalse())
+			})
+		})
+
+		Context("when the member ID is resolved from the lease and is in the tombstone", func() {
+			It("reports the member as permanently removed", func() {
+				identity := "abcdef:c1c1:Member"
+				cl := fake.NewClientBuilder().WithObjects(newLease(&identity)).Build()
+				writeTombstoneDB(dataDir, true, uint64(0xabcdef))
+
+				removed, err := m.WasPermanentlyRemoved(testCtx, dataDir, cl)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(removed).To(BeTrue())
+			})
+		})
+
+		Context("when the member ID is resolved but is not in the tombstone", func() {
+			It("reports the member as not removed", func() {
+				identity := "abcdef:c1c1:Member"
+				cl := fake.NewClientBuilder().WithObjects(newLease(&identity)).Build()
+				writeTombstoneDB(dataDir, true, uint64(0xdef))
+
+				removed, err := m.WasPermanentlyRemoved(testCtx, dataDir, cl)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(removed).To(BeFalse())
+			})
+		})
+
+		Context("when the member ID is resolved from the member-id file (lease absent)", func() {
+			It("reports the member as permanently removed", func() {
+				cl := fake.NewClientBuilder().Build() // lease NotFound
+				Expect(member.WriteMemberIDFile(dataDir, "abcdef:c1c1:Member")).To(Succeed())
+				writeTombstoneDB(dataDir, true, uint64(0xabcdef))
+
+				removed, err := m.WasPermanentlyRemoved(testCtx, dataDir, cl)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(removed).To(BeTrue())
+			})
+		})
+
+		Context("when the member ID is resolved but the boltdb backend is missing", func() {
+			It("fails closed (possible partial deletion)", func() {
+				identity := "abcdef:c1c1:Member"
+				cl := fake.NewClientBuilder().WithObjects(newLease(&identity)).Build()
+				// No boltdb written under dataDir/member/snap/db.
+
+				removed, err := m.WasPermanentlyRemoved(testCtx, dataDir, cl)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(member.ErrMembershipCheckFailed))
+				Expect(removed).To(BeFalse())
 			})
 		})
 	})

--- a/pkg/member/member_control_test.go
+++ b/pkg/member/member_control_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/gardener/etcd-backup-restore/pkg/member"
@@ -260,8 +261,10 @@ auto-compaction-retention: 30m` + prefixLine
 		}
 
 		BeforeEach(func() {
-			dataDir, err = os.MkdirTemp("", "was-removed-")
+			root, err := os.MkdirTemp("", "was-removed-")
 			Expect(err).NotTo(HaveOccurred())
+			dataDir = filepath.Join(root, "new.etcd")
+			Expect(os.MkdirAll(dataDir, 0700)).To(Succeed())
 		})
 
 		JustBeforeEach(func() {
@@ -269,7 +272,7 @@ auto-compaction-retention: 30m` + prefixLine
 		})
 
 		AfterEach(func() {
-			Expect(os.RemoveAll(dataDir)).To(Succeed())
+			Expect(os.RemoveAll(filepath.Dir(dataDir))).To(Succeed())
 		})
 
 		Context("when the local member ID cannot be resolved (no lease, no file)", func() {

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -275,7 +275,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 			mmStopCh = make(chan struct{})
 			if b.config.HealthConfig.MemberLeaseRenewalEnabled {
 				go func() {
-					if err := heartbeat.RenewMemberLeasePeriodically(ctx, mmStopCh, b.config.HealthConfig, b.logger, b.config.EtcdConnectionConfig); err != nil {
+					if err := heartbeat.RenewMemberLeasePeriodically(ctx, mmStopCh, b.config.HealthConfig, b.logger, b.config.EtcdConnectionConfig, b.config.RestorationConfig.DataDir); err != nil {
 						b.logger.Fatalf("failed RenewMemberLeases: %v", err)
 					}
 				}()
@@ -311,7 +311,7 @@ func (b *BackupRestoreServer) runServer(ctx context.Context, restoreOpts *brtype
 
 	if b.config.HealthConfig.MemberLeaseRenewalEnabled {
 		go func() {
-			if err := heartbeat.RenewMemberLeasePeriodically(ctx, mmStopCh, b.config.HealthConfig, b.logger, b.config.EtcdConnectionConfig); err != nil {
+			if err := heartbeat.RenewMemberLeasePeriodically(ctx, mmStopCh, b.config.HealthConfig, b.logger, b.config.EtcdConnectionConfig, b.config.RestorationConfig.DataDir); err != nil {
 				b.logger.Fatalf("failed RenewMemberLeases: %v", err)
 			}
 		}()

--- a/pkg/types/defragmentation.go
+++ b/pkg/types/defragmentation.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
**How to categorize this PR?**
/area high-availability
/area robustness
/area control-plane
/kind enhancement

This PR adds an anti-rejoin guard for removed etcd members.

During scale-in of a multi-node etcd cluster, `etcd-druid` removes an etcd member before the corresponding pod/PVC cleanup has fully completed. If that pod restarts with its old data directory, `etcd-backup-restore` can otherwise interpret the state as a scale-out/rejoin case and re-add the removed member as a learner. This can cause a remove/re-add loop. Refer [DEP-08](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/08-scale-in.md#anti-rejoin-guard)

The guard runs before the learner-add path and checks whether the local member ID is present in etcd's local `members_removed` tombstone bucket. If the member was permanently removed, initialization stops and the member is not re-added.

The local member ID is resolved from:

1. the Kubernetes member Lease
2. a member-id file persisted on the PV by the heartbeat

The member-id file gives the guard a local fallback when the Kubernetes Lease is unavailable, for example in self-hosted or temporary API-unavailable scenarios.

**Which issue(s) this PR fixes**:
Fixes #
Part of https://github.com/gardener/etcd-druid/pull/1425

**Special notes for your reviewer**:

This change supports safe scale-in for multi-node etcd clusters only.

**Release note**:
```feature operator
Added a membership removal check to etcd-backup-restore that prevents a scaled-in etcd member from re-adding itself as a learner after etcd-druid removes it during a scale-in operation.
```
