### PR TITLE
fix: defragments the leader blocking all cluster writes for the duration

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -138,7 +138,7 @@ func (cp *Compactor) Compact(ctx context.Context, opts *brtypes.CompactOptions) 
 		}
 		defer client.Close()
 
-		err = etcdutil.DefragmentData(ctx, clientMaintenance, client, ep, opts.DefragTimeout.Duration, cp.logger)
+		err = etcdutil.DefragmentData(ctx, clientMaintenance, client, clientFactory, ep, opts.DefragTimeout.Duration, cp.logger, false)
 		if err != nil {
 			cp.logger.Errorf("failed to defragment: %v", err)
 		}

--- a/pkg/defragmentor/defrag.go
+++ b/pkg/defragmentor/defrag.go
@@ -89,7 +89,7 @@ waitLoop:
 
 			if isClusterHealthy {
 				d.logger.Infof("Starting the scheduled defragmentation since all members of the etcd cluster are in a healthy state")
-				err = etcdutil.DefragmentData(d.ctx, clientMaintenance, client, etcdEndpoints, d.defragConfig.DefragTimeout.Duration, d.logger)
+				err = etcdutil.DefragmentData(d.ctx, clientMaintenance, client, clientFactory, etcdEndpoints, d.defragConfig.DefragTimeout.Duration, d.logger, d.defragConfig.MoveLeader)
 				if err != nil {
 					d.logger.Warnf("failed to defrag data with error: %v", err)
 					continue

--- a/pkg/etcdutil/client/types.go
+++ b/pkg/etcdutil/client/types.go
@@ -33,5 +33,6 @@ type Factory interface {
 	NewCluster() (ClusterCloser, error)
 	NewKV() (KVCloser, error)
 	NewMaintenance() (MaintenanceCloser, error)
+	NewMaintenanceForEndpoint(endpoint string) (MaintenanceCloser, error)
 	NewWatcher() (clientv3.Watcher, error) // clientv3.Watcher already supports io.Closer
 }

--- a/pkg/etcdutil/etcdutil.go
+++ b/pkg/etcdutil/etcdutil.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
@@ -224,57 +225,8 @@ func DefragmentData(defragCtx context.Context, clientMaintenance client.Maintena
 	}
 
 	// Optionally transfer leadership before defragmenting the leader to keep writes flowing.
-	// MoveLeader must be sent to the current leader, so use the first known leader endpoint.
-	leaderTransferred := false
-	if moveLeader && len(followerEtcdEndpoints) > 0 && len(leaderEtcdEndpoints) > 0 {
-		func() {
-			ctx, cancel := context.WithTimeout(defragCtx, brtypes.DefaultEtcdConnectionTimeout)
-			defer cancel()
-			membersInfo, err := clientCluster.MemberList(ctx)
-			if err != nil {
-				logger.Warnf("failed to list members for leadership transfer: %v, defragmenting leader in place", err)
-				return
-			}
-			// Pick the first voting non-learner follower as the transfer target.
-			var transfereeID uint64
-			for _, m := range membersInfo.Members {
-				if m.GetID() != leaderID && !m.GetIsLearner() {
-					transfereeID = m.GetID()
-					break
-				}
-			}
-			if transfereeID == 0 {
-				logger.Warnf("no eligible voting follower found for leadership transfer, defragmenting leader in place")
-				return
-			}
+	transferLeadership(defragCtx, clientMaintenance, clientCluster, clientFactory, leaderEtcdEndpoints, followerEtcdEndpoints, leaderID, logger, moveLeader)
 
-			leaderEndpoint := leaderEtcdEndpoints[0]
-			func() {
-				ctx, cancel := context.WithTimeout(defragCtx, brtypes.DefaultLeaderTransferTimeout)
-				defer cancel()
-				// clientFactory is used to create a maintenance client pinned to the leader endpoint for the
-				// MoveLeader call, ensuring the request is never rejected with ErrNotLeader.
-				leaderMaintenance, err := clientFactory.NewMaintenanceForEndpoint(leaderEndpoint)
-				if err != nil {
-					logger.Warnf("failed to create maintenance client for leader endpoint %s: %v, defragmenting leader in place", leaderEndpoint, err)
-					return
-				}
-				defer leaderMaintenance.Close()
-				if _, err := leaderMaintenance.MoveLeader(ctx, transfereeID); err != nil {
-					logger.Warnf("failed to transfer etcd leadership from %s to member %d: %v, defragmenting leader in place", leaderEndpoint, transfereeID, err)
-				} else {
-					logger.Infof("etcd leadership transferred from %s to member %d, will now defragment the former leader", leaderEndpoint, transfereeID)
-					leaderTransferred = true
-				}
-			}()
-		}()
-	}
-
-	if leaderTransferred {
-		logger.Info("Starting the defragmentation on former etcd leader (now follower)")
-	} else {
-		logger.Info("Starting the defragmentation on etcd leader")
-	}
 	// Perform the defragmentation on etcd leader (or former leader after transfer).
 	for _, ep := range leaderEtcdEndpoints {
 		if err := func() error {
@@ -289,6 +241,87 @@ func DefragmentData(defragCtx context.Context, clientMaintenance client.Maintena
 		}
 	}
 	return nil
+}
+
+// transferLeadership attempts to transfer etcd leadership away from the current leader to the
+// most up-to-date voting follower before the leader is defragmented, avoiding cluster-wide write
+// stalls during the leader's defragmentation. Returns true if the transfer succeeded.
+// If the transfer cannot be performed it logs a warning and returns false so the caller can
+// defragment the leader in place.
+func transferLeadership(defragCtx context.Context, clientMaintenance client.MaintenanceCloser, clientCluster client.ClusterCloser, clientFactory client.Factory, leaderEtcdEndpoints, followerEtcdEndpoints []string, leaderID uint64, logger *logrus.Entry, moveLeader bool) bool {
+	if !moveLeader || len(followerEtcdEndpoints) == 0 || len(leaderEtcdEndpoints) == 0 {
+		return false
+	}
+
+	leaderTransferred := false
+	func() {
+		ctx, cancel := context.WithTimeout(defragCtx, brtypes.DefaultEtcdConnectionTimeout)
+		defer cancel()
+		membersInfo, err := clientCluster.MemberList(ctx)
+		if err != nil {
+			logger.Warnf("failed to list members for leadership transfer: %v, defragmenting leader in place", err)
+			return
+		}
+
+		transfereeID := selectLeaderTransferee(ctx, clientMaintenance, membersInfo.Members, leaderID, logger)
+		if transfereeID == 0 {
+			return
+		}
+
+		leaderEndpoint := leaderEtcdEndpoints[0]
+		func() {
+			ctx, cancel := context.WithTimeout(defragCtx, brtypes.DefaultLeaderTransferTimeout)
+			defer cancel()
+			leaderMaintenance, err := clientFactory.NewMaintenanceForEndpoint(leaderEndpoint)
+			if err != nil {
+				logger.Warnf("failed to create maintenance client for leader endpoint %s: %v, defragmenting leader in place", leaderEndpoint, err)
+				return
+			}
+			defer leaderMaintenance.Close()
+			if _, err := leaderMaintenance.MoveLeader(ctx, transfereeID); err != nil {
+				logger.Warnf("failed to transfer etcd leadership from %s to member %d: %v, defragmenting leader in place", leaderEndpoint, transfereeID, err)
+			} else {
+				logger.Infof("etcd leadership transferred from %s to member %d, will now defragment the former leader", leaderEndpoint, transfereeID)
+				leaderTransferred = true
+			}
+		}()
+	}()
+	if leaderTransferred {
+		logger.Info("Starting the defragmentation on former etcd leader (now follower)")
+	} else {
+		logger.Info("Starting the defragmentation on etcd leader")
+	}
+	return leaderTransferred
+}
+
+// selectLeaderTransferee picks the voting member with the highest RaftIndex as the MoveLeader transfer target.
+func selectLeaderTransferee(ctx context.Context, clientMaintenance client.MaintenanceCloser, members []*etcdserverpb.Member, leaderID uint64, logger *logrus.Entry) uint64 {
+	var transfereeID uint64
+	var bestRaftIndex uint64
+	reachableFollowers := 0
+	for _, m := range members {
+		if m.GetID() == leaderID || m.GetIsLearner() {
+			continue
+		}
+		for _, ep := range m.GetClientURLs() {
+			if status, err := clientMaintenance.Status(ctx, ep); err == nil {
+				reachableFollowers++
+				if transfereeID == 0 || status.RaftIndex > bestRaftIndex {
+					bestRaftIndex = status.RaftIndex
+					transfereeID = m.GetID()
+				}
+				break
+			}
+		}
+	}
+	if transfereeID == 0 {
+		if reachableFollowers == 0 {
+			logger.Warnf("no reachable voting follower found for leadership transfer, defragmenting leader in place")
+		} else {
+			logger.Warnf("no eligible voting follower found for leadership transfer, defragmenting leader in place")
+		}
+	}
+	return transfereeID
 }
 
 // GetEtcdEndPointsSorted returns the etcd leaderEndpoints, etcd followerEndpoints, and the leader member ID.

--- a/pkg/etcdutil/etcdutil.go
+++ b/pkg/etcdutil/etcdutil.go
@@ -72,6 +72,12 @@ func (f *factoryImpl) NewMaintenance() (client.MaintenanceCloser, error) {
 	return f.NewClient()
 }
 
+func (f *factoryImpl) NewMaintenanceForEndpoint(endpoint string) (client.MaintenanceCloser, error) {
+	cfg := f.EtcdConnectionConfig
+	cfg.Endpoints = []string{endpoint}
+	return GetTLSClientForEtcd(&cfg, f.options)
+}
+
 func (f *factoryImpl) NewWatcher() (clientv3.Watcher, error) {
 	return f.NewClient()
 }
@@ -188,8 +194,11 @@ func PerformDefragmentation(defragCtx context.Context, client client.Maintenance
 
 // DefragmentData calls the defragmentation on each etcd followers endPoints
 // then calls the defragmentation on etcd leader endPoints.
-func DefragmentData(defragCtx context.Context, clientMaintenance client.MaintenanceCloser, clientCluster client.ClusterCloser, etcdEndpoints []string, defragTimeout time.Duration, logger *logrus.Entry) error {
-	leaderEtcdEndpoints, followerEtcdEndpoints, err := GetEtcdEndPointsSorted(defragCtx, clientMaintenance, clientCluster, etcdEndpoints, logger)
+// When moveLeader is true and the cluster has followers, leadership is transferred to a follower
+// before the leader is defragmented, avoiding cluster-wide write stalls. If the transfer fails,
+// a warning is logged and the leader is defragmented in place.
+func DefragmentData(defragCtx context.Context, clientMaintenance client.MaintenanceCloser, clientCluster client.ClusterCloser, clientFactory client.Factory, etcdEndpoints []string, defragTimeout time.Duration, logger *logrus.Entry, moveLeader bool) error {
+	leaderEtcdEndpoints, followerEtcdEndpoints, leaderID, err := GetEtcdEndPointsSorted(defragCtx, clientMaintenance, clientCluster, etcdEndpoints, logger)
 	logger.Debugf("etcdEndpoints: %v", etcdEndpoints)
 	logger.Debugf("leaderEndpoints: %v", leaderEtcdEndpoints)
 	logger.Debugf("followerEtcdEndpointss: %v", followerEtcdEndpoints)
@@ -214,8 +223,59 @@ func DefragmentData(defragCtx context.Context, clientMaintenance client.Maintena
 		}
 	}
 
-	logger.Info("Starting the defragmentation on etcd leader")
-	// Perform the defragmentation on etcd leader.
+	// Optionally transfer leadership before defragmenting the leader to keep writes flowing.
+	// MoveLeader must be sent to the current leader, so use the first known leader endpoint.
+	leaderTransferred := false
+	if moveLeader && len(followerEtcdEndpoints) > 0 && len(leaderEtcdEndpoints) > 0 {
+		func() {
+			ctx, cancel := context.WithTimeout(defragCtx, brtypes.DefaultEtcdConnectionTimeout)
+			defer cancel()
+			membersInfo, err := clientCluster.MemberList(ctx)
+			if err != nil {
+				logger.Warnf("failed to list members for leadership transfer: %v, defragmenting leader in place", err)
+				return
+			}
+			// Pick the first voting non-learner follower as the transfer target.
+			var transfereeID uint64
+			for _, m := range membersInfo.Members {
+				if m.GetID() != leaderID && !m.GetIsLearner() {
+					transfereeID = m.GetID()
+					break
+				}
+			}
+			if transfereeID == 0 {
+				logger.Warnf("no eligible voting follower found for leadership transfer, defragmenting leader in place")
+				return
+			}
+
+			leaderEndpoint := leaderEtcdEndpoints[0]
+			func() {
+				ctx, cancel := context.WithTimeout(defragCtx, brtypes.DefaultLeaderTransferTimeout)
+				defer cancel()
+				// clientFactory is used to create a maintenance client pinned to the leader endpoint for the
+				// MoveLeader call, ensuring the request is never rejected with ErrNotLeader.
+				leaderMaintenance, err := clientFactory.NewMaintenanceForEndpoint(leaderEndpoint)
+				if err != nil {
+					logger.Warnf("failed to create maintenance client for leader endpoint %s: %v, defragmenting leader in place", leaderEndpoint, err)
+					return
+				}
+				defer leaderMaintenance.Close()
+				if _, err := leaderMaintenance.MoveLeader(ctx, transfereeID); err != nil {
+					logger.Warnf("failed to transfer etcd leadership from %s to member %d: %v, defragmenting leader in place", leaderEndpoint, transfereeID, err)
+				} else {
+					logger.Infof("etcd leadership transferred from %s to member %d, will now defragment the former leader", leaderEndpoint, transfereeID)
+					leaderTransferred = true
+				}
+			}()
+		}()
+	}
+
+	if leaderTransferred {
+		logger.Info("Starting the defragmentation on former etcd leader (now follower)")
+	} else {
+		logger.Info("Starting the defragmentation on etcd leader")
+	}
+	// Perform the defragmentation on etcd leader (or former leader after transfer).
 	for _, ep := range leaderEtcdEndpoints {
 		if err := func() error {
 			ctx, cancel := context.WithTimeout(defragCtx, defragTimeout)
@@ -231,8 +291,8 @@ func DefragmentData(defragCtx context.Context, clientMaintenance client.Maintena
 	return nil
 }
 
-// GetEtcdEndPointsSorted returns the etcd leaderEndpoints and etcd followerEndpoints.
-func GetEtcdEndPointsSorted(ctx context.Context, clientMaintenance client.MaintenanceCloser, clientCluster client.ClusterCloser, etcdEndpoints []string, logger *logrus.Entry) ([]string, []string, error) {
+// GetEtcdEndPointsSorted returns the etcd leaderEndpoints, etcd followerEndpoints, and the leader member ID.
+func GetEtcdEndPointsSorted(ctx context.Context, clientMaintenance client.MaintenanceCloser, clientCluster client.ClusterCloser, etcdEndpoints []string, logger *logrus.Entry) ([]string, []string, uint64, error) {
 	var leaderEtcdEndpoints []string
 	var followerEtcdEndpoints []string
 	var endPoint string
@@ -243,17 +303,17 @@ func GetEtcdEndPointsSorted(ctx context.Context, clientMaintenance client.Mainte
 	membersInfo, err := clientCluster.MemberList(ctx)
 	if err != nil {
 		logger.Errorf("failed to get memberList of etcd with error: %v", err)
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 
 	// to handle the single node etcd case (particularly: single node embedded etcd case)
 	if len(membersInfo.Members) == 1 {
 		leaderEtcdEndpoints = append(leaderEtcdEndpoints, etcdEndpoints...)
-		return leaderEtcdEndpoints, nil, nil
+		return leaderEtcdEndpoints, nil, membersInfo.Members[0].GetID(), nil
 	}
 
 	if len(etcdEndpoints) == 0 {
-		return nil, nil, &errors.EtcdError{
+		return nil, nil, 0, &errors.EtcdError{
 			Message: "etcd endpoints are not passed correctly",
 		}
 	}
@@ -262,7 +322,7 @@ func GetEtcdEndPointsSorted(ctx context.Context, clientMaintenance client.Mainte
 	response, err := clientMaintenance.Status(ctx, endPoint)
 	if err != nil {
 		logger.Errorf("failed to get status of etcd endPoint: %v with error: %v", endPoint, err)
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 
 	for _, member := range membersInfo.Members {
@@ -273,7 +333,7 @@ func GetEtcdEndPointsSorted(ctx context.Context, clientMaintenance client.Mainte
 		}
 	}
 
-	return leaderEtcdEndpoints, followerEtcdEndpoints, nil
+	return leaderEtcdEndpoints, followerEtcdEndpoints, response.Leader, nil
 }
 
 // TakeAndSaveFullSnapshot does the following operations:

--- a/pkg/etcdutil/etcdutil_test.go
+++ b/pkg/etcdutil/etcdutil_test.go
@@ -329,9 +329,17 @@ var _ = Describe("EtcdUtil Tests", func() {
 					return response, nil
 				}).AnyTimes()
 
-				cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
+				// Status on the leader endpoint.
+				cm.EXPECT().Status(gomock.Any(), dummyClientEndpoints[0]).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
 					response := new(clientv3.StatusResponse)
 					response.Leader = dummyID
+					response.DbSize = 10
+					return response, nil
+				}).AnyTimes()
+				// Status on the follower endpoint.
+				cm.EXPECT().Status(gomock.Any(), dummyClientEndpoints[1]).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
+					response := new(clientv3.StatusResponse)
+					response.RaftIndex = 42
 					response.DbSize = 10
 					return response, nil
 				}).AnyTimes()

--- a/pkg/etcdutil/etcdutil_test.go
+++ b/pkg/etcdutil/etcdutil_test.go
@@ -175,12 +175,12 @@ var _ = Describe("EtcdUtil Tests", func() {
 
 				cl.EXPECT().MemberList(gomock.Any()).Return(nil, fmt.Errorf("failed to connect with the dummy etcd")).AnyTimes()
 
-				leaderEtcdEndpoints, followerEtcdEndpoints, err := etcdutil.GetEtcdEndPointsSorted(testCtx, clientMaintenance, client, dummyClientEndpoints, logger)
+				leaderEtcdEndpoints, followerEtcdEndpoints, _, err := etcdutil.GetEtcdEndPointsSorted(testCtx, clientMaintenance, client, dummyClientEndpoints, logger)
 				Expect(err).Should(HaveOccurred())
 				Expect(leaderEtcdEndpoints).Should(BeNil())
 				Expect(followerEtcdEndpoints).Should(BeNil())
 
-				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, dummyClientEndpoints, mockTimeout, logger)
+				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, factory, dummyClientEndpoints, mockTimeout, logger, false)
 				Expect(err).Should(HaveOccurred())
 			})
 		})
@@ -209,12 +209,12 @@ var _ = Describe("EtcdUtil Tests", func() {
 
 				cm.EXPECT().Status(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("failed to connect to the dummy etcd")).AnyTimes()
 
-				leaderEtcdEndpoints, followerEtcdEndpoints, err := etcdutil.GetEtcdEndPointsSorted(testCtx, clientMaintenance, client, dummyClientEndpoints, logger)
+				leaderEtcdEndpoints, followerEtcdEndpoints, _, err := etcdutil.GetEtcdEndPointsSorted(testCtx, clientMaintenance, client, dummyClientEndpoints, logger)
 				Expect(err).Should(HaveOccurred())
 				Expect(leaderEtcdEndpoints).Should(BeNil())
 				Expect(followerEtcdEndpoints).Should(BeNil())
 
-				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, dummyClientEndpoints, mockTimeout, logger)
+				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, factory, dummyClientEndpoints, mockTimeout, logger, false)
 				Expect(err).Should(HaveOccurred())
 			})
 		})
@@ -257,12 +257,12 @@ var _ = Describe("EtcdUtil Tests", func() {
 
 				cm.EXPECT().Defragment(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("failed to defrag the etcd")).AnyTimes()
 
-				leaderEtcdEndpoints, followerEtcdEndpoints, err := etcdutil.GetEtcdEndPointsSorted(testCtx, clientMaintenance, client, dummyClientEndpoints, logger)
+				leaderEtcdEndpoints, followerEtcdEndpoints, _, err := etcdutil.GetEtcdEndPointsSorted(testCtx, clientMaintenance, client, dummyClientEndpoints, logger)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(leaderEtcdEndpoints).Should(Equal([]string{dummyClientEndpoints[0]}))
 				Expect(followerEtcdEndpoints).Should(Equal([]string{dummyClientEndpoints[1]}))
 
-				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, dummyClientEndpoints, mockTimeout, logger)
+				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, factory, dummyClientEndpoints, mockTimeout, logger, false)
 				Expect(err).Should(HaveOccurred())
 			})
 		})
@@ -303,7 +303,198 @@ var _ = Describe("EtcdUtil Tests", func() {
 					return response, nil
 				}).AnyTimes()
 
-				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, dummyClientEndpoints, mockTimeout, logger)
+				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, factory, dummyClientEndpoints, mockTimeout, logger, false)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+
+		Context("MoveLeader enabled and MoveLeader API call succeeds", func() {
+			It("should defragment follower, transfer leadership, then defragment former leader in order", func() {
+				clientMaintenance, err := factory.NewMaintenance()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				client, err := factory.NewCluster()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// leaderCM is the maintenance client pinned to the leader endpoint for MoveLeader.
+				leaderCM := mockfactory.NewMockMaintenanceCloser(ctrl)
+				leaderCM.EXPECT().Close().Return(nil).AnyTimes()
+
+				cl.EXPECT().MemberList(gomock.Any()).DoAndReturn(func(_ context.Context) (*clientv3.MemberListResponse, error) {
+					response := new(clientv3.MemberListResponse)
+					response.Members = []*etcdserverpb.Member{
+						{ID: dummyID, ClientURLs: []string{dummyClientEndpoints[0]}},
+						{ID: dummyID + 1, ClientURLs: []string{dummyClientEndpoints[1]}},
+					}
+					return response, nil
+				}).AnyTimes()
+
+				cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
+					response := new(clientv3.StatusResponse)
+					response.Leader = dummyID
+					response.DbSize = 10
+					return response, nil
+				}).AnyTimes()
+
+				// Enforce ordering: should defragment follower, transfer leadership, then defragment former leader.
+				followerDefrag := cm.EXPECT().Defragment(gomock.Any(), dummyClientEndpoints[1]).
+					Return(new(clientv3.DefragmentResponse), nil).Times(1)
+				factory.EXPECT().NewMaintenanceForEndpoint(dummyClientEndpoints[0]).
+					Return(leaderCM, nil).Times(1).After(followerDefrag)
+				moveLeaderCall := leaderCM.EXPECT().MoveLeader(gomock.Any(), uint64(dummyID+1)).
+					Return(new(clientv3.MoveLeaderResponse), nil).Times(1).After(followerDefrag)
+				cm.EXPECT().Defragment(gomock.Any(), dummyClientEndpoints[0]).
+					Return(new(clientv3.DefragmentResponse), nil).Times(1).After(moveLeaderCall)
+
+				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, factory, dummyClientEndpoints, mockTimeout, logger, true)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+
+		Context("MoveLeader enabled but MoveLeader API call fails", func() {
+			It("should warn and defragment all members in place without error", func() {
+				clientMaintenance, err := factory.NewMaintenance()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				client, err := factory.NewCluster()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				leaderCM := mockfactory.NewMockMaintenanceCloser(ctrl)
+				leaderCM.EXPECT().Close().Return(nil).AnyTimes()
+
+				cl.EXPECT().MemberList(gomock.Any()).DoAndReturn(func(_ context.Context) (*clientv3.MemberListResponse, error) {
+					response := new(clientv3.MemberListResponse)
+					response.Members = []*etcdserverpb.Member{
+						{ID: dummyID, ClientURLs: []string{dummyClientEndpoints[0]}},
+						{ID: dummyID + 1, ClientURLs: []string{dummyClientEndpoints[1]}},
+					}
+					return response, nil
+				}).AnyTimes()
+
+				cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
+					response := new(clientv3.StatusResponse)
+					response.Leader = dummyID
+					response.DbSize = 10
+					return response, nil
+				}).AnyTimes()
+
+				cm.EXPECT().Defragment(gomock.Any(), gomock.Any()).
+					Return(new(clientv3.DefragmentResponse), nil).Times(2)
+
+				factory.EXPECT().NewMaintenanceForEndpoint(dummyClientEndpoints[0]).Return(leaderCM, nil).Times(1)
+				leaderCM.EXPECT().MoveLeader(gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("leadership transfer rejected")).Times(1)
+
+				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, factory, dummyClientEndpoints, mockTimeout, logger, true)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+
+		Context("MoveLeader enabled on a single member cluster", func() {
+			It("should skip MoveLeader and defragment the single member without error", func() {
+				clientMaintenance, err := factory.NewMaintenance()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				client, err := factory.NewCluster()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				cl.EXPECT().MemberList(gomock.Any()).DoAndReturn(func(_ context.Context) (*clientv3.MemberListResponse, error) {
+					response := new(clientv3.MemberListResponse)
+					response.Members = []*etcdserverpb.Member{
+						{ID: dummyID, ClientURLs: []string{dummyClientEndpoints[0]}},
+					}
+					return response, nil
+				}).AnyTimes()
+
+				cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
+					response := new(clientv3.StatusResponse)
+					response.Leader = dummyID
+					response.DbSize = 10
+					return response, nil
+				}).AnyTimes()
+
+				cm.EXPECT().Defragment(gomock.Any(), dummyClientEndpoints[0]).
+					Return(new(clientv3.DefragmentResponse), nil).Times(1)
+
+				// No leader pinned client or MoveLeader call for a single-member cluster.
+				factory.EXPECT().NewMaintenanceForEndpoint(gomock.Any()).Times(0)
+
+				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, factory, dummyClientEndpoints[:1], mockTimeout, logger, true)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+
+		Context("MoveLeader enabled but only a learner follower is present", func() {
+			It("should skip MoveLeader and defragment leader in place without error", func() {
+				clientMaintenance, err := factory.NewMaintenance()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				client, err := factory.NewCluster()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				cl.EXPECT().MemberList(gomock.Any()).DoAndReturn(func(_ context.Context) (*clientv3.MemberListResponse, error) {
+					response := new(clientv3.MemberListResponse)
+					response.Members = []*etcdserverpb.Member{
+						{ID: dummyID, ClientURLs: []string{dummyClientEndpoints[0]}},
+						{ID: dummyID + 1, ClientURLs: []string{dummyClientEndpoints[1]}, IsLearner: true},
+					}
+					return response, nil
+				}).AnyTimes()
+
+				cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
+					response := new(clientv3.StatusResponse)
+					response.Leader = dummyID
+					response.DbSize = 10
+					return response, nil
+				}).AnyTimes()
+
+				cm.EXPECT().Defragment(gomock.Any(), gomock.Any()).
+					Return(new(clientv3.DefragmentResponse), nil).Times(2)
+
+				// No leader pinned client or MoveLeader call when only follower is a learner.
+				factory.EXPECT().NewMaintenanceForEndpoint(gomock.Any()).Times(0)
+
+				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, factory, dummyClientEndpoints, mockTimeout, logger, true)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+
+		Context("MoveLeader enabled but second MemberList call fails", func() {
+			It("should warn and defragment the leader in place without error", func() {
+				clientMaintenance, err := factory.NewMaintenance()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				client, err := factory.NewCluster()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				callCount := 0
+				cl.EXPECT().MemberList(gomock.Any()).DoAndReturn(func(_ context.Context) (*clientv3.MemberListResponse, error) {
+					callCount++
+					if callCount == 1 {
+						response := new(clientv3.MemberListResponse)
+						response.Members = []*etcdserverpb.Member{
+							{ID: dummyID, ClientURLs: []string{dummyClientEndpoints[0]}},
+							{ID: dummyID + 1, ClientURLs: []string{dummyClientEndpoints[1]}},
+						}
+						return response, nil
+					}
+					return nil, fmt.Errorf("memberlist temporarily unavailable")
+				}).Times(2)
+
+				cm.EXPECT().Status(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
+					response := new(clientv3.StatusResponse)
+					response.Leader = dummyID
+					response.DbSize = 10
+					return response, nil
+				}).AnyTimes()
+
+				cm.EXPECT().Defragment(gomock.Any(), gomock.Any()).
+					Return(new(clientv3.DefragmentResponse), nil).Times(2)
+
+				// No leader pinned client because MemberList failed before transferee was selected.
+				factory.EXPECT().NewMaintenanceForEndpoint(gomock.Any()).Times(0)
+
+				err = etcdutil.DefragmentData(testCtx, clientMaintenance, client, factory, dummyClientEndpoints, mockTimeout, logger, true)
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 		})

--- a/pkg/mock/etcdutil/client/mocks.go
+++ b/pkg/mock/etcdutil/client/mocks.go
@@ -88,6 +88,21 @@ func (mr *MockFactoryMockRecorder) NewMaintenance() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMaintenance", reflect.TypeOf((*MockFactory)(nil).NewMaintenance))
 }
 
+// NewMaintenanceForEndpoint mocks base method.
+func (m *MockFactory) NewMaintenanceForEndpoint(endpoint string) (client.MaintenanceCloser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewMaintenanceForEndpoint", endpoint)
+	ret0, _ := ret[0].(client.MaintenanceCloser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewMaintenanceForEndpoint indicates an expected call of NewMaintenanceForEndpoint.
+func (mr *MockFactoryMockRecorder) NewMaintenanceForEndpoint(endpoint any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMaintenanceForEndpoint", reflect.TypeOf((*MockFactory)(nil).NewMaintenanceForEndpoint), endpoint)
+}
+
 // NewWatcher mocks base method.
 func (m *MockFactory) NewWatcher() (clientv3.Watcher, error) {
 	m.ctrl.T.Helper()

--- a/pkg/types/defragmentation.go
+++ b/pkg/types/defragmentation.go
@@ -23,6 +23,8 @@ const (
 	DefragRetryPeriod time.Duration = 1 * time.Minute
 	// DefaultFreeSpaceThreshold is the minimum default free space above which schedule defragmentation is triggered.
 	DefaultFreeSpaceThreshold = 1 * 1024 * 1024 * 1024 // 1GB
+	// DefaultLeaderTransferTimeout is the timeout for a single etcd leader transfer operation.
+	DefaultLeaderTransferTimeout time.Duration = 30 * time.Second
 )
 
 // DefragConfig holds the configuration for etcd defragmentation.
@@ -33,6 +35,8 @@ type DefragConfig struct {
 	DefragTimeout wrappers.Duration `json:"defragTimeout,omitempty"`
 	// FreespaceThreshold is the minimum free space above which schedule defragmentation is triggered.
 	FreespaceThreshold int64 `json:"freespaceThreshold,omitempty"`
+	// MoveLeader controls whether etcd leadership is transferred away from the leader member before defragmenting it.
+	MoveLeader bool `json:"moveLeader,omitempty"`
 }
 
 // NewDefragConfig returns a DefragConfig with default values.
@@ -49,6 +53,7 @@ func (c *DefragConfig) AddFlags(fs *flag.FlagSet) {
 	fs.Int64Var(&c.FreespaceThreshold, "freespace-threshold", c.FreespaceThreshold, "minimum free-space in database only above which schedule defragmentation is triggered.")
 	fs.StringVar(&c.DefragmentationSchedule, "defragmentation-schedule", c.DefragmentationSchedule, "cron schedule to defragment etcd data directory")
 	fs.DurationVar(&c.DefragTimeout.Duration, "etcd-defrag-timeout", c.DefragTimeout.Duration, "timeout duration for etcd's api defrag call")
+	fs.BoolVar(&c.MoveLeader, "move-leader", c.MoveLeader, "transfer etcd leadership away from the leader before defragmenting it to avoid cluster-wide write stalls")
 }
 
 // Validate validates the DefragConfig fields.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area etcd
/kind bug

**What this PR does / why we need it**:
When DefragmentData defragments a multi-member etcd cluster, it defragments the leader, blocking all cluster writes for the duration. The new --move-leader flag was added to transfer leadership to a follower before defragmenting the former leader.

**Which issue(s) this PR fixes**:
Fixes #1061

**Special notes for your reviewer**:

> % go build ./... 2>&1 && go test ./pkg/etcdutil/... 2>&1
> ok      github.com/gardener/etcd-backup-restore/pkg/etcdutil    2.177s
> ?       github.com/gardener/etcd-backup-restore/pkg/etcdutil/client     [no test files]
> 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
add move-leader parameter to transfer etcd leadership before defragmenting the leader member to avoid cluster-wide write stalls.
```
