### PR TITLE
Fix `UpdateMemberPeerURL` to update the correct cluster member

### DIFF
--- a/pkg/member/member_control.go
+++ b/pkg/member/member_control.go
@@ -276,7 +276,12 @@ func (m *memberControl) UpdateMemberPeerURL(ctx context.Context, cli etcdClient.
 		return fmt.Errorf("error listing members: %v", err)
 	}
 
-	return m.doUpdateMemberPeerAddress(ctx, cli, membersInfo.Header.GetMemberId())
+	foundMember := findMember(membersInfo.Members, m.memberName)
+	if foundMember == nil {
+		return ErrMissingMember
+	}
+
+	return m.doUpdateMemberPeerAddress(ctx, cli, foundMember.GetID())
 }
 
 // RemoveMember removes the member from the etcd cluster.

--- a/pkg/member/member_control_test.go
+++ b/pkg/member/member_control_test.go
@@ -152,29 +152,32 @@ auto-compaction-retention: 30m` + prefixLine
 			m = member.NewMemberControl(etcdConnectionConfig)
 		})
 
+		memberListResponse := func(targetName string) func(_ context.Context) (*clientv3.MemberListResponse, error) {
+			return func(_ context.Context) (*clientv3.MemberListResponse, error) {
+				etcdMember1 := &etcdserverpb.Member{
+					ID:   dummyID,
+					Name: targetName,
+				}
+				etcdMember2 := &etcdserverpb.Member{
+					ID:   dummyID + 1,
+					Name: "other-member",
+				}
+				response := new(clientv3.MemberListResponse)
+				response.Members = []*etcdserverpb.Member{etcdMember1, etcdMember2}
+				response.Header = &etcdserverpb.ResponseHeader{
+					MemberId: dummyID + 1, // responding member is NOT the target
+				}
+				return response, nil
+			}
+		}
+
 		Context("Able to connect to etcd member", func() {
-			It("Should not return error", func() {
+			It("Should not return error and update the correct member ID", func() {
 				client, err := factory.NewCluster()
 				Expect(err).ShouldNot(HaveOccurred())
 
-				cl.EXPECT().MemberList(gomock.Any()).DoAndReturn(func(_ context.Context) (*clientv3.MemberListResponse, error) {
-					etcdMember1 := &etcdserverpb.Member{
-						ID: dummyID,
-					}
-					etcdMember2 := &etcdserverpb.Member{
-						ID: dummyID + 1,
-					}
-					response := new(clientv3.MemberListResponse)
-
-					response.Members = append(response.Members, etcdMember1, etcdMember2)
-					response.Members = []*etcdserverpb.Member{etcdMember1, etcdMember2}
-					response.Header = &etcdserverpb.ResponseHeader{
-						MemberId: dummyID,
-					}
-					return response, nil
-				})
-
-				cl.EXPECT().MemberUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+				cl.EXPECT().MemberList(gomock.Any()).DoAndReturn(memberListResponse(podName))
+				cl.EXPECT().MemberUpdate(gomock.Any(), dummyID, gomock.Any()).Return(nil, nil)
 
 				err = m.UpdateMemberPeerURL(context.TODO(), client)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -186,27 +189,23 @@ auto-compaction-retention: 30m` + prefixLine
 				client, err := factory.NewCluster()
 				Expect(err).ShouldNot(HaveOccurred())
 
-				cl.EXPECT().MemberList(gomock.Any()).DoAndReturn(func(_ context.Context) (*clientv3.MemberListResponse, error) {
-					etcdMember1 := &etcdserverpb.Member{
-						ID: dummyID,
-					}
-					etcdMember2 := &etcdserverpb.Member{
-						ID: dummyID + 1,
-					}
-					response := new(clientv3.MemberListResponse)
-
-					response.Members = append(response.Members, etcdMember1, etcdMember2)
-					response.Members = []*etcdserverpb.Member{etcdMember1, etcdMember2}
-					response.Header = &etcdserverpb.ResponseHeader{
-						MemberId: dummyID,
-					}
-					return response, nil
-				})
-
-				cl.EXPECT().MemberUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("unable to connect to dummy etcd"))
+				cl.EXPECT().MemberList(gomock.Any()).DoAndReturn(memberListResponse(podName))
+				cl.EXPECT().MemberUpdate(gomock.Any(), dummyID, gomock.Any()).Return(nil, fmt.Errorf("unable to connect to dummy etcd"))
 
 				err = m.UpdateMemberPeerURL(context.TODO(), client)
 				Expect(err).Should(HaveOccurred())
+			})
+		})
+
+		Context("Member not found in the cluster member list", func() {
+			It("Should return ErrMissingMember", func() {
+				client, err := factory.NewCluster()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				cl.EXPECT().MemberList(gomock.Any()).DoAndReturn(memberListResponse("unknown-member"))
+
+				err = m.UpdateMemberPeerURL(context.TODO(), client)
+				Expect(err).Should(MatchError(member.ErrMissingMember))
 			})
 		})
 	})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane control-plane-migration
/kind bug

**What this PR does / why we need it**:
UpdateMemberPeerURL was passing `membersInfo.Header.GetMemberId()` to MemberUpdate. The response header's MemberId is the ID of the etcd member that handled the RPC (typically the leader), not the member whose peer URL should be updated. Under a multi-member cluster where the local member is not the leader, this silently updated the wrong member.

Fix: Use findMember(membersInfo.Members, m.memberName) to look up the target member by name — consistent with how PromoteMember and RemoveMember already work. Returns ErrMissingMember if the member is not found in the list.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @seshachalam-yv @ishan16696 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
fix: UpdateMemberPeerURL now correctly identifies the target member by name instead of using the RPC response header's member ID (which reflects the responding server, not the intended target). In multi-member clusters where the local member is not the leader, the peer URL was being updated on the wrong member.
```
