### PR TITLE
Removes extra handling done to change the file-permissions of legacy `safe_guard` files.

### DIFF
--- a/pkg/initializer/validator/datavalidator.go
+++ b/pkg/initializer/validator/datavalidator.go
@@ -99,12 +99,6 @@ func (d *DataValidator) sanityCheck() (DataDirStatus, error) {
 			}
 		}
 
-		// Change file permissions of legacy `safe_guard` files.
-		// TODO: To be removed in etcd-backup-restore:v0.41.0.
-		if err := os.Chmod(path, 0600); err != nil {
-			d.Logger.Fatalf("can't change the permission of the `safe_guard` file because : %v", err)
-		}
-
 		// read the content of the file safe_guard and match it with the environment variable
 		content, err := os.ReadFile(path) // #nosec G304 -- this is a trusted safe_guard file written to by etcdbr.
 		if err != nil {


### PR DESCRIPTION

/kind technical-debt

**What this PR does / why we need it**:
This PR removes the extra handling done to change the file-permissions of legacy `safe_guard` files.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
